### PR TITLE
ci: contributor setup — CI, CONTRIBUTING, PR & issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,58 @@
+name: 🐛 Bug report
+description: Report something that isn't working as expected
+title: "bug: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug! Please search [existing issues](https://github.com/tam159/next-role/issues) first to avoid duplicates.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug, and what you expected instead.
+      placeholder: When I ..., I expected ..., but instead ...
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps so we can see it too.
+      placeholder: |
+        1. Upload CV + JD
+        2. Ask for "..."
+        3. See error
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      options:
+        - Backend (agents / LangGraph / tools)
+        - Frontend (Next.js UI)
+        - Docker / local setup
+        - Docs
+        - Not sure
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / screenshots / trace
+      description: |
+        Relevant logs, screenshots, or a LangSmith trace link. Container logs help a lot:
+        `docker compose logs backend` / `docker compose logs frontend`.
+      render: shell
+    validations:
+      required: false
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, Docker version, and which LLM provider/model you had configured.
+      placeholder: macOS 15.5, Docker 27.x, main agent = openai:gpt-5.x
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Questions & discussion
+    url: https://github.com/tam159/next-role/discussions
+    about: Ask a question or discuss an idea (please don't open an issue for support).

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,50 @@
+name: 💡 Feature request
+description: Suggest an idea or enhancement
+title: "feat: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have an idea? Great! For larger changes, opening this issue **before** writing code helps us align on scope. Check the [Roadmap](https://github.com/tam159/next-role#roadmap) and [existing issues](https://github.com/tam159/next-role/issues) first.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What problem does this solve, or what's the use case?
+      placeholder: As a user preparing for interviews, I want ... so that ...
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you like to see happen?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you thought about, if any.
+    validations:
+      required: false
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      options:
+        - Backend (agents / LangGraph / tools)
+        - Frontend (Next.js UI)
+        - Docker / local setup
+        - Docs
+        - Not sure
+    validations:
+      required: true
+  - type: checkboxes
+    id: contribute
+    attributes:
+      label: Contribution
+      options:
+        - label: I'm willing to open a PR for this
+          required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+<!--
+Thanks for contributing to NextRole! Please fill this in so reviewers have context.
+See CONTRIBUTING.md for the full workflow.
+-->
+
+## What & why
+
+<!-- What does this PR change, and why? Link any related issue, e.g. "Closes #123". -->
+
+## Type of change
+
+<!-- Mark with an "x". Match your commit prefix (feat/fix/docs/...). -->
+
+- [ ] 🐛 `fix` — bug fix
+- [ ] ✨ `feat` — new feature
+- [ ] 📝 `docs` — documentation only
+- [ ] ♻️ `refactor` — no behavior change
+- [ ] 🧹 `chore` / `test` — tooling, deps, tests
+
+## How was it tested?
+
+<!-- Commands you ran, manual steps, screenshots, or a LangSmith trace link. -->
+
+## Checklist
+
+- [ ] PR is focused on a single logical change
+- [ ] Added/updated tests for changed behavior (`cd backend && uv run pytest` passes)
+- [ ] Ran the quality gate locally (`pre-commit run --all-files`)
+- [ ] Updated docs (README / `CLAUDE.md` / `docs/prd/`) if behavior changed
+- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
+- [ ] No secrets or user uploads (CVs/JDs) committed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,87 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+# Cancel superseded runs on the same ref (e.g. new push to a PR branch).
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  # Code quality: the exact same pre-commit gate contributors run locally —
+  # ruff (lint + format), ty (backend types), eslint + prettier + tsc
+  # (frontend), gitleaks, and the file hygiene hooks.
+  code-quality:
+    name: code-quality
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # gitleaks scans full history
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8
+        with:
+          enable-cache: true
+
+      - name: "Sync backend (dev tools: pre-commit, ruff, ty)"
+        working-directory: backend
+        run: uv sync
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          package_json_file: frontend/package.json
+
+      - name: Install Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: frontend/pnpm-lock.yaml
+
+      - name: Install frontend deps
+        working-directory: frontend
+        run: pnpm install --frozen-lockfile
+
+      - name: Cache pre-commit hook environments
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+
+      - name: Run pre-commit
+        env:
+          UV_PROJECT: backend # makes the `uv run ty check` hook resolve backend/ from repo root
+        run: uv run pre-commit run --all-files --show-diff-on-failure --color always
+
+  # Backend tests: the default suite (unit tests). Integration tests
+  # (`-m integration`) need a live Postgres/Redis stack and run separately.
+  backend-tests:
+    name: backend-tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8
+        with:
+          enable-cache: true
+
+      - name: Sync backend
+        run: uv sync
+
+      - name: Run unit tests
+        run: uv run pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           fetch-depth: 0 # gitleaks scans full history
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.1.0 # no moving v8 major tag is published; pin the exact release
         with:
           enable-cache: true
 
@@ -76,7 +76,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.1.0 # no moving v8 major tag is published; pin the exact release
         with:
           enable-cache: true
 

--- a/backend/tests/career_agent/test_tools.py
+++ b/backend/tests/career_agent/test_tools.py
@@ -596,10 +596,10 @@ def test_prepare_render_settings_appends_block(tmp_path, monkeypatch, backend):
 
     result = make_prepare_render_settings(backend).invoke({"yaml_path": yaml_path})
 
-    # Confirmation + the verbatim execute command (virtual path — the shell
-    # backend translates `/tailored_resume/...` to its on-disk equivalent).
-    assert "Prepared for rendering." in result
-    assert f"rendercv render {yaml_path}" in result
+    # Confirmation names the prepared YAML; the agent invokes `rendercv render`
+    # separately via `execute` (the shell backend translates the virtual path).
+    assert f"Prepared for rendering: {yaml_path}" in result
+    assert "Ready to render now." in result
     written = on_disk.read_text()
     # The body the LLM wrote is preserved verbatim.
     assert "# changes:" in written
@@ -689,6 +689,6 @@ def test_prepare_render_settings_accepts_yml_extension(tmp_path, monkeypatch, ba
     on_disk = _seed_yaml(tmp_path, monkeypatch, relative=yaml_path, content=_MINIMAL_CV_YAML)
 
     result = make_prepare_render_settings(backend).invoke({"yaml_path": yaml_path})
-    assert "Prepared" in result
-    assert f"rendercv render {yaml_path}" in result
+    assert f"Prepared for rendering: {yaml_path}" in result
+    assert "Ready to render now." in result
     assert "settings:" in on_disk.read_text()


### PR DESCRIPTION
Sets up contribution infrastructure for outside contributors.

## What's included
- **CI** (`.github/workflows/ci.yml`) — two checks on every PR to `main`:
  - `code-quality` — full pre-commit gate (ruff, ty, eslint, prettier, gitleaks, file hygiene)
  - `backend-tests` — `uv run pytest` (default unit suite)
- **CONTRIBUTING.md** — fork/PR flow, Docker dev setup, quality gate, testing, conventions
- **PR template** + **bug/feature issue forms** + issue chooser config
- **test fix** — 2 stale `prepare_render_settings` assertions updated to the current return string (so `backend-tests` is green)

Verified locally: `pre-commit run --all-files` passes; `uv run pytest` → 80 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)