### PR TITLE
docs: add SECURITY.md vulnerability disclosure policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,38 @@
+# Security Policy
+
+Thanks for helping keep NextRole and its users safe.
+
+## Supported Versions
+
+NextRole is an early-stage project. Security fixes are applied to the latest code on the `main`
+branch, and we do not maintain backported patches for older commits or forks.
+
+## Reporting a Vulnerability
+
+Please do **not** open a public GitHub issue for suspected vulnerabilities.
+
+Use GitHub's private vulnerability reporting flow if it is enabled for this repository:
+
+- Go to the [Security advisories page](https://github.com/tam159/next-role/security/advisories/new)
+- Submit the report privately with reproduction steps, impact, and any suggested mitigation
+
+If private vulnerability reporting is not available, email the maintainer at
+[`npt.dc@outlook.com`](mailto:npt.dc@outlook.com) and include:
+
+- A clear description of the issue
+- Steps to reproduce or a proof of concept
+- The affected area, commit, or configuration
+- Any known impact or suggested remediation
+
+## Response Expectations
+
+We will try to acknowledge new reports within 5 business days and will share follow-up status as we
+validate and scope the issue.
+
+Because NextRole is currently designed for local, single-user, trusted use, reports that affect
+shared-hosting, multi-tenant isolation, or public internet exposure should include the deployment
+assumptions required for the issue to apply.
+
+## Disclosure
+
+Please give us reasonable time to investigate and ship a fix before making details public.


### PR DESCRIPTION
## What & why

Adds a root `SECURITY.md` so the repository has a documented private vulnerability reporting path and a clear fallback contact if GitHub private reporting is not enabled. Closes #3.

## Type of change

- [x] 📝 `docs` — documentation only

## How was it tested?

- Reviewed the rendered Markdown content locally
- Ran `git diff --check upstream/main...HEAD`

## Checklist

- [x] PR is focused on a single logical change
- [ ] Added/updated tests for changed behavior (`cd backend && uv run pytest` passes)
- [ ] Ran the quality gate locally (`pre-commit run --all-files`)
- [x] Updated docs (README / `CLAUDE.md` / `docs/prd/`) if behavior changed
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] No secrets or user uploads (CVs/JDs) committed

Notes:
- Tests are not applicable because this is a docs-only change.
- `pre-commit` is referenced by the repo but was not available in this environment.