### PR TITLE
feat: add long-term user-preference memory for the career agent

### DIFF
--- a/backend/app/career_agent/AGENTS.md
+++ b/backend/app/career_agent/AGENTS.md
@@ -108,6 +108,8 @@ Phrase the task input concretely. Include company name and role hook so the suba
 
 > Research <Company> for the <Role> role. Inputs: resume_path=/processed/<resume>.md, jd_path=/processed/<jd>.md, intake_path=/processed/<resume>-<jd>-intake.md. Save the report to output_path=/research/<resume>/<jd>.md. Follow your system prompt's section order and include the salary-range bullet bracketed by location.
 
+If `/memory/preferences.md` holds preferences relevant to research (salary detail, report length, sections to emphasize), fold them into the task input as a `User preferences: <lines>` line so the subagent honors them.
+
 ## Stage 4 — Customize resume and prep interview
 
 Spawn `resume-tailor` and `interview-coach` **in parallel** so they can run concurrently. Each subagent gets the same five paths in its task input:
@@ -120,6 +122,8 @@ Spawn `resume-tailor` and `interview-coach` **in parallel** so they can run conc
   - for `resume-tailor` → `yaml_path=/tailored_resume/<resume-slug>/<jd-slug>.yaml`. The subagent writes the YAML and renders the `.pdf` next to it; the intermediate `.typ` goes to `/render_intermediate/<resume-slug>/<jd-slug>.typ` (not shown in the UI Workspace).
   - for `interview-coach` → `output_path=/interview_coach/<resume-slug>/<jd-slug>.md`
 
+If `/memory/preferences.md` holds preferences relevant to the tailored resume or interview prep, add a `User preferences: <lines>` line to each subagent's task input.
+
 ## Stage 5 — Interview battlecard
 
 You generate the battlecard yourself, applying the `interview-battlecard` skill. No subagent is involved.
@@ -131,7 +135,7 @@ You generate the battlecard yourself, applying the `interview-battlecard` skill.
 
 Once all five stages have run, users will ask to iterate ("add a 4th round to the battlecard", "add a topic to the research report", "add React to my resume skills", "add common questions to round 2 of the prep doc"). Route by which file owns the change. Do NOT call `write_todos` for a single-file update; trivial Q&A about existing content ("what's in my battlecard?") stays in the normal answer path.
 
-**Cross-cutting principle:** the user's explicit request is the first priority. Skill-level preservation defaults ("never drop a skill", "never drop a URL", etc.) apply when the user has not asked for the opposite. If the user explicitly asks to remove a skill, drop a link — comply, and only touch what they named. Truth/fabrication guardrails (don't invent metrics, titles, experience, or company facts) remain absolute.
+**Cross-cutting principle:** the user's explicit request is the first priority. Skill-level preservation defaults ("never drop a skill", "never drop a URL", etc.) apply when the user has not asked for the opposite. If the user explicitly asks to remove a skill, drop a link — comply, and only touch what they named. Truth/fabrication guardrails (don't invent metrics, titles, experience, or company facts) remain absolute. When an update spawns a subagent, also fold any relevant saved `/memory/` preferences into its task description (a `User preferences:` line), the same as for a fresh run.
 
 ### Battlecard updates (you own this — no subagent)
 

--- a/backend/app/career_agent/agents.py
+++ b/backend/app/career_agent/agents.py
@@ -7,7 +7,11 @@ import deepagents.middleware.skills as _skills_mw
 import deepagents.middleware.subagents as _sub_mw
 import langchain.agents.middleware.todo as _todo_mw
 from backend.app.career_agent import prompts as _prompts
