### PR TITLE
docs: add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,33 @@
+# Security Policy
+
+## Supported Versions
+
+NextRole is an early-stage project. Security fixes are currently applied to the latest code on `main`.
+
+| Version | Supported |
+| --- | --- |
+| `main` | :white_check_mark: |
+| older commits, tags, and forks | :x: |
+
+## Reporting a Vulnerability
+
+Please do **not** open a public GitHub issue for suspected vulnerabilities.
+
+If GitHub's **Private vulnerability reporting** option is available in this repository's Security tab, use that channel so maintainers can investigate without exposing users or deploys. Include:
+
+- a short description of the issue
+- affected files, endpoints, or workflows
+- clear reproduction steps or a proof of concept
+- impact assessment and any suggested mitigation
+
+If private vulnerability reporting is not enabled yet, contact the maintainer directly through their GitHub profile before disclosing details publicly.
+
+## Response Expectations
+
+- Initial acknowledgment target: within 72 hours
+- Status updates target: at least once every 7 days while a fix is being prepared
+- Public disclosure: after a fix is available or a coordinated disclosure date is agreed
+
+## Scope and Threat Model Notes
+
+NextRole is currently designed for local, single-user, trusted-use workflows. Even so, please report issues involving secrets, prompt injection, unsafe file access, container exposure, dependency vulnerabilities, or authentication and authorization boundaries.


### PR DESCRIPTION
## What & why
- add a repository-level `SECURITY.md` so GitHub can surface a clear vulnerability reporting path
- document supported versions, private reporting guidance, response expectations, and the project's current local trusted-use threat-model note

Closes #3.

## Type of change
- [x] 📝 `docs` — documentation only
- [ ] 🐛 `fix` — bug fix
- [ ] ✨ `feat` — new feature
- [ ] ♻️ `refactor` — no behavior change
- [ ] 🧹 `chore` / `test` — tooling, deps, tests

## How was it tested?
- `git diff --check`
- manual review of the rendered Markdown content
- note: the repo's documented formatter path was not available in this fresh clone (`pnpm --dir frontend exec prettier --check ../SECURITY.md` could not find `prettier`)

## Checklist
- [x] PR is focused on a single logical change
- [ ] Added/updated tests for changed behavior (`cd backend && uv run pytest` passes)
- [ ] Ran the quality gate locally (`pre-commit run --all-files`)
- [x] Updated docs (README / `CLAUDE.md` / `docs/prd/`) if behavior changed
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] No secrets or user uploads (CVs/JDs) committed