-from backend.app.career_agent.middleware import ModelOverrideMiddleware, UtcDatetimeMiddleware
+from backend.app.career_agent.middleware import (
+    EnsurePreferencesFileMiddleware,
+    ModelOverrideMiddleware,
+    UtcDatetimeMiddleware,
+)
 from backend.app.career_agent.shell_backend import VirtualPathShellBackend
 from backend.app.career_agent.tools import (
     CAREER_AGENT_DIR,
@@ -29,11 +33,11 @@ def _apply_prompt_overrides() -> None:
     """Replace the prompts that deepagents/langchain inject into the system message.
 
     Most middlewares read their constant by bare name at call time, so patching
-    the module attribute is enough. `TodoListMiddleware` and `SubAgentMiddleware`
-    are different — they capture the constant as a keyword-only default arg,
-    which Python freezes into `__init__.__kwdefaults__` at class-definition
-    time. Reassigning the module attribute after that does nothing; we must
-    patch `__kwdefaults__` directly.
+    the module attribute is enough. `TodoListMiddleware`, `SubAgentMiddleware`,
+    and — on deepagents 0.6.3+ — `MemoryMiddleware` are different: they capture
+    the constant as a keyword-only default arg, which Python freezes into
+    `__init__.__kwdefaults__` at class-definition time. Reassigning the module
+    attribute after that does nothing; we must patch `__kwdefaults__` directly.
 
     `BASE_AGENT_PROMPT` is patched here (rather than via
     `HarnessProfile.base_system_prompt`) because the harness-profile overlay
@@ -63,6 +67,15 @@ def _apply_prompt_overrides() -> None:
 
     _todo_mw.TodoListMiddleware.__init__.__kwdefaults__["system_prompt"] = _prompts.TODO  # type: ignore # noqa: PGH003
     _sub_mw.SubAgentMiddleware.__init__.__kwdefaults__["system_prompt"] = _prompts.TASK  # type: ignore # noqa: PGH003
+
+    # deepagents 0.6.3+ freezes the memory prompt into MemoryMiddleware's
+    # keyword-only `system_prompt` default, so the module-level setattr above no
+    # longer reaches the constructed middleware (0.6.1 read the bare global, so it
+    # did). Patch the kwdefault too; guarded so it's a no-op on 0.6.1, which has
+    # no such parameter.
+    _mem_kwdefaults = _mem_mw.MemoryMiddleware.__init__.__kwdefaults__
+    if _mem_kwdefaults and "system_prompt" in _mem_kwdefaults:
+        _mem_kwdefaults["system_prompt"] = _prompts.MEMORY
 
 
 _apply_prompt_overrides()
@@ -131,7 +144,7 @@ _model_override_middleware = ModelOverrideMiddleware()
 career_agent = create_deep_agent(
     system_prompt=_prompts.SYSTEM_PROMPT,
     model=_MODEL,
-    memory=["AGENTS.md"],
+    memory=["AGENTS.md", "/memory/preferences.md"],
     skills=["skills/career-agent/"],
     tools=[
         _list_files,
@@ -147,5 +160,9 @@ career_agent = create_deep_agent(
         default_middleware=[_model_override_middleware],
     ),
     backend=_backend,
-    middleware=[_model_override_middleware, UtcDatetimeMiddleware()],
+    middleware=[
+        EnsurePreferencesFileMiddleware(_backend),
+        _model_override_middleware,
+        UtcDatetimeMiddleware(),
+    ],
 )

--- a/backend/app/career_agent/middleware.py
+++ b/backend/app/career_agent/middleware.py
@@ -14,19 +14,20 @@ logger = logging.getLogger(__name__)
 
 
 class UtcDatetimeMiddleware(AgentMiddleware):
-    """Append a fresh `Current UTC datetime: ...` line to the system message.
+    """Append a `Current UTC date: ...` line to the system message.
 
     Without this the agent has no clock and can't interpret `modified_at`
-    timestamps from `list_files(...)` (e.g. tell "uploaded seconds ago" apart
-    from "uploaded yesterday"). Injecting per call rather than at module
-    import keeps the value accurate across long-lived deployments.
+    timestamps from `list_files(...)` (e.g. tell "uploaded yesterday" apart
+    from "uploaded last month"). Injecting per call rather than at module
+    import keeps the value accurate across long-lived deployments, while date
+    precision avoids invalidating prompt caches on every turn.
     """
 
     @staticmethod
     def _inject(request: Any) -> Any:  # noqa: ANN401  # ModelRequest is generic
         existing = request.system_message.text if request.system_message else ""
-        now = datetime.now(UTC).isoformat(timespec="seconds")
-        new_content = f"{existing}\n\nCurrent UTC datetime: {now}".strip()
+        today = datetime.now(UTC).date().isoformat()
+        new_content = f"{existing}\n\nCurrent UTC date: {today}".strip()
         return request.override(system_message=SystemMessage(content=new_content))
 
     def wrap_model_call(self, request: Any, handler: Any) -> Any:  # noqa: ANN401
@@ -36,6 +37,64 @@ class UtcDatetimeMiddleware(AgentMiddleware):
     async def awrap_model_call(self, request: Any, handler: Any) -> Any:  # noqa: ANN401
         """Async entry point."""
         return await handler(self._inject(request))
+
+
+# Path of the always-loaded preferences file (a StoreBackend route; the same
+# string is wired as a `memory=` source in agents.py).
+PREFERENCES_PATH = "/memory/preferences.md"
+
+# Scaffold written when the preferences file is absent. The section headings
+# give the model an obvious place to append each preference, and let it pull the
+# right ones per stage when delegating to subagents.
+_PREFERENCES_SCAFFOLD = """# Saved preferences
+
+Standing preferences for how to prepare this user's materials. Apply the relevant
+ones on every run, and fold them into subagent task descriptions.
+
+## Research
+
+## Tailored resume
+
+## Interview prep
+
+## Battlecard
+
+## General
+"""
+
+
+class EnsurePreferencesFileMiddleware(AgentMiddleware):
+    """Guarantee the always-loaded preferences file exists before the model runs.
+
+    gpt-5.4 reliably *appends* a preference to `/memory/preferences.md` when the
+    file already exists, but won't reliably *create* it on a clean slate — it
+    fumbles toward AGENTS.md or starts the intake workflow instead. So we seed
+    the scaffold here in `before_agent`: a single cheap store write — no model
+    round trip, so no added response latency — and idempotent, because the
+    backend's `write` refuses to overwrite an existing file. This keeps the
+    preferences memory source present on every deployment without relying on the
+    LLM to bootstrap it.
+
+    Main-agent only — subagents have no memory and never touch this file.
+    """
+
+    def __init__(self, backend: Any) -> None:  # noqa: ANN401  # CompositeBackend
+        """Capture the backend used to seed the preferences scaffold."""
+        self._backend = backend
+
+    def before_agent(self, state: Any, runtime: Any) -> dict[str, Any] | None:  # noqa: ANN401, ARG002
+        """Seed the scaffold if missing (sync invocation path)."""
+        try:
+            self._backend.write(PREFERENCES_PATH, _PREFERENCES_SCAFFOLD)
+        except Exception:  # never break a run over preference seeding
+            logger.debug("ensure preferences file (sync) skipped", exc_info=True)
+
+    async def abefore_agent(self, state: Any, runtime: Any) -> dict[str, Any] | None:  # noqa: ANN401, ARG002
+        """Seed the scaffold if missing (async invocation path)."""
+        try:
+            await self._backend.awrite(PREFERENCES_PATH, _PREFERENCES_SCAFFOLD)
+        except Exception:  # never break a run over preference seeding
+            logger.debug("ensure preferences file (async) skipped", exc_info=True)
 
 
 # Module-level cache: `init_chat_model` builds a client each call (allocates

--- a/backend/app/career_agent/prompts.py
+++ b/backend/app/career_agent/prompts.py
@@ -224,6 +224,41 @@ MEMORY = """<agent_memory>
 </agent_memory>
 
 <memory_guidelines>
-    The above <agent_memory> was loaded in from files in your filesystem.
+The block above is loaded from your filesystem at the start of each session. It contains two things:
+
+- **AGENTS.md** — your operating procedures. READ-ONLY. Never write to it.
+- **/memory/preferences.md** — the user's saved preferences (always loaded). This is the ONLY place preferences live, and the file already exists. To save or change one, you edit THIS file.
+
+## What memory is for
+Remember durable, cross-session preferences about HOW the user wants their materials made — the shape, length, tone, and content of each artifact, and your general working style. These are standing instructions for every future prep run, not facts about one job.
+
+Worth remembering (examples):
+- Research reports should include the company's typical salary range for the role.
+- Emphasize AI / agent engineering skills near the top of the tailored resume.
+- Interview prep must always include predicted questions with model answers, per round.
+- Keep battlecards very concise — short phrases, no paragraphs.
+
+Do NOT remember:
+- One-off, this-run-only instructions ("for THIS resume, drop the Twitter link").
+- Anything derivable from the CV or JD (skills, titles, dates, the company) — that lives in /processed/.
+- Anything specific to a single resume-and-JD pair — that belongs in the intake file, not memory.
+- Transient context. And never secrets, tokens, or credentials.
+
+## Retrieving is free — do not spend tool calls on it
+The preferences are ALREADY in the block above every session. Do NOT run ls, glob, grep, or read_file over /memory/ to check them — you can see them. Just use them.
+
+## Saving — when a durable preference appears, persist it (do NOT just say "got it")
+Triggers: the user explicitly asks you to remember something, OR states a standing preference ("always", "from now on", "I prefer", "every time", or repeats the same correction). When a trigger fires you MUST record it in /memory/preferences.md in the SAME turn — replying in prose without editing the file is a failure, not compliance. This overrides any "don't write files yet" intake rule: that rule is about CV / JD / intake artifacts, and a preference needs no CV or JD, so do it anytime. Skip only genuine one-offs ("for THIS run, ...").
+
+How: call edit_file("/memory/preferences.md", ...) and add ONE short, actionable bullet under the matching section heading (Research, Tailored resume, Interview prep, Battlecard, or General). One bullet per preference. To change or drop a preference, edit or delete its bullet. The file always exists — you will see it in the block above — so just edit_file it; do NOT create new files. NEVER write preferences into AGENTS.md — it is read-only procedure, not your preference store.
+
+Then acknowledge in one short, warm line ("Noted — I'll keep battlecards concise from now on.") and carry on. Don't re-read /memory/ to confirm: the block above is a session-start snapshot, but you already know what you just saved, and it reloads fresh next session.
+
+## Applying — fold preferences into the work
+When you run a stage or spawn a subagent via task, pass the relevant saved preferences along:
+- For subagents (hiring-recon, resume-tailor, interview-coach), add a short "User preferences: <the relevant lines>" line to the task description. Subagents treat their task input as user instructions, so this is enough.
+- For the battlecard, which you build yourself, apply the preferences directly.
+
+Saved preferences are explicit user requests: they OVERRIDE the skills' preservation defaults (don't drop a skill, a URL, a section), just as a request typed in chat would. They never override the truth and no-fabrication rules — don't invent metrics, titles, experience, or company facts.
 </memory_guidelines>
 """

--- a/backend/tests/career_agent/test_middleware.py
+++ b/backend/tests/career_agent/test_middleware.py
@@ -1,7 +1,9 @@
-"""Tests for the career-agent UTC datetime middleware."""
+"""Tests for the career-agent UTC date middleware."""
 
 import re
+from datetime import UTC, datetime, tzinfo
 from types import SimpleNamespace
+from typing import Self
 
 import pytest
 from langchain_core.messages import SystemMessage
@@ -26,23 +28,22 @@ def _fake_request(text: str | None):
     return SimpleNamespace(system_message=sm, override=_override), captured
 
 
-_DATETIME_RE = re.compile(
-    r"Current UTC datetime: \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:\+00:00|Z)?",
-)
+_DATE_RE = re.compile(r"Current UTC date: \d{4}-\d{2}-\d{2}$")
 
 
 def _content(msg: SystemMessage) -> str:
     return str(msg.content)
 
 
-def test_middleware_appends_datetime_to_existing_system_prompt(middleware):
+def test_middleware_appends_date_to_existing_system_prompt(middleware):
     request, captured = _fake_request("You are a career agent.")
 
     middleware.wrap_model_call(request, lambda r: r)
 
     content = _content(captured["system_message"])
     assert content.startswith("You are a career agent.")
-    assert _DATETIME_RE.search(content)
+    assert _DATE_RE.search(content)
+    assert "Current UTC datetime:" not in content
 
 
 def test_middleware_creates_message_when_system_prompt_is_none(middleware):
@@ -50,7 +51,7 @@ def test_middleware_creates_message_when_system_prompt_is_none(middleware):
 
     middleware.wrap_model_call(request, lambda r: r)
 
-    assert _DATETIME_RE.search(_content(captured["system_message"]))
+    assert _DATE_RE.search(_content(captured["system_message"]))
 
 
 @pytest.mark.asyncio
@@ -64,17 +65,97 @@ async def test_middleware_async_path_also_injects(middleware):
 
     content = _content(captured["system_message"])
     assert "hi" in content
-    assert _DATETIME_RE.search(content)
+    assert _DATE_RE.search(content)
 
 
-def test_middleware_produces_fresh_value_per_call(middleware):
-    """Two consecutive calls should yield different timestamps (or at least not be cached)."""
-    import time
+def test_middleware_uses_same_date_for_different_times_on_same_day(middleware, monkeypatch):
+    """Two same-day calls should keep the injected prompt line cacheable."""
+    from backend.app.career_agent import middleware as middleware_module
+
+    class _Datetime(datetime):
+        calls = 0
+
+        @classmethod
+        def now(cls, tz: tzinfo | None = None) -> Self:
+            cls.calls += 1
+            hour = 3 if cls.calls == 1 else 21
+            return cls(2026, 6, 6, hour, 38, 8, tzinfo=tz or UTC)
+
+    monkeypatch.setattr(middleware_module, "datetime", _Datetime)
 
     request1, captured1 = _fake_request("x")
     middleware.wrap_model_call(request1, lambda r: r)
-    time.sleep(1.1)  # iso seconds precision — sleep over 1s to guarantee a different stamp
     request2, captured2 = _fake_request("x")
     middleware.wrap_model_call(request2, lambda r: r)
 
-    assert _content(captured1["system_message"]) != _content(captured2["system_message"])
+    assert _content(captured1["system_message"]) == _content(captured2["system_message"])
+    assert _content(captured1["system_message"]).endswith("Current UTC date: 2026-06-06")
+
+
+# Pre-built so the `raise` sites below carry no inline string literal (EM101/TRY003).
+_STORE_DOWN = RuntimeError("store unavailable")
+
+
+class _RecordingBackend:
+    """Stand-in backend that records write/awrite calls.
+
+    `fail=True` raises to mimic a store outage, so we can assert the middleware
+    swallows it rather than crashing the run.
+    """
+
+    def __init__(self, *, fail: bool = False) -> None:
+        self.fail = fail
+        self.writes: list[tuple[str, str]] = []
+
+    def write(self, path: str, content: str):
+        if self.fail:
+            raise _STORE_DOWN
+        self.writes.append((path, content))
+        return SimpleNamespace(error=None, path=path)
+
+    async def awrite(self, path: str, content: str):
+        if self.fail:
+            raise _STORE_DOWN
+        self.writes.append((path, content))
+        return SimpleNamespace(error=None, path=path)
+
+
+def test_ensure_preferences_seeds_scaffold_when_missing():
+    from backend.app.career_agent.middleware import (
+        PREFERENCES_PATH,
+        EnsurePreferencesFileMiddleware,
+    )
+
+    backend = _RecordingBackend()
+    EnsurePreferencesFileMiddleware(backend).before_agent(state={}, runtime=None)
+
+    assert len(backend.writes) == 1
+    path, content = backend.writes[0]
+    assert path == PREFERENCES_PATH
+    assert content.startswith("# Saved preferences")
+    assert "## Battlecard" in content  # section headings the model appends under
+
+
+def test_ensure_preferences_swallows_backend_errors():
+    from backend.app.career_agent.middleware import EnsurePreferencesFileMiddleware
+
+    # A failing store write must never crash the agent run.
+    EnsurePreferencesFileMiddleware(_RecordingBackend(fail=True)).before_agent(
+        state={},
+        runtime=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_ensure_preferences_async_path_seeds():
+    from backend.app.career_agent.middleware import (
+        PREFERENCES_PATH,
+        EnsurePreferencesFileMiddleware,
+    )
+
+    backend = _RecordingBackend()
+    await EnsurePreferencesFileMiddleware(backend).abefore_agent(state={}, runtime=None)
+
+    assert len(backend.writes) == 1
+    assert backend.writes[0][0] == PREFERENCES_PATH
+    assert backend.writes[0][1].startswith("# Saved preferences")

--- a/backend/tests/career_agent/test_prompts.py
+++ b/backend/tests/career_agent/test_prompts.py
@@ -1,0 +1,84 @@
+"""Unit tests for the career-agent prompt overrides.
+
+Pure-string assertions — no model is constructed and no network is hit. The
+`MEMORY` prompt is injected via `str.format(agent_memory=...)` by deepagents'
+`MemoryMiddleware`, so any stray `{`/`}` in it would raise at runtime; the
+format guard below catches that permanently.
+"""
+
+import ast
+from pathlib import Path
+
+_AGENTS_PY = Path(__file__).resolve().parents[2] / "app" / "career_agent" / "agents.py"
+
+
+def test_memory_prompt_formats_with_only_agent_memory_placeholder() -> None:
+    """`MEMORY` must format cleanly with just `agent_memory` — no stray braces."""
+    from backend.app.career_agent import prompts
+
+    rendered = prompts.MEMORY.format(agent_memory="SENTINEL_MEMORY_BODY")
+
+    assert "SENTINEL_MEMORY_BODY" in rendered
+    assert "<agent_memory>" in rendered
+    assert "</agent_memory>" in rendered
+
+
+def test_memory_prompt_keeps_required_placeholder() -> None:
+    """`_format_agent_memory` calls `.format(agent_memory=...)`, so it must stay."""
+    from backend.app.career_agent import prompts
+
+    assert "{agent_memory}" in prompts.MEMORY
+
+
+def test_memory_index_wired_as_second_memory_source() -> None:
+    """`create_deep_agent(memory=[...])` must load both AGENTS.md and the index.
+
+    Parsed from source via AST so the check needs no model/API key and runs no
+    agent code.
+    """
+    tree = ast.parse(_AGENTS_PY.read_text())
+
+    sources: list[str] = []
+    for node in ast.walk(tree):
+        if not (
+            isinstance(node, ast.Call) and getattr(node.func, "id", None) == "create_deep_agent"
+        ):
+            continue
+        for kw in node.keywords:
+            if kw.arg == "memory" and isinstance(kw.value, ast.List):
+                sources = [
+                    el.value
+                    for el in kw.value.elts
+                    if isinstance(el, ast.Constant) and isinstance(el.value, str)
+                ]
+
+    from backend.app.career_agent.middleware import PREFERENCES_PATH
+
+    assert sources, "create_deep_agent(memory=[...]) with string entries not found"
+    assert "AGENTS.md" in sources
+    # The literal wired in agents.py must match the path the ensure-middleware seeds.
+    assert PREFERENCES_PATH in sources
+
+
+def test_memory_prompt_override_reaches_the_middleware(monkeypatch) -> None:
+    """`_apply_prompt_overrides` must make deepagents use our MEMORY prompt.
+
+    Importing the agent applies the overrides. deepagents 0.6.1 reads
+    `MEMORY_SYSTEM_PROMPT` as a bare module global, but 0.6.3+ also freezes it
+    into `MemoryMiddleware.__init__`'s keyword-only `system_prompt` default —
+    where a plain module-level `setattr` no longer reaches it. Whichever path
+    the installed version uses, the effective prompt must be ours; otherwise the
+    agent silently falls back to deepagents' generic memory guidelines (the
+    regression this guards).
+    """
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")  # model-client construction needs a key string
+
+    import backend.app.career_agent.agents  # noqa: F401  # import triggers _apply_prompt_overrides
+    import deepagents.middleware.memory as mem
+    from backend.app.career_agent import prompts
+
+    kwdefaults = mem.MemoryMiddleware.__init__.__kwdefaults__ or {}
+    if "system_prompt" in kwdefaults:  # deepagents 0.6.3+
+        assert kwdefaults["system_prompt"] == prompts.MEMORY
+    else:  # deepagents <= 0.6.1
+        assert mem.MEMORY_SYSTEM_PROMPT == prompts.MEMORY

--- a/docs/prd/17_preference_memory.md
+++ b/docs/prd/17_preference_memory.md
@@ -1,0 +1,116 @@
+# PRD: Long-term user-preference memory (v1)
+
+**Status:** shipped · **Scope:** Backend (career-agent memory)
+
+## Why
+
+The career agent is configured by files — `AGENTS.md` (procedure + brand voice) is always loaded as
+memory (PRD 08). But that memory is *repo-owned* and identical for everyone; there was no per-user
+**personalization**. A user who wanted salary ranges in research, AI skills emphasized in the resume,
+predicted Q&A in interview prep, or a terse battlecard had to re-state it on every prep run. We wanted
+Claude-Code-style auto memory: notice a durable preference once, persist it, and apply it on every
+future run — as a low-latency *add-on*, not a feature that taxes every turn. Only the main agent owns
+memory; subagents stay stateless and receive the relevant preferences in their task input.
+
+## What the user sees
+
+No new UI — it's behavioral. When the user states a standing preference ("from now on keep my
+battlecards concise", "always include the company's salary range", or an explicit "remember…"), the
+agent saves it, gives a one-line ack ("Noted — I'll keep battlecards concise from now on."), and then
+honors it automatically on this run and every future one (research / tailored resume / interview prep /
+battlecard). Preferences **persist across conversations** — a brand-new chat already knows them. They
+live in a human-readable, user-editable file at `/memory/preferences.md` (visible in Workspace > Files),
+grouped by stage heading.
+
+Deliberately *not* saved: one-off this-run-only instructions ("for THIS resume, drop the Twitter link"),
+anything derivable from the CV/JD, and pair-specific notes (those stay in `/processed/` and the intake
+file). And deliberately *not built*: a per-fact memory store, a new tool/button, or an `ls`/`grep`
+discovery flow — see below.
+
+## How — the key architectural choices
+
+- **One always-loaded file, not per-file + index.** The original plan mirrored Claude Code: a file per
+  preference (`/memory/<slug>.md`) plus an always-loaded `MEMORY.md` index. Live testing killed it —
+  gpt-5.4 would not maintain that shape by prompting alone: it wrote the preference into `AGENTS.md`,
+  wrote nothing (just acknowledged), or — once the index was seeded — collapsed everything into the
+  single index file and skipped the per-slug file. The model strongly gravitates to *one* file. So
+  preferences live in a single `/memory/preferences.md`, sectioned by stage. Retrieval and application
+  cost **0 tool calls** (it's in the system prompt every session); saving is **one `edit_file`**.
+- **Loaded as a memory source, not discovered at runtime.** `memory=["AGENTS.md", "/memory/preferences.md"]`
+  injects the file into the system prompt. The drafted alternative — `ls` → `grep` description → `read`
+  on every turn — costs ~3 round-trips *each time* the agent wants preferences. deepagents loads memory
+  sources once per thread, so always-loading is free per turn and is how Claude Code's own index works.
+- **Seed the file from a `before_agent` hook, never the LLM.** The agent reliably *edits* an existing
+  preferences file but cannot reliably *create* one on a clean slate (it fumbles toward `AGENTS.md` or
+  starts the intake workflow). `EnsurePreferencesFileMiddleware` writes the scaffold in
+  `before_agent`/`abefore_agent` — a single cheap store write (no model round-trip → no added latency),
+  idempotent because the backend's `write` refuses to overwrite an existing file. This is what makes
+  saving reliable: the model only ever has to edit.
+- **Apply by folding preferences into subagent task descriptions.** Subagents have no memory; the main
+  agent copies the relevant preference lines into each subagent's task input (which subagents already
+  treat as user instructions, per PRD 06). The battlecard, which the main agent builds itself, applies
+  them directly. `AGENTS.md` Stage 3/4/6 templates carry a `User preferences:` reminder at each
+  delegation point.
+
+## Files of interest
+
+| Concern | Path |
+|---|---|
+| The memory contract — what to remember, when to save, how to apply | `backend/app/career_agent/prompts.py` (`MEMORY`, block 7) |
+| Preferences file wired as a 2nd always-loaded memory source | `backend/app/career_agent/agents.py` (`create_deep_agent(memory=…)`) |
+| Monkey-patch that makes deepagents use our `MEMORY` prompt | `backend/app/career_agent/agents.py` (`_apply_prompt_overrides`) |
+| Seeds the `/memory/preferences.md` scaffold before the model runs | `backend/app/career_agent/middleware.py` (`EnsurePreferencesFileMiddleware`, `PREFERENCES_PATH`, `_PREFERENCES_SCAFFOLD`) |
+| `User preferences:` reminders at the delegation points | `backend/app/career_agent/AGENTS.md` (Stage 3 / Stage 4 / Stage 6) |
+| Guards: `MEMORY.format()`, override reaches middleware, seeder | `backend/tests/career_agent/test_prompts.py`, `test_middleware.py` |
+
+## Decisions worth remembering
+
+- **Single-file won because the model wouldn't cooperate with per-file, not because it's simpler.** The
+  user explicitly chose per-file first (granularity/auditability); we switched only after four live
+  attempts proved gpt-5.4 won't bootstrap or maintain it by prompt. If per-file is ever wanted, the
+  reliable path is a `save_preference(slug, description, body)` helper tool that writes the file and the
+  index in one Python step — moving the fragile two-write dance out of the LLM.
+- **Saving had to be made imperative *and* exempt from "don't write files yet."** A soft "save
+  preferences" prompt produced only a prose ack. The fix: "when a trigger fires you MUST record it in
+  `/memory/preferences.md` in the SAME turn — replying in prose is a failure," plus an explicit override
+  of the Stage-1 intake rule (that rule is about CV/JD artifacts; a preference needs no CV/JD), plus a
+  blunt "never write preferences into AGENTS.md" because the agent's first instinct was to append there.
+- **deepagents 0.6.3+ freezes the memory prompt into a kwdefault — the patch must reach it.**
+  `setattr(_mem_mw, "MEMORY_SYSTEM_PROMPT", …)` worked on 0.6.1 (read as a bare module global) but
+  silently no-op'd on 0.6.3+, which captures the prompt into `MemoryMiddleware.__init__.__kwdefaults__["system_prompt"]`
+  (same trap as Todo/SubAgent middleware). A container-vs-lock version skew (image shipped 0.6.3 while
+  `uv.lock` pinned 0.6.1) hid it in local tests. `_apply_prompt_overrides` now patches the kwdefault too,
+  guarded so it's a no-op on versions without the param. `test_memory_prompt_override_reaches_the_middleware`
+  guards both paths. (Skew later resolved by aligning everything to 0.6.8.)
+- **Memory is a once-per-thread snapshot, on purpose.** `MemoryMiddleware.before_agent` loads sources
+  once and caches them in `memory_contents` state; `modify_request` re-injects that cache every call but
+  never re-reads. So a mid-thread save is *not* reflected in that thread's system prompt — the agent
+  already has it in conversation context — and a new thread reloads it fresh. This stability is what keeps
+  the system-prompt prefix cacheable (`add_cache_control=True`); a per-turn reload would bust the cache.
+- **No delete primitive is needed.** deepagents exposes no delete tool/method; with single-file,
+  "remove a preference" is just editing out its bullet — which sidesteps the orphaned-tombstone problem
+  a per-file design would have hit.
+
+## Deferred (intentional non-goals for v1)
+
+- **Per-user namespacing.** The memory namespace is the constant `("career_agent","memory")` → a single
+  global store. Correct for a solo-user product (preferences persist across every thread). Multi-tenant
+  use would derive the namespace from a user id (the `StoreBackend` namespace factory already receives
+  runtime/config).
+- **Per-fact / index granularity.** Rejected for v1; revisit only if preferences grow large or numerous
+  enough that one always-loaded file becomes a real token cost — then load an index and read bodies on
+  demand, paired with a `save_preference` helper tool to keep the writes reliable.
+- **End-to-end apply verification.** The save → cross-thread recall loop is verified; folding prefs into a
+  full multi-subagent prep run was not exercised (a costly real run). Recall confirms prefs reach the
+  orchestrator's context, and the AGENTS.md templates wire the hand-off.
+- **A `delete_file` tool.** Unnecessary while single-file. Worth adding only alongside a per-file design.
+
+## How to verify end-to-end
+
+1. `cd backend && uv run pytest tests/career_agent/test_prompts.py tests/career_agent/test_middleware.py` — green.
+2. `pre-commit run --files backend/app/career_agent/{agents,prompts,middleware}.py backend/app/career_agent/AGENTS.md` — ruff + `ty` pass.
+3. `docker compose up -d`; grab the LangGraph host port from `docker ps`. Backend hot-reloads — confirm `graph_id=career_agent` re-imports cleanly in `docker logs next-role-backend-1`.
+4. From a clean store, send any message ("hi") → `EnsurePreferencesFileMiddleware` creates `/memory/preferences.md` (check Workspace > Files, or the `next-role-postgres` store under namespace `career_agent/memory`).
+5. State a standing preference ("from now on keep my battlecards very concise") → the agent makes **one** `edit_file` under the matching section, leaves `AGENTS.md` untouched, and acks in one line.
+6. Open a **new thread** → ask what it already knows about your preferences → it recalls them with **0 tool calls** (they're in the loaded `<agent_memory>` block).
+7. (Patch sanity) `docker exec next-role-backend-1 python -c "import deepagents.middleware.memory as m; from backend.app.career_agent import agents; print('It contains two things' in (m.MemoryMiddleware.__init__.__kwdefaults__ or {}).get('system_prompt',''))"` → `True` (the effective prompt is ours, not the deepagents default).


### PR DESCRIPTION
## Summary

Adds Claude-Code-style **long-term user-preference memory** to the career agent. Durable, cross-session preferences about *how* the user wants their materials made (e.g. salary range in research, AI skills emphasized in the resume, predicted Q&A in interview prep, concise battlecards) are remembered once and applied on every future prep run. It's a low-latency add-on: retrieval and application cost **0 tool calls**; saving is **one `edit_file`**.

Full design + rationale: [`docs/prd/17_preference_memory.md`](https://github.com/tam159/next-role/blob/feat/preference-memory/docs/prd/17_preference_memory.md).

## How it works

- **Single always-loaded file** `/memory/preferences.md`, sectioned by stage — chosen over a per-file + index design because gpt-5.4 wouldn't reliably maintain that shape (it wrote into `AGENTS.md`, wrote nothing, or collapsed to one file).
- **`EnsurePreferencesFileMiddleware`** seeds the scaffold in `before_agent` (a store write, no LLM, no per-turn latency) so the model only ever has to *edit* — it can't reliably *create* the file on a clean slate.
- **Apply via subagent task descriptions**: subagents stay stateless; the main agent folds relevant preferences into each task input (`AGENTS.md` Stage 3/4/6 reminders).
- **`MEMORY` prompt override** rewritten (what/when/how to save, retrieve, apply). The `_apply_prompt_overrides` monkey-patch now also patches `MemoryMiddleware.__init__`'s `system_prompt` kwdefault — deepagents 0.6.3+ freezes the prompt there, so the old module `setattr` silently no-op'd.
- **`UtcDatetimeMiddleware`** now injects date (not datetime) for prompt-cache stability.

## Test plan

- `cd backend && uv run pytest` → **87 passed, 2 skipped** (incl. new `test_prompts.py` and the ensure-middleware tests).
- `pre-commit` (ruff 0.15.16 + ty 0.0.44) clean on all changed files.
- Live, against the container (deepagents 0.6.8): a benign message auto-creates `/memory/preferences.md`; a stated standing preference is saved under the correct section with `AGENTS.md` untouched; a **new thread recalls it with 0 tool calls**; and the effective `MemoryMiddleware` prompt is ours, not the deepagents default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)