### PR TITLE
feat: migrate frontend to @langchain/react and re-enable subagent streaming

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,3 +59,10 @@ repos:
         files: ^frontend/
         types_or: [ts, tsx]
         pass_filenames: false
+
+      - id: frontend-langchain-sdk-sync
+        name: Frontend LangChain SDK sync
+        entry: node frontend/scripts/check-langchain-sdk-sync.mjs
+        language: system
+        files: ^frontend/(package\.json|pnpm-lock\.yaml)$
+        pass_filenames: false

--- a/backend/app/career_agent/middleware.py
+++ b/backend/app/career_agent/middleware.py
@@ -121,22 +121,27 @@ def _resolve_model(name: str) -> BaseChatModel | None:
     return model
 
 
-# Feature toggle (see PRD 16). Subagents don't stream tokens by default, because
-# parallel subagents streaming large tool-call args trigger an O(n^2) chunk
-# concat in the LangGraph SDK and hang the client. Flip to `False` — here for a
-# global default, or per run via `configurable.disable_subagent_streaming` — to
-# restore live subagent token streaming once the frontend/SDK is fixed for good.
-DISABLE_SUBAGENT_STREAMING: bool = True
+# Feature toggle (see PRD 16). Default `False`: subagents stream tokens live.
+# The freeze that forced the original `True` default was an O(n^2) per-token
+# chunk concat in the legacy `@langchain/langgraph-sdk` useStream path; the
+# frontend now runs on `@langchain/react`'s v2 stream runtime (fragment
+# accumulation + per-tick batched flushes), verified in-browser with
+# `resume-tailor` + `interview-coach` streaming large tool-call args in
+# parallel. Kept as a rollback lever: set `True` here — or per run via
+# `configurable.disable_subagent_streaming` — to drop subagents back to
+# per-step (whole-message) updates if a client-side freeze ever resurfaces.
+DISABLE_SUBAGENT_STREAMING: bool = False
 
 
 def _without_streaming(model: BaseChatModel) -> BaseChatModel:
     """Return a copy of `model` with token streaming disabled.
 
-    Subagents must not stream tokens: when two run in parallel and both emit a
-    large tool-call argument (e.g. `overwrite_file`'s `new_content`), the
-    LangGraph SDK's per-token `MessageTupleManager.concat` is O(n^2) and hangs
-    the client. `disable_streaming` makes the model defer to `(a)invoke`, so
-    LangGraph emits one complete message per step instead of token deltas.
+    Rollback path for subagent streaming (off by default since the
+    `@langchain/react` migration — see `DISABLE_SUBAGENT_STREAMING`). When
+    enabled, `disable_streaming` makes the model defer to `(a)invoke`, so
+    LangGraph emits one complete message per step instead of token deltas —
+    the historical mitigation for the legacy SDK's O(n^2) per-token concat
+    under parallel large tool-call args.
 
     `model_copy` leaves the shared/cached instance untouched — the main agent
     may use the same `provider:model` string (`openai:gpt-5.4` is shared with
@@ -161,8 +166,9 @@ class ModelOverrideMiddleware(AgentMiddleware):
        bake-time default (`_MODEL` in `agents.py`; `model:` in `subagents.yaml`)
        still wins.
 
-    2. **Disable streaming for subagents.** When `DISABLE_SUBAGENT_STREAMING`
-       is on (module default; overridable per run via
+    2. **Disable streaming for subagents (rollback lever).** When
+       `DISABLE_SUBAGENT_STREAMING` is on (module default `False` since the
+       `@langchain/react` migration; overridable per run via
        `configurable.disable_subagent_streaming`), every subagent call (override
        or default model) gets `disable_streaming=True` so parallel subagents
        emitting large tool-call args don't flood the client (see

--- a/backend/tests/career_agent/test_middleware_model_override.py
+++ b/backend/tests/career_agent/test_middleware_model_override.py
@@ -88,7 +88,12 @@ def test_main_agent_override_invokes_init_chat_model(middleware):
     assert result == "OK"
 
 
-def test_subagent_override_disables_streaming(middleware):
+def test_subagent_override_disables_streaming_when_default_on(middleware, monkeypatch):
+    """With the rollback default flipped on, a subagent override gets a no-stream copy."""
+    monkeypatch.setattr(
+        "backend.app.career_agent.middleware.DISABLE_SUBAGENT_STREAMING",
+        True,
+    )
     request, captured = _fake_request()
     received: dict = {}
     fake_model = _FakeModel(name="subagent-override")
@@ -119,7 +124,8 @@ def test_subagent_override_disables_streaming(middleware):
     assert fake_model.disable_streaming is False  # shared/cached instance untouched
 
 
-def test_subagent_without_override_disables_streaming_on_default(middleware):
+def test_subagent_streams_by_default(middleware):
+    """Module default is `False` since the `@langchain/react` migration: pass-through."""
     req_model = _FakeModel(name="subagent-default")
     request, captured = _fake_request(model=req_model)
     received: dict = {}
@@ -137,10 +143,9 @@ def test_subagent_without_override_disables_streaming_on_default(middleware):
         middleware.wrap_model_call(request, _fake_handler(received))
 
     mocked_init.assert_not_called()  # no override name → keep the request's own model
-    overridden = captured["model"]
-    assert overridden is not req_model
-    assert overridden.disable_streaming is True
-    assert req_model.disable_streaming is False  # copied, not mutated
+    assert captured == {}  # no override, streaming left intact
+    assert received["request"] is request
+    assert req_model.disable_streaming is False
 
 
 def test_subagent_streaming_can_be_reenabled_via_config(middleware):
@@ -192,11 +197,11 @@ def test_reenabled_subagent_still_gets_model_override(middleware):
     assert fake_model.disable_streaming is False
 
 
-def test_module_default_off_keeps_subagent_streaming(middleware, monkeypatch):
-    """Flipping the `DISABLE_SUBAGENT_STREAMING` module default off is enough to re-enable."""
+def test_module_default_on_disables_subagent_streaming(middleware, monkeypatch):
+    """Flipping the `DISABLE_SUBAGENT_STREAMING` module default back on is the rollback."""
     monkeypatch.setattr(
         "backend.app.career_agent.middleware.DISABLE_SUBAGENT_STREAMING",
-        False,
+        True,
     )
     req_model = _FakeModel(name="subagent-default")
     request, captured = _fake_request(model=req_model)
@@ -209,10 +214,34 @@ def test_module_default_off_keeps_subagent_streaming(middleware, monkeypatch):
     ):
         middleware.wrap_model_call(request, _fake_handler(received))
 
+    mocked_init.assert_not_called()  # no override name → keep the request's own model
+    overridden = captured["model"]
+    assert overridden is not req_model
+    assert overridden.disable_streaming is True
+    assert req_model.disable_streaming is False  # copied, not mutated
+
+
+def test_per_run_rollback_disables_streaming(middleware):
+    """`configurable.disable_subagent_streaming=True` overrides the `False` default."""
+    req_model = _FakeModel(name="subagent-default")
+    request, captured = _fake_request(model=req_model)
+    received: dict = {}
+
+    config = {
+        "configurable": {"disable_subagent_streaming": True},
+        "metadata": {"lc_agent_name": "interview-coach"},
+    }
+    with (
+        patch("backend.app.career_agent.middleware.get_config", return_value=config),
+        patch("backend.app.career_agent.middleware.init_chat_model") as mocked_init,
+    ):
+        middleware.wrap_model_call(request, _fake_handler(received))
+
     mocked_init.assert_not_called()
-    assert captured == {}
-    assert received["request"] is request
-    assert req_model.disable_streaming is False
+    overridden = captured["model"]
+    assert overridden is not req_model
+    assert overridden.disable_streaming is True
+    assert req_model.disable_streaming is False  # copied, not mutated
 
 
 def test_no_configurable_passes_request_through(middleware):

--- a/docs/prd/05_chat_streaming_throttle.md
+++ b/docs/prd/05_chat_streaming_throttle.md
@@ -1,6 +1,15 @@
 # PRD: Chat Streaming Throttle (v1)
 
-**Status:** shipped · **Scope:** Frontend chat surface (LangGraph SDK consumer) — throttle + identity-stable caching + click responsiveness under streaming load
+**Status:** partially superseded by [18_langchain_react_migration](18_langchain_react_migration.md)
+— the headline mechanism (80 ms hot-window throttle, `isHotStreaming`, hot-exit scroll re-engage,
+`sdkSubagents` memo + nested tool-call cache, `uiByMessageId`) was removed with the
+`@langchain/react` migration, whose v2 stream runtime batches store flushes per macrotask and
+makes a render-side throttle unnecessary. The orthogonal hardening from the same commit **remains
+shipped and load-bearing**: `ToolCall`/`toolCalls[]` identity caches in `ChatInterface`, the
+`pending`-state `JSON.stringify` guards + 256-char error-inspection cap in `ToolCallBox`, the
+`onPointerDown`+`onClick` dedupe (Safari click-swallowing is OS behavior, SDK-independent), and
+the sweep animation. · **Scope:** Frontend chat surface (LangGraph SDK consumer) — throttle +
+identity-stable caching + click responsiveness under streaming load
 
 ## Why
 

--- a/docs/prd/16_disable_subagent_streaming.md
+++ b/docs/prd/16_disable_subagent_streaming.md
@@ -1,6 +1,11 @@
 # PRD: Disable token streaming for subagents (v1)
 
-**Status:** shipped · **Scope:** Backend (career-agent model middleware) · **Extends:** [05_chat_streaming_throttle](05_chat_streaming_throttle.md)
+**Status:** superseded — default flipped to `False` (subagents stream again) after the frontend
+migrated to `@langchain/react`'s v2 stream runtime, whose fragment-array accumulation + per-tick
+batched flushes remove the O(n²) concat this PRD worked around. The toggle machinery is kept
+verbatim as the rollback lever (`DISABLE_SUBAGENT_STREAMING = True` or per-run
+`configurable.disable_subagent_streaming`). · **Scope:** Backend (career-agent model middleware) ·
+**Extends:** [05_chat_streaming_throttle](05_chat_streaming_throttle.md)
 
 ## Why
 

--- a/docs/prd/16_disable_subagent_streaming.md
+++ b/docs/prd/16_disable_subagent_streaming.md
@@ -1,8 +1,9 @@
 # PRD: Disable token streaming for subagents (v1)
 
-**Status:** superseded — default flipped to `False` (subagents stream again) after the frontend
-migrated to `@langchain/react`'s v2 stream runtime, whose fragment-array accumulation + per-tick
-batched flushes remove the O(n²) concat this PRD worked around. The toggle machinery is kept
+**Status:** superseded by [18_langchain_react_migration](18_langchain_react_migration.md) —
+default flipped to `False` (subagents stream again) after the frontend migrated to
+`@langchain/react`'s v2 stream runtime, whose fragment-array accumulation + per-tick batched
+flushes remove the O(n²) concat this PRD worked around. The toggle machinery is kept
 verbatim as the rollback lever (`DISABLE_SUBAGENT_STREAMING = True` or per-run
 `configurable.disable_subagent_streaming`). · **Scope:** Backend (career-agent model middleware) ·
 **Extends:** [05_chat_streaming_throttle](05_chat_streaming_throttle.md)

--- a/docs/prd/18_langchain_react_migration.md
+++ b/docs/prd/18_langchain_react_migration.md
@@ -1,0 +1,131 @@
+# PRD: @langchain/react migration + subagent streaming re-enable (v1)
+
+**Status:** shipped (PR #12) · **Scope:** Frontend chat surface (stream runtime swap) + backend
+career-agent middleware (toggle flip) · **Supersedes:** [16_disable_subagent_streaming](16_disable_subagent_streaming.md),
+partially [05_chat_streaming_throttle](05_chat_streaming_throttle.md)
+
+## Why
+
+PRD 16 disabled subagent token streaming because the legacy `@langchain/langgraph-sdk/react`
+`useStream` re-ran an O(n²) per-token `concat` (`MessageTupleManager.add` →
+`AIMessageChunk.concat`), freezing the browser whenever `resume-tailor` + `interview-coach`
+streamed large tool-call args in parallel. That PRD's stated endgame was "flip the toggle back
+once the FE/SDK is fixed for good." LangChain shipped that fix as a new package:
+`@langchain/react`, a v2-native stream runtime that accumulates content-block fragments in
+arrays (rope-concat per block) and batches store flushes per macrotask — the O(n²) is
+structurally gone, verified by reading the installed dist before migrating. Two goals, in order:
+migrate the frontend onto the new runtime, then re-enable subagent streaming and prove in a real
+browser that the freeze is dead.
+
+## What the user sees
+
+Subagent output streams live again: nested tool boxes inside a subagent card appear while the
+LLM is still emitting their args, and the args grow incrementally instead of landing whole per
+step. The chat surface stays responsive through the parallel phase — measured zero long tasks
+(worst 79 ms all-session), 8 ms worst input delay. Everything else is behavior parity: optimistic
+message echo, subagent cards with Running/Complete badges, files sidebar, thread switching,
+hard-reload hydration. One server-side caveat: main-agent *prose* now arrives per content block
+rather than per token (see Decisions) — tool args, the payload that caused the freeze, stream
+fine.
+
+## How — the key architectural choices
+
+- **Migrate to the v2 runtime instead of patching the legacy SDK.** PRD 16 had already rejected
+  `pnpm patch` of the O(n²) `concat` as fragile. `@langchain/react` is the upstream fix: a
+  different protocol (`POST /threads/{id}/stream/events`, channels `values`/`messages`/`tools`/
+  `lifecycle`), supported by our `langchain/langgraph-api:3.13` image (0.9.0 — confirmed live via
+  `openapi.json` before committing to the plan). Messages become `@langchain/core` `BaseMessage`
+  instances; interrupts resume via `respond()`; hydration and reattach-to-in-flight-runs are
+  automatic, so `reconnectOnMount`/`fetchStateHistory`/`onFinish`/`filterSubagentMessages` all
+  disappear rather than being ported.
+- **Subagent UI = discovery map + scoped selector hooks, with live args derived from
+  `tool_call_chunks`.** `stream.subagents` is keyed by the spawning `task` tool-call id, which
+  replaces `getSubagentsByMessage`. Each `SubagentCard` mounts `useToolCalls(stream, snapshot)` +
+  `useMessages(stream, snapshot)` (mount = ref-counted subscribe). The dual subscription is
+  load-bearing: the `tools` channel only emits `tool-started/finished/error` — **no arg deltas**
+  — so a call whose args are still streaming exists only as `tool_call_chunks` on the subagent's
+  messages channel. Chunk-derived entries (partial-JSON args via `parsePartialJson`) render until
+  the tools channel takes over at `tool-started`.
+- **Flip the backend default; keep the toggle as a rollback lever.** `DISABLE_SUBAGENT_STREAMING
+  = False` in `middleware.py` — no logic changes, comments rewritten as rollback docs. Rollback is
+  one hot-reloaded line (effective on the next subagent model call) or per-run
+  `configurable.disable_subagent_streaming: true`; the FE renders both cadences transparently.
+- **Delete dead surface instead of migrating it** (user-confirmed). `runSingleStep`,
+  `continueStream`, `markCurrentThreadAsResolved`, `getMessagesMetadata` had zero UI consumers
+  and depended on removed submit options (`interruptBefore/After`, `command`); the GenUI
+  `LoadExternalComponent` path was unreachable (backend never emits `values.ui`). Rebuilding any
+  of these later means raw `client.runs.*` / `useMessageMetadata`, not the old options.
+
+## Files of interest
+
+| Concern | Path |
+|---|---|
+| Hub rewrite: v2 `useStream`, `respond()`, throttle deletion, assistantId-hydrate guard | `frontend/src/app/hooks/useChat.ts` |
+| Per-subagent card: scoped hooks + chunk-derived pending tool calls | `frontend/src/app/components/SubagentCard.tsx` |
+| Task-call → snapshot association, pending-discovery fallback indicator | `frontend/src/app/components/ChatMessage.tsx` |
+| `BaseMessage` extraction (`tool_calls` + `tool_call_chunks`), GenUI/hot-scroll removal | `frontend/src/app/components/ChatInterface.tsx` |
+| `.text` accessor, `parsePartialArgs`/`toResultString` helpers | `frontend/src/app/utils/utils.ts` |
+| Sources from scoped tool calls (`SubagentSourcesProbe` consumer) | `frontend/src/app/utils/sources.ts` (`extractSourcesFromToolCalls`) |
+| Per-subagent sources probes replacing legacy `sub.messages` merge | `frontend/src/app/components/Workspace.tsx` |
+| `stream_mode` body-rewrite workaround removal (0.8.1-era, dead on the new protocol) | `frontend/src/providers/ClientProvider.tsx` |
+| Toggle flip + rollback-lever comments | `backend/app/career_agent/middleware.py` (`DISABLE_SUBAGENT_STREAMING`) |
+| Default/rollback test matrix | `backend/tests/career_agent/test_middleware_model_override.py` |
+
+## Decisions worth remembering
+
+- **Pin the direct `@langchain/langgraph-sdk` to the exact version `@langchain/react` bundles**
+  (1.9.20, plus `@langchain/core` `^1.1.48` per peers). Installing `@langchain/react` alone left
+  two SDK copies in node_modules; a `Client` constructed from one copy crossing into the other's
+  `StreamController` breaks instance identity. Keep them locked together on every future bump
+  (noted in `frontend/CLAUDE.md`).
+- **Hold `threadId` back until the assistant resolves.** Found in browser testing: on reload the
+  controller hydrated the URL's thread with `assistantId: ""` (assistant still fetching) and threw
+  `ThreadStream requires an assistantId option` — the legacy hook tolerated the empty string. Fix
+  in `useChat.ts`: `threadId: activeAssistant ? (threadId ?? null) : null`; the assistantId change
+  recreates the controller, which hydrates on `activate()`.
+- **langgraph-api 0.9.0 emits no `text` deltas on the v2 bridge.** Wire replay of
+  `/stream/events` showed all `content-block-delta`s carry tool-call `args` fields (550–1189 per
+  run); narration text arrives whole per block. Per-block prose cadence is server behavior — don't
+  chase it in the FE; re-check on langgraph-api upgrades and consider an upstream report.
+- **PRD 05 is only *partially* superseded.** The 80 ms throttle existed to slow the legacy SDK's
+  per-token churn; the v2 runtime batches flushes itself, so the throttle died. But the same
+  commit's hardening stays: `ToolCall` identity caches (a store flush still fires several times
+  per second mid-stream — without the caches every completed message re-renders per flush),
+  pending-state `JSON.stringify` guards, and `pointerdown` click hardening (Safari swallows
+  `click` under load regardless of SDK).
+- **Two-gate verification, baseline first.** Gate A ran the full SAP-JD pipeline on the migrated
+  FE with streaming still disabled — isolating migration regressions from streaming behavior and
+  producing a metrics baseline (2 long tasks, worst 88 ms). Only then was the toggle flipped for
+  Gate B's freeze test (zero long tasks during the parallel phase; streaming proven at wire +
+  UI levels). Debugging a freeze and a migration bug simultaneously would have been far slower.
+- **`defaultHeaders` on the hook was dead code.** Both legacy and v2 hooks ignore it whenever a
+  `client` is passed (headers live on the `Client`); the `x-auth-scheme` header was never sent.
+  Dropped rather than ported.
+
+## Deferred (intentional non-goals for v1)
+
+- **Per-token main-agent prose.** Blocked on the server bridge emitting text deltas (see
+  Decisions); nothing to do in the FE today.
+- **Step-mode / GenUI rebuild.** Deleted as dead code; if either returns, build on
+  `client.runs.*` (interrupt_before) / `useMessageMetadata` / the v2 `Client` re-exports — the
+  removed implementations targeted APIs that no longer exist.
+- **Frontend Settings switch for the rollback toggle.** Carried over from PRD 16:
+  `configurable.disable_subagent_streaming` is honored per-run; wiring it into `buildSubmitConfig`
+  is trivial if it ever needs to be user-facing. Operator knob today.
+
+## How to verify end-to-end
+
+1. `cd backend && uv run pytest tests/career_agent/test_middleware_model_override.py` — 13 green
+   (default pass-through + module/per-run rollback paths).
+2. `docker compose up -d`; both containers hot-reload. Open the frontend port from `docker ps`.
+3. Run a flow to the parallel `resume-tailor` + `interview-coach` phase (CV upload + JD URL +
+   timeline). During the phase: both cards show **Running** with nested tool boxes whose args grow
+   live; clicks land; no freeze. Optionally inject a `PerformanceObserver({type:'longtask'})`
+   before submitting — expect no entry > 1 s during the phase.
+4. Wire check (replace `<tid>`): `curl -N -X POST http://localhost:<port>/threads/<tid>/stream/events
+   -H 'Content-Type: application/json' -d '{"channels":["messages"],"namespaces":[],"since":0}'`
+   — subagent namespaces carry `content-block-delta` events with incremental `args` fields.
+5. Hard-reload mid-thread: messages, tool boxes, and subagent cards rehydrate; no
+   `ThreadStream requires an assistantId` overlay error.
+6. Rollback drill: set `DISABLE_SUBAGENT_STREAMING = True` (hot-reloads), rerun a subagent —
+   nested output arrives per step, whole; flip back.

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -24,7 +24,13 @@ Next.js 16 (App Router, Turbopack) + React 19 + TypeScript + Tailwind. Talks to 
 
 - UI primitives are Radix (`@radix-ui/*`) + Tailwind, not a single component library.
 - State: `swr` for data fetching, `nuqs` for URL state, `zod` for runtime validation.
-- LangGraph integration uses `@langchain/react` + `@langchain/langgraph-sdk`. Keep the direct
-  `@langchain/langgraph-sdk` pin identical to the version `@langchain/react` depends on (one copy
-  in node_modules — `Client` instances cross the package boundary), and the SDK in sync with the
-  backend's `langgraph` major.
+- LangGraph integration uses `@langchain/react` + `@langchain/langgraph-sdk` + `@langchain/core`.
+  All three direct deps are required: app code imports `Client`/`Assistant`/`Thread` from the SDK
+  (not re-exported by `@langchain/react`) and message classes from core (a _peer_ dep of
+  `@langchain/react` — peers are never bundled; the app owns the single `BaseMessage` identity).
+  **Upgrade rule:** bump `@langchain/react` first, then (a) set the `@langchain/langgraph-sdk` pin
+  to the exact version the new `@langchain/react` depends on (one copy in node_modules — `Client`
+  instances cross the package boundary), and (b) keep `@langchain/core` inside its peer range
+  (pnpm warns on violation). Prefer `@langchain/react` re-exports for stream types
+  (`SubagentDiscoverySnapshot`, `AssembledToolCall`); only `Client` + schema types come from the
+  SDK. Keep the SDK in sync with the backend's `langgraph` major.

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -28,9 +28,13 @@ Next.js 16 (App Router, Turbopack) + React 19 + TypeScript + Tailwind. Talks to 
   All three direct deps are required: app code imports `Client`/`Assistant`/`Thread` from the SDK
   (not re-exported by `@langchain/react`) and message classes from core (a _peer_ dep of
   `@langchain/react` — peers are never bundled; the app owns the single `BaseMessage` identity).
-  **Upgrade rule:** bump `@langchain/react` first, then (a) set the `@langchain/langgraph-sdk` pin
-  to the exact version the new `@langchain/react` depends on (one copy in node_modules — `Client`
-  instances cross the package boundary), and (b) keep `@langchain/core` inside its peer range
-  (pnpm warns on violation). Prefer `@langchain/react` re-exports for stream types
+  **Upgrade rule:** bump `@langchain/react` first; the other two follow it. The invariant is
+  **one installed copy of `@langchain/langgraph-sdk`**, shared with `@langchain/react` (`Client`
+  instances cross the package boundary). The SDK is a _regular_ dep of `@langchain/react`
+  (exact-pinned upstream), so a version conflict does NOT warn at install time — pnpm silently
+  installs two copies; only _peer_ conflicts (`@langchain/core`) warn. That's why
+  `scripts/check-langchain-sdk-sync.mjs` guards the invariant (pre-commit hook
+  `frontend-langchain-sdk-sync` + `pnpm quality`) and prints the exact fix command when the
+  copies split. Prefer `@langchain/react` re-exports for stream types
   (`SubagentDiscoverySnapshot`, `AssembledToolCall`); only `Client` + schema types come from the
   SDK. Keep the SDK in sync with the backend's `langgraph` major.

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -1,6 +1,6 @@
 # frontend/CLAUDE.md
 
-Next.js 16 (App Router, Turbopack) + React 19 + TypeScript + Tailwind. Talks to the backend agents via `@langchain/langgraph-sdk`.
+Next.js 16 (App Router, Turbopack) + React 19 + TypeScript + Tailwind. Talks to the backend agents via `@langchain/react` (the `useStream` v2 runtime + scoped selector hooks) with `@langchain/langgraph-sdk` for the raw `Client` (threads/store APIs) and shared types.
 
 ## Tooling
 
@@ -24,4 +24,7 @@ Next.js 16 (App Router, Turbopack) + React 19 + TypeScript + Tailwind. Talks to 
 
 - UI primitives are Radix (`@radix-ui/*`) + Tailwind, not a single component library.
 - State: `swr` for data fetching, `nuqs` for URL state, `zod` for runtime validation.
-- LangGraph integration uses `@langchain/langgraph-sdk` — keep the SDK version in sync with the backend's `langgraph` major.
+- LangGraph integration uses `@langchain/react` + `@langchain/langgraph-sdk`. Keep the direct
+  `@langchain/langgraph-sdk` pin identical to the version `@langchain/react` depends on (one copy
+  in node_modules — `Client` instances cross the package boundary), and the SDK in sync with the
+  backend's `langgraph` major.

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -28,13 +28,16 @@ Next.js 16 (App Router, Turbopack) + React 19 + TypeScript + Tailwind. Talks to 
   All three direct deps are required: app code imports `Client`/`Assistant`/`Thread` from the SDK
   (not re-exported by `@langchain/react`) and message classes from core (a _peer_ dep of
   `@langchain/react` — peers are never bundled; the app owns the single `BaseMessage` identity).
-  **Upgrade rule:** bump `@langchain/react` first; the other two follow it. The invariant is
-  **one installed copy of `@langchain/langgraph-sdk`**, shared with `@langchain/react` (`Client`
-  instances cross the package boundary). The SDK is a _regular_ dep of `@langchain/react`
-  (exact-pinned upstream), so a version conflict does NOT warn at install time — pnpm silently
-  installs two copies; only _peer_ conflicts (`@langchain/core`) warn. That's why
-  `scripts/check-langchain-sdk-sync.mjs` guards the invariant (pre-commit hook
-  `frontend-langchain-sdk-sync` + `pnpm quality`) and prints the exact fix command when the
-  copies split. Prefer `@langchain/react` re-exports for stream types
+  **Upgrade rule:** `@langchain/react` + `@langchain/langgraph-sdk` are a lockstep pair (same
+  monorepo, like `react`/`react-dom`) — bump `@langchain/react` first, then pin the SDK
+  **exactly** (no `^`) to the version the new `@langchain/react` depends on:
+  `pnpm --dir frontend add @langchain/langgraph-sdk@<ver> --save-exact`. The invariant is **one
+  installed copy of the SDK**, shared with `@langchain/react` (`Client` instances cross the
+  package boundary). The SDK is a _regular_ dep of `@langchain/react`, so a version conflict does
+  NOT warn at install time — pnpm silently installs two copies; only _peer_ conflicts
+  (`@langchain/core`) warn. The exact pin prevents self-inflicted drift (`pnpm update` can't
+  float it), and `scripts/check-langchain-sdk-sync.mjs` (pre-commit hook
+  `frontend-langchain-sdk-sync` + `pnpm quality`) catches the forgotten-sync case on
+  `@langchain/react` bumps, printing the exact fix command. Prefer `@langchain/react` re-exports for stream types
   (`SubagentDiscoverySnapshot`, `AssembledToolCall`); only `Client` + schema types come from the
   SDK. Keep the SDK in sync with the backend's `langgraph` major.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,11 +13,12 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "type-check": "tsc --noEmit",
-    "quality": "pnpm lint:fix && pnpm format && pnpm type-check"
+    "quality": "pnpm lint:fix && pnpm format && pnpm type-check && pnpm check:sdk-sync",
+    "check:sdk-sync": "node scripts/check-langchain-sdk-sync.mjs"
   },
   "dependencies": {
     "@langchain/core": "^1.1.48",
-    "@langchain/langgraph-sdk": "1.9.20",
+    "@langchain/langgraph-sdk": "^1.9.20",
     "@langchain/react": "^1.0.20",
     "@radix-ui/colors": "^1.0.1",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,9 +16,10 @@
     "quality": "pnpm lint:fix && pnpm format && pnpm type-check"
   },
   "dependencies": {
-    "@langchain/core": "^1.1.46",
+    "@langchain/core": "^1.1.48",
     "@langchain/langgraph": "^1.3.0",
-    "@langchain/langgraph-sdk": "1.9.2",
+    "@langchain/langgraph-sdk": "1.9.20",
+    "@langchain/react": "^1.0.20",
     "@radix-ui/colors": "^1.0.1",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-label": "^2.1.8",
@@ -30,7 +31,6 @@
     "@radix-ui/react-tooltip": "^1.2.8",
     "@types/diff": "^5.2.3",
     "@types/react-syntax-highlighter": "^15.5.13",
-    "@types/uuid": "^9.0.8",
     "class-variance-authority": "^0.7.1",
     "clsx": "^1.2.1",
     "date-fns": "^4.1.0",
@@ -52,7 +52,6 @@
     "swr": "^2.4.1",
     "tailwind-merge": "^2.6.1",
     "use-stick-to-bottom": "^1.1.3",
-    "uuid": "^9.0.1",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@langchain/core": "^1.1.48",
-    "@langchain/langgraph-sdk": "^1.9.20",
+    "@langchain/langgraph-sdk": "1.9.20",
     "@langchain/react": "^1.0.20",
     "@radix-ui/colors": "^1.0.1",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,6 @@
   },
   "dependencies": {
     "@langchain/core": "^1.1.48",
-    "@langchain/langgraph": "^1.3.0",
     "@langchain/langgraph-sdk": "1.9.20",
     "@langchain/react": "^1.0.20",
     "@radix-ui/colors": "^1.0.1",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -9,14 +9,17 @@ importers:
   .:
     dependencies:
       '@langchain/core':
-        specifier: ^1.1.46
-        version: 1.1.46
+        specifier: ^1.1.48
+        version: 1.1.48
       '@langchain/langgraph':
         specifier: ^1.3.0
-        version: 1.3.0(@langchain/core@1.1.46)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(zod@4.3.6)
+        version: 1.3.0(@langchain/core@1.1.48)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(zod@4.3.6)
       '@langchain/langgraph-sdk':
-        specifier: 1.9.2
-        version: 1.9.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: 1.9.20
+        version: 1.9.20(@langchain/core@1.1.48)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@langchain/react':
+        specifier: ^1.0.20
+        version: 1.0.20(@langchain/core@1.1.48)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/colors':
         specifier: ^1.0.1
         version: 1.0.1
@@ -50,9 +53,6 @@ importers:
       '@types/react-syntax-highlighter':
         specifier: ^15.5.13
         version: 15.5.13
-      '@types/uuid':
-        specifier: ^9.0.8
-        version: 9.0.8
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -116,9 +116,6 @@ importers:
       use-stick-to-bottom:
         specifier: ^1.1.3
         version: 1.1.3(react@19.1.0)
-      uuid:
-        specifier: ^9.0.1
-        version: 9.0.1
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -536,8 +533,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@langchain/core@1.1.46':
-    resolution: {integrity: sha512-i8rDC83BpItxChCw4Lf+6tAr+k+OUcbirc5ZkrhI9ywYWmvxegUljLGOGYvtJNTbEAIFkhYIODPE5QRqyjF6sA==}
+  '@langchain/core@1.1.48':
+    resolution: {integrity: sha512-fQU6Guyb1pwc2fEplmA8FPbKfOMAofjnyJzExevro0FxEiuGHE18Ov/ZHmT9trWCDTZRI9eW1VIc6aChxV8pAQ==}
     engines: {node: '>=20'}
 
   '@langchain/langgraph-checkpoint@1.0.2':
@@ -549,6 +546,24 @@ packages:
   '@langchain/langgraph-sdk@1.9.2':
     resolution: {integrity: sha512-1kDPjR0VH/39q2h8k0Sxi35KxOvEQPModVCepxGLlRkbZmuWUH+zfICuJd3rmD1ByeOKQBZEaB7Y+VCYmSMt1w==}
     peerDependencies:
+      react: ^18 || ^19
+      react-dom: ^18 || ^19
+      svelte: ^4.0.0 || ^5.0.0
+      vue: ^3.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+
+  '@langchain/langgraph-sdk@1.9.20':
+    resolution: {integrity: sha512-waZQNUN6apVg3jvDApy16wUGwrCvJB8WXHbIPvVrrUZHObqx0w5tk7P/Ite5Qvu4abWrvNtrmqk2zmcqCx7jVw==}
+    peerDependencies:
+      '@langchain/core': ^1.1.48
       react: ^18 || ^19
       react-dom: ^18 || ^19
       svelte: ^4.0.0 || ^5.0.0
@@ -576,6 +591,15 @@ packages:
 
   '@langchain/protocol@0.0.15':
     resolution: {integrity: sha512-MllvbpMjqHevUm+v94M422mH7XKN+wGCvJRBVROTWBotEDOATYB4Ktk2UheYP859y9o2LlhtPek5t1T9eyfAbQ==}
+
+  '@langchain/protocol@0.0.16':
+    resolution: {integrity: sha512-ws+J7MaHyhO5dG7f0vdyHQiUn9hoCnki0f3crJPa4MCTGzcRC39jYSCghyrGtBPYQnZbUQiGyRVpW3z3M8IpJg==}
+
+  '@langchain/react@1.0.20':
+    resolution: {integrity: sha512-KF6/88Ib847SPSRzOdvUcSu5E0Qlln6h4uB6ywdkPmVd+Ol3y9RcteFpF84dWAPdYl411nyOrIfA08PoO4M0hw==}
+    peerDependencies:
+      '@langchain/core': ^1.1.48
+      react: ^18 || ^19
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
@@ -1205,9 +1229,6 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
-
-  '@types/uuid@9.0.8':
-    resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==}
 
   '@typescript-eslint/eslint-plugin@8.59.1':
     resolution: {integrity: sha512-BOziFIfE+6osHO9FoJG4zjoHUcvI7fTNBSpdAwrNH0/TLvzjsk2oo8XSSOT2HhqUyhZPfHv4UOffoJ9oEEQ7Ag==}
@@ -3374,8 +3395,8 @@ packages:
     resolution: {integrity: sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==}
     hasBin: true
 
-  uuid@9.0.1:
-    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
 
   vfile-message@4.0.3:
@@ -3763,7 +3784,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@langchain/core@1.1.46':
+  '@langchain/core@1.1.48':
     dependencies:
       '@cfworker/json-schema': 4.1.1
       '@standard-schema/spec': 1.1.0
@@ -3779,14 +3800,14 @@ snapshots:
       - openai
       - ws
 
-  '@langchain/langgraph-checkpoint@1.0.2(@langchain/core@1.1.46)':
+  '@langchain/langgraph-checkpoint@1.0.2(@langchain/core@1.1.48)':
     dependencies:
-      '@langchain/core': 1.1.46
+      '@langchain/core': 1.1.48
       uuid: 10.0.0
 
   '@langchain/langgraph-sdk@1.9.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
-      '@langchain/core': 1.1.46
+      '@langchain/core': 1.1.48
       '@langchain/protocol': 0.0.15
       '@types/json-schema': 7.0.15
       p-queue: 9.3.0
@@ -3802,10 +3823,22 @@ snapshots:
       - openai
       - ws
 
-  '@langchain/langgraph@1.3.0(@langchain/core@1.1.46)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(zod@4.3.6)':
+  '@langchain/langgraph-sdk@1.9.20(@langchain/core@1.1.48)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
-      '@langchain/core': 1.1.46
-      '@langchain/langgraph-checkpoint': 1.0.2(@langchain/core@1.1.46)
+      '@langchain/core': 1.1.48
+      '@langchain/protocol': 0.0.16
+      '@types/json-schema': 7.0.15
+      p-queue: 9.3.0
+      p-retry: 7.1.1
+      uuid: 14.0.0
+    optionalDependencies:
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
+  '@langchain/langgraph@1.3.0(@langchain/core@1.1.48)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(zod@4.3.6)':
+    dependencies:
+      '@langchain/core': 1.1.48
+      '@langchain/langgraph-checkpoint': 1.0.2(@langchain/core@1.1.48)
       '@langchain/langgraph-sdk': 1.9.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@langchain/protocol': 0.0.15
       '@standard-schema/spec': 1.1.0
@@ -3823,6 +3856,18 @@ snapshots:
       - ws
 
   '@langchain/protocol@0.0.15': {}
+
+  '@langchain/protocol@0.0.16': {}
+
+  '@langchain/react@1.0.20(@langchain/core@1.1.48)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@langchain/core': 1.1.48
+      '@langchain/langgraph-sdk': 1.9.20(@langchain/core@1.1.48)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+    transitivePeerDependencies:
+      - react-dom
+      - svelte
+      - vue
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
@@ -4378,8 +4423,6 @@ snapshots:
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
-
-  '@types/uuid@9.0.8': {}
 
   '@typescript-eslint/eslint-plugin@8.59.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)':
     dependencies:
@@ -6993,7 +7036,7 @@ snapshots:
 
   uuid@13.0.2: {}
 
-  uuid@9.0.1: {}
+  uuid@14.0.0: {}
 
   vfile-message@4.0.3:
     dependencies:

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -12,7 +12,7 @@ importers:
         specifier: ^1.1.48
         version: 1.1.48
       '@langchain/langgraph-sdk':
-        specifier: 1.9.20
+        specifier: ^1.9.20
         version: 1.9.20(@langchain/core@1.1.48)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@langchain/react':
         specifier: ^1.0.20

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -12,7 +12,7 @@ importers:
         specifier: ^1.1.48
         version: 1.1.48
       '@langchain/langgraph-sdk':
-        specifier: ^1.9.20
+        specifier: 1.9.20
         version: 1.9.20(@langchain/core@1.1.48)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@langchain/react':
         specifier: ^1.0.20

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       '@langchain/core':
         specifier: ^1.1.48
         version: 1.1.48
-      '@langchain/langgraph':
-        specifier: ^1.3.0
-        version: 1.3.0(@langchain/core@1.1.48)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(zod@4.3.6)
       '@langchain/langgraph-sdk':
         specifier: 1.9.20
         version: 1.9.20(@langchain/core@1.1.48)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -537,29 +534,6 @@ packages:
     resolution: {integrity: sha512-fQU6Guyb1pwc2fEplmA8FPbKfOMAofjnyJzExevro0FxEiuGHE18Ov/ZHmT9trWCDTZRI9eW1VIc6aChxV8pAQ==}
     engines: {node: '>=20'}
 
-  '@langchain/langgraph-checkpoint@1.0.2':
-    resolution: {integrity: sha512-F4E5Tr0nt8FGghgdscJtHw+ABzChOHeI80R7Y1pjIHdiJom6c2ieo76vL+FWiny80JmoGqhrVAEIWrw0cXKPxg==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@langchain/core': ^1.1.44
-
-  '@langchain/langgraph-sdk@1.9.2':
-    resolution: {integrity: sha512-1kDPjR0VH/39q2h8k0Sxi35KxOvEQPModVCepxGLlRkbZmuWUH+zfICuJd3rmD1ByeOKQBZEaB7Y+VCYmSMt1w==}
-    peerDependencies:
-      react: ^18 || ^19
-      react-dom: ^18 || ^19
-      svelte: ^4.0.0 || ^5.0.0
-      vue: ^3.0.0
-    peerDependenciesMeta:
-      react:
-        optional: true
-      react-dom:
-        optional: true
-      svelte:
-        optional: true
-      vue:
-        optional: true
-
   '@langchain/langgraph-sdk@1.9.20':
     resolution: {integrity: sha512-waZQNUN6apVg3jvDApy16wUGwrCvJB8WXHbIPvVrrUZHObqx0w5tk7P/Ite5Qvu4abWrvNtrmqk2zmcqCx7jVw==}
     peerDependencies:
@@ -577,20 +551,6 @@ packages:
         optional: true
       vue:
         optional: true
-
-  '@langchain/langgraph@1.3.0':
-    resolution: {integrity: sha512-QvhTjiyqFPz81A+y6LHs223w6DTjv5+882DT4mup72bd72rRhNjTYo5fhes5um0swnKArvY/arc7KeFInfHHWw==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@langchain/core': ^1.1.44
-      zod: ^3.25.32 || ^4.2.0
-      zod-to-json-schema: ^3.x
-    peerDependenciesMeta:
-      zod-to-json-schema:
-        optional: true
-
-  '@langchain/protocol@0.0.15':
-    resolution: {integrity: sha512-MllvbpMjqHevUm+v94M422mH7XKN+wGCvJRBVROTWBotEDOATYB4Ktk2UheYP859y9o2LlhtPek5t1T9eyfAbQ==}
 
   '@langchain/protocol@0.0.16':
     resolution: {integrity: sha512-ws+J7MaHyhO5dG7f0vdyHQiUn9hoCnki0f3crJPa4MCTGzcRC39jYSCghyrGtBPYQnZbUQiGyRVpW3z3M8IpJg==}
@@ -3386,15 +3346,6 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  uuid@10.0.0:
-    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
-    hasBin: true
-
-  uuid@13.0.2:
-    resolution: {integrity: sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==}
-    hasBin: true
-
   uuid@14.0.0:
     resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
@@ -3800,29 +3751,6 @@ snapshots:
       - openai
       - ws
 
-  '@langchain/langgraph-checkpoint@1.0.2(@langchain/core@1.1.48)':
-    dependencies:
-      '@langchain/core': 1.1.48
-      uuid: 10.0.0
-
-  '@langchain/langgraph-sdk@1.9.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
-    dependencies:
-      '@langchain/core': 1.1.48
-      '@langchain/protocol': 0.0.15
-      '@types/json-schema': 7.0.15
-      p-queue: 9.3.0
-      p-retry: 7.1.1
-      uuid: 13.0.2
-    optionalDependencies:
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-    transitivePeerDependencies:
-      - '@opentelemetry/api'
-      - '@opentelemetry/exporter-trace-otlp-proto'
-      - '@opentelemetry/sdk-trace-base'
-      - openai
-      - ws
-
   '@langchain/langgraph-sdk@1.9.20(@langchain/core@1.1.48)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@langchain/core': 1.1.48
@@ -3834,28 +3762,6 @@ snapshots:
     optionalDependencies:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
-
-  '@langchain/langgraph@1.3.0(@langchain/core@1.1.48)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(zod@4.3.6)':
-    dependencies:
-      '@langchain/core': 1.1.48
-      '@langchain/langgraph-checkpoint': 1.0.2(@langchain/core@1.1.48)
-      '@langchain/langgraph-sdk': 1.9.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@langchain/protocol': 0.0.15
-      '@standard-schema/spec': 1.1.0
-      uuid: 10.0.0
-      zod: 4.3.6
-    transitivePeerDependencies:
-      - '@opentelemetry/api'
-      - '@opentelemetry/exporter-trace-otlp-proto'
-      - '@opentelemetry/sdk-trace-base'
-      - openai
-      - react
-      - react-dom
-      - svelte
-      - vue
-      - ws
-
-  '@langchain/protocol@0.0.15': {}
 
   '@langchain/protocol@0.0.16': {}
 
@@ -7031,10 +6937,6 @@ snapshots:
       react: 19.1.0
 
   util-deprecate@1.0.2: {}
-
-  uuid@10.0.0: {}
-
-  uuid@13.0.2: {}
 
   uuid@14.0.0: {}
 

--- a/frontend/scripts/check-langchain-sdk-sync.mjs
+++ b/frontend/scripts/check-langchain-sdk-sync.mjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+// Guard: the app and @langchain/react must resolve the SAME copy of
+// @langchain/langgraph-sdk. The SDK is a *regular* dependency of
+// @langchain/react (exact-pinned upstream), so a version conflict does NOT
+// warn at install time — pnpm silently installs two copies, and `Client`
+// instances created from one copy break instance identity inside the
+// other's StreamController (the original parallel-subagent freeze era bug).
+// pnpm only warns for *peer* conflicts (e.g. @langchain/core).
+//
+// Runs in pre-commit (Frontend LangChain SDK sync) and `pnpm quality`.
+import { createRequire } from "node:module";
+import { realpathSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const frontendDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const version = (pkgJsonPath) => JSON.parse(readFileSync(pkgJsonPath, "utf8")).version;
+
+const appRequire = createRequire(path.join(frontendDir, "package.json"));
+const appSdk = realpathSync(appRequire.resolve("@langchain/langgraph-sdk/package.json"));
+
+// Resolve the SDK copy @langchain/react itself sees (its .pnpm sibling).
+const reactDir = realpathSync(path.dirname(appRequire.resolve("@langchain/react/package.json")));
+const reactRequire = createRequire(path.join(reactDir, "package.json"));
+const reactSdk = realpathSync(reactRequire.resolve("@langchain/langgraph-sdk/package.json"));
+
+if (appSdk !== reactSdk) {
+  const wanted = version(reactSdk);
+  console.error(
+    `✗ Two copies of @langchain/langgraph-sdk are installed:\n` +
+      `    app resolves        ${version(appSdk)}  (${appSdk})\n` +
+      `    @langchain/react uses ${wanted}  (${reactSdk})\n` +
+      `  Fix: pnpm --dir frontend add "@langchain/langgraph-sdk@^${wanted}"\n` +
+      `  (then docker compose restart frontend)`
+  );
+  process.exit(1);
+}
+console.log(
+  `✓ @langchain/langgraph-sdk ${version(appSdk)}: single copy, shared with @langchain/react`
+);

--- a/frontend/scripts/check-langchain-sdk-sync.mjs
+++ b/frontend/scripts/check-langchain-sdk-sync.mjs
@@ -30,7 +30,7 @@ if (appSdk !== reactSdk) {
     `✗ Two copies of @langchain/langgraph-sdk are installed:\n` +
       `    app resolves        ${version(appSdk)}  (${appSdk})\n` +
       `    @langchain/react uses ${wanted}  (${reactSdk})\n` +
-      `  Fix: pnpm --dir frontend add "@langchain/langgraph-sdk@^${wanted}"\n` +
+      `  Fix: pnpm --dir frontend add @langchain/langgraph-sdk@${wanted} --save-exact\n` +
       `  (then docker compose restart frontend)`
   );
   process.exit(1);

--- a/frontend/src/app/components/ChatInterface.tsx
+++ b/frontend/src/app/components/ChatInterface.tsx
@@ -5,8 +5,15 @@ import { Button } from "@/components/ui/button";
 import { Square, ArrowUp } from "lucide-react";
 import { ChatMessage } from "@/app/components/ChatMessage";
 import type { ToolCall, ActionRequest, ReviewConfig } from "@/app/types/types";
-import { Assistant, Message } from "@langchain/langgraph-sdk";
-import { extractStringFromMessageContent } from "@/app/utils/utils";
+import { Assistant } from "@langchain/langgraph-sdk";
+import {
+  type AIMessageChunk,
+  type BaseMessage,
+  isAIMessage,
+  isHumanMessage,
+  isToolMessage,
+} from "@langchain/core/messages";
+import { extractStringFromMessageContent, parsePartialArgs } from "@/app/utils/utils";
 import { useChatContext } from "@/providers/ChatProvider";
 import { useStickToBottom } from "use-stick-to-bottom";
 
@@ -17,13 +24,11 @@ interface ChatInterfaceProps {
 export const ChatInterface = React.memo<ChatInterfaceProps>(({ assistant }) => {
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
 
-  const { scrollRef, contentRef, scrollToBottom } = useStickToBottom();
+  const { scrollRef, contentRef } = useStickToBottom();
 
   const {
     stream,
     messages,
-    isHotStreaming,
-    ui,
     isLoading,
     isThreadLoading,
     interrupt,
@@ -34,21 +39,6 @@ export const ChatInterface = React.memo<ChatInterfaceProps>(({ assistant }) => {
     setInput,
     focusComposerNonce,
   } = useChatContext();
-
-  // Re-engage sticky scroll whenever a throttled (hot) streaming window
-  // ends. During the hot window the user can lose the bottom-lock — a
-  // stray scroll-wheel tick, or the library reading a batched content jump
-  // as an escape — and any output that follows would otherwise render
-  // below the fold until the user manually scrolls. This transition is the
-  // right moment to recapture, regardless of which agent or step produced
-  // the window.
-  const prevHotRef = useRef(isHotStreaming);
-  useEffect(() => {
-    if (prevHotRef.current && !isHotStreaming) {
-      scrollToBottom();
-    }
-    prevHotRef.current = isHotStreaming;
-  }, [isHotStreaming, scrollToBottom]);
 
   const submitDisabled = isLoading || !assistant;
 
@@ -128,55 +118,38 @@ export const ChatInterface = React.memo<ChatInterfaceProps>(({ assistant }) => {
      2. For each AI message, add the AI message, and any tool calls to the messageMap
      3. For each tool message, find the corresponding tool call in the messageMap and update the status and output
     */
-    const messageMap = new Map<string, { message: Message; toolCalls: ToolCall[] }>();
-    messages.forEach((message: Message) => {
-      if (message.type === "ai") {
-        const toolCallsInMessage: Array<{
-          id?: string;
-          function?: { name?: string; arguments?: unknown };
-          name?: string;
-          type?: string;
-          args?: unknown;
-          input?: unknown;
-        }> = [];
-        if (
-          message.additional_kwargs?.tool_calls &&
-          Array.isArray(message.additional_kwargs.tool_calls)
-        ) {
-          toolCallsInMessage.push(...message.additional_kwargs.tool_calls);
-        } else if (message.tool_calls && Array.isArray(message.tool_calls)) {
-          toolCallsInMessage.push(
-            ...message.tool_calls.filter((toolCall: { name?: string }) => toolCall.name !== "")
-          );
-        } else if (Array.isArray(message.content)) {
-          const toolUseBlocks = message.content.filter(
-            (block: { type?: string }) => block.type === "tool_use"
-          );
-          toolCallsInMessage.push(...toolUseBlocks);
-        }
-        const toolCallsWithStatus = toolCallsInMessage.map(
-          (toolCall: {
-            id?: string;
-            function?: { name?: string; arguments?: unknown };
-            name?: string;
-            type?: string;
-            args?: unknown;
-            input?: unknown;
-          }) => {
-            const name = toolCall.function?.name || toolCall.name || toolCall.type || "unknown";
-            const args = toolCall.function?.arguments || toolCall.args || toolCall.input || {};
-            const id = toolCall.id || `tool-${Math.random()}`;
-            const status: ToolCall["status"] = interrupt ? "interrupted" : "pending";
-            // Pending tools: always fresh reference so the streaming box re-renders.
-            // Cache hit happens later when the matching ToolMessage flips status.
-            return { id, name, args, status } as ToolCall;
-          }
-        );
+    const messageMap = new Map<string, { message: BaseMessage; toolCalls: ToolCall[] }>();
+    messages.forEach((message: BaseMessage) => {
+      if (isAIMessage(message)) {
+        // Completed calls live on `tool_calls` (parsed args); a call whose
+        // args are still streaming only exists as a `tool_call_chunks` entry
+        // (partial-JSON string args) until it finishes assembling.
+        const status: ToolCall["status"] = interrupt ? "interrupted" : "pending";
+        const done = (message.tool_calls ?? []).filter((tc) => tc.name !== "");
+        const doneIds = new Set(done.map((tc) => tc.id));
+        const chunks = (message as AIMessageChunk).tool_call_chunks ?? [];
+        const streaming = chunks.filter((c) => c.id && c.name && !doneIds.has(c.id));
+        // Pending tools: always fresh reference so the streaming box re-renders.
+        // Cache hit happens later when the matching ToolMessage flips status.
+        const toolCallsWithStatus: ToolCall[] = [
+          ...done.map((tc) => ({
+            id: tc.id ?? `tool-${Math.random()}`,
+            name: tc.name,
+            args: (tc.args ?? {}) as Record<string, unknown>,
+            status,
+          })),
+          ...streaming.map((c) => ({
+            id: c.id!,
+            name: c.name!,
+            args: parsePartialArgs(c.args),
+            status,
+          })),
+        ];
         messageMap.set(message.id!, {
           message,
           toolCalls: toolCallsWithStatus,
         });
-      } else if (message.type === "tool") {
+      } else if (isToolMessage(message)) {
         const toolCallId = message.tool_call_id;
         if (!toolCallId) {
           return;
@@ -201,7 +174,7 @@ export const ChatInterface = React.memo<ChatInterfaceProps>(({ assistant }) => {
           }
           break;
         }
-      } else if (message.type === "human") {
+      } else if (isHumanMessage(message)) {
         messageMap.set(message.id!, {
           message,
           toolCalls: [],
@@ -257,22 +230,6 @@ export const ChatInterface = React.memo<ChatInterfaceProps>(({ assistant }) => {
     return new Map(reviewConfigs.map((rc: ReviewConfig) => [rc.actionName, rc]));
   }, [interrupt]);
 
-  // Bucket UI items by message_id once per ui change so that ChatMessage gets
-  // a stable array reference per message instead of a fresh `.filter()` result
-  // on every render.
-  const uiByMessageId = useMemo(() => {
-    const buckets = new Map<string, any[]>();
-    if (!ui) return buckets;
-    for (const u of ui as any[]) {
-      const mid = u?.metadata?.message_id;
-      if (!mid) continue;
-      const existing = buckets.get(mid);
-      if (existing) existing.push(u);
-      else buckets.set(mid, [u]);
-    }
-    return buckets;
-  }, [ui]);
-
   return (
     <div className="flex flex-1 flex-col overflow-hidden bg-canvas">
       <div className="flex-1 overflow-y-auto overflow-x-hidden overscroll-contain" ref={scrollRef}>
@@ -284,7 +241,6 @@ export const ChatInterface = React.memo<ChatInterfaceProps>(({ assistant }) => {
           ) : (
             <>
               {processedMessages.map((data, index) => {
-                const messageUi = data.message.id ? uiByMessageId.get(data.message.id) : undefined;
                 const isLastMessage = index === processedMessages.length - 1;
                 return (
                   <ChatMessage
@@ -294,10 +250,8 @@ export const ChatInterface = React.memo<ChatInterfaceProps>(({ assistant }) => {
                     isLoading={isLoading}
                     actionRequestsMap={isLastMessage ? actionRequestsMap : undefined}
                     reviewConfigsMap={isLastMessage ? reviewConfigsMap : undefined}
-                    ui={messageUi}
                     stream={stream}
                     onResumeInterrupt={resumeInterrupt}
-                    graphId={assistant?.graph_id}
                   />
                 );
               })}

--- a/frontend/src/app/components/ChatMessage.tsx
+++ b/frontend/src/app/components/ChatMessage.tsx
@@ -1,24 +1,24 @@
 "use client";
 
-import React, { useMemo, useState, useCallback, useRef } from "react";
+import React, { useMemo } from "react";
 import { SubAgentIndicator } from "@/app/components/SubAgentIndicator";
+import { SubagentCard } from "@/app/components/SubagentCard";
 import { ToolCallBox } from "@/app/components/ToolCallBox";
 import { MarkdownContent } from "@/app/components/MarkdownContent";
-import type { SubAgent, ToolCall, ActionRequest, ReviewConfig } from "@/app/types/types";
-import { Message } from "@langchain/langgraph-sdk";
-import { extractSubAgentContent, extractStringFromMessageContent } from "@/app/utils/utils";
+import type { ToolCall, ActionRequest, ReviewConfig } from "@/app/types/types";
+import type { BaseMessage } from "@langchain/core/messages";
+import type { AnyStream } from "@langchain/react";
+import { extractStringFromMessageContent } from "@/app/utils/utils";
 import { cn } from "@/lib/utils";
 
 interface ChatMessageProps {
-  message: Message;
+  message: BaseMessage;
   toolCalls: ToolCall[];
   isLoading?: boolean;
   actionRequestsMap?: Map<string, ActionRequest>;
   reviewConfigsMap?: Map<string, ReviewConfig>;
-  ui?: any[];
-  stream?: any;
-  onResumeInterrupt?: (value: any) => void;
-  graphId?: string;
+  stream: AnyStream;
+  onResumeInterrupt?: (value: unknown) => void;
 }
 
 export const ChatMessage = React.memo<ChatMessageProps>(
@@ -28,162 +28,27 @@ export const ChatMessage = React.memo<ChatMessageProps>(
     isLoading,
     actionRequestsMap,
     reviewConfigsMap,
-    ui,
     stream,
     onResumeInterrupt,
-    graphId,
   }) => {
     const isUser = message.type === "human";
     const messageContent = extractStringFromMessageContent(message);
     const hasContent = messageContent && messageContent.trim() !== "";
     const hasToolCalls = toolCalls.length > 0;
 
-    // Cache nested-tool-call objects (per subagent's tool call) by id so that
-    // ToolCallBox.memo short-circuits for completed nested tools while the
-    // streaming one alone passes a fresh reference.
-    const nestedToolCallCacheRef = useRef(new Map<string, ToolCall>());
-
-    // Subscribe to the SDK's per-subagent state so the box stays populated
-    // after the run reconciles with thread history (which only persists the
-    // parent `task` tool call). `stream.subagents` is a Map kept up to date
-    // by SubagentManager for the lifetime of the React state. We sample via
-    // `toolCalls` (throttled transitively by the messages snapshot in
-    // useChat) instead of `stream.subagents` directly — the SDK exposes it
-    // as a getter that returns a fresh reference on every read, which would
-    // re-run this memo on every token and starve the main thread under any
-    // high-rate streaming.
-    const sdkSubagents: any[] = useMemo(() => {
-      if (!stream?.getSubagentsByMessage || !message.id) return [];
-      try {
-        return stream.getSubagentsByMessage(message.id) ?? [];
-      } catch {
-        return [];
-      }
-    }, [stream, message.id, toolCalls]);
-
-    const subAgents = useMemo(() => {
-      const sdkById = new Map<string, any>(sdkSubagents.map((s) => [s.id, s]));
-      const mapStatus = (
-        sdkStatus: string | undefined,
-        fallback: ToolCall["status"]
-      ): SubAgent["status"] => {
-        switch (sdkStatus) {
-          case "running":
-            return "active";
-          case "complete":
-            return "completed";
-          case "pending":
-            return "pending";
-          case "error":
-            return "error";
-          default:
-            if (fallback === "completed") return "completed";
-            if (fallback === "error") return "error";
-            return "pending";
-        }
-      };
-      const toResultString = (result: unknown): string | undefined => {
-        if (result == null) return undefined;
-        if (typeof result === "string") return result;
-        if (Array.isArray(result)) {
-          return result
-            .map((block) => {
-              if (typeof block === "string") return block;
-              if (block && typeof block === "object" && "text" in block) {
-                return String((block as { text: unknown }).text ?? "");
-              }
-              try {
-                return JSON.stringify(block);
-              } catch {
-                return String(block);
-              }
-            })
-            .join("");
-        }
-        try {
-          return JSON.stringify(result);
-        } catch {
-          return String(result);
-        }
-      };
-      return toolCalls
-        .filter((toolCall: ToolCall) => {
-          return (
+    // A `task` tool call's id doubles as the subagent discovery key:
+    // `stream.subagents` is keyed by the spawning tool-call id.
+    const taskToolCalls = useMemo(
+      () =>
+        toolCalls.filter(
+          (toolCall) =>
             toolCall.name === "task" &&
             toolCall.args["subagent_type"] &&
             toolCall.args["subagent_type"] !== "" &&
             toolCall.args["subagent_type"] !== null
-          );
-        })
-        .map((toolCall: ToolCall) => {
-          const subagentType = (toolCall.args as Record<string, unknown>)[
-            "subagent_type"
-          ] as string;
-          const sdk = sdkById.get(toolCall.id);
-
-          // The SDK exposes nested tool calls as `ToolCallWithResult` objects:
-          // `{ id, call: { name, args, id }, result: ToolMessage|undefined, state }`.
-          // Map them into our local flat ToolCall shape and skip nested `task`
-          // invocations (we don't recursively render sub-subagents inside this
-          // box).
-          const nestedToolCalls: ToolCall[] | undefined = sdk?.toolCalls
-            ? (sdk.toolCalls as Array<any>)
-                .filter((tc) => tc?.call?.name && tc.call.name !== "task")
-                .map((tc) => {
-                  const call = tc.call ?? {};
-                  const resultStr = toResultString(tc.result?.content);
-                  const state = tc.state ?? (resultStr !== undefined ? "completed" : "pending");
-                  const status: ToolCall["status"] =
-                    state === "error" ? "error" : state === "completed" ? "completed" : "pending";
-                  const id =
-                    tc.id ||
-                    call.id ||
-                    `${toolCall.id}-${call.name}-${Math.random().toString(36).slice(2)}`;
-                  // Cache only finalized nested tools — pending ones must keep
-                  // emitting fresh refs so streaming tokens render live.
-                  if (status === "completed" || status === "error") {
-                    const cached = nestedToolCallCacheRef.current.get(id);
-                    if (cached && cached.status === status && cached.result === resultStr) {
-                      return cached;
-                    }
-                  }
-                  const next: ToolCall = {
-                    id,
-                    name: call.name,
-                    args: (call.args ?? {}) as Record<string, unknown>,
-                    result: resultStr,
-                    status,
-                  };
-                  if (status === "completed" || status === "error") {
-                    nestedToolCallCacheRef.current.set(id, next);
-                  }
-                  return next;
-                })
-            : undefined;
-
-          return {
-            id: toolCall.id,
-            name: toolCall.name,
-            subAgentName: subagentType,
-            input: toolCall.args,
-            output: toolCall.result ? { result: toolCall.result } : undefined,
-            status: mapStatus(sdk?.status, toolCall.status),
-            toolCalls: nestedToolCalls,
-          } as SubAgent;
-        });
-    }, [toolCalls, sdkSubagents]);
-
-    const [expandedSubAgents, setExpandedSubAgents] = useState<Record<string, boolean>>({});
-    const isSubAgentExpanded = useCallback(
-      (id: string) => expandedSubAgents[id] ?? true,
-      [expandedSubAgents]
+        ),
+      [toolCalls]
     );
-    const toggleSubAgent = useCallback((id: string) => {
-      setExpandedSubAgents((prev) => ({
-        ...prev,
-        [id]: prev[id] === undefined ? false : !prev[id],
-      }));
-    }, []);
 
     return (
       <div className={cn("flex w-full max-w-full overflow-x-hidden", isUser && "flex-row-reverse")}>
@@ -213,18 +78,12 @@ export const ChatMessage = React.memo<ChatMessageProps>(
             <div className="mt-4 flex w-full flex-col gap-2">
               {toolCalls.map((toolCall: ToolCall) => {
                 if (toolCall.name === "task") return null;
-                const toolCallGenUiComponent = ui?.find(
-                  (u) => u.metadata?.tool_call_id === toolCall.id
-                );
                 const actionRequest = actionRequestsMap?.get(toolCall.name);
                 const reviewConfig = reviewConfigsMap?.get(toolCall.name);
                 return (
                   <ToolCallBox
                     key={toolCall.id}
                     toolCall={toolCall}
-                    uiComponent={toolCallGenUiComponent}
-                    stream={stream}
-                    graphId={graphId}
                     actionRequest={actionRequest}
                     reviewConfig={reviewConfig}
                     onResume={onResumeInterrupt}
@@ -234,60 +93,37 @@ export const ChatMessage = React.memo<ChatMessageProps>(
               })}
             </div>
           )}
-          {!isUser && subAgents.length > 0 && (
+          {!isUser && taskToolCalls.length > 0 && (
             <div className="mt-4 flex w-fit max-w-full flex-col gap-4">
-              {subAgents.map((subAgent) => (
-                <div key={subAgent.id} className="flex w-full flex-col gap-3">
-                  <div className="flex items-end gap-2">
-                    <div className="w-[calc(100%-100px)]">
-                      <SubAgentIndicator
-                        subAgent={subAgent}
-                        onClick={() => toggleSubAgent(subAgent.id)}
-                        isExpanded={isSubAgentExpanded(subAgent.id)}
-                      />
-                    </div>
-                  </div>
-                  {isSubAgentExpanded(subAgent.id) && (
-                    <div className="w-full max-w-full">
-                      <div className="rounded-2xl border border-border bg-surface-raised p-4 shadow-sm">
-                        <h4 className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                          Input
-                        </h4>
-                        <div className="mb-4 rounded-xl border border-border bg-background/50 p-3">
-                          <MarkdownContent content={extractSubAgentContent(subAgent.input)} />
-                        </div>
-                        {subAgent.toolCalls && subAgent.toolCalls.length > 0 && (
-                          <>
-                            <h4 className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                              Activity
-                            </h4>
-                            <div className="mb-4 flex flex-col gap-2 border-l border-border pl-3">
-                              {subAgent.toolCalls.map((tc) => (
-                                <ToolCallBox
-                                  key={tc.id}
-                                  toolCall={tc}
-                                  stream={stream}
-                                  graphId={graphId}
-                                />
-                              ))}
-                            </div>
-                          </>
-                        )}
-                        {subAgent.output && (
-                          <>
-                            <h4 className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                              Output
-                            </h4>
-                            <div className="rounded-xl border border-border bg-background/50 p-3">
-                              <MarkdownContent content={extractSubAgentContent(subAgent.output)} />
-                            </div>
-                          </>
-                        )}
-                      </div>
-                    </div>
-                  )}
-                </div>
-              ))}
+              {taskToolCalls.map((toolCall) => {
+                const snapshot = stream.subagents.get(toolCall.id);
+                if (!snapshot) {
+                  // Discovery hasn't landed yet (the task call's args are
+                  // still streaming): show a static queued indicator until
+                  // the tools-channel event creates the snapshot.
+                  return (
+                    <SubAgentIndicator
+                      key={toolCall.id}
+                      subAgent={{
+                        id: toolCall.id,
+                        name: toolCall.name,
+                        subAgentName: String(toolCall.args["subagent_type"]),
+                        input: toolCall.args,
+                        status: "pending",
+                      }}
+                      onClick={() => {}}
+                    />
+                  );
+                }
+                return (
+                  <SubagentCard
+                    key={toolCall.id}
+                    stream={stream}
+                    snapshot={snapshot}
+                    taskToolCall={toolCall}
+                  />
+                );
+              })}
             </div>
           )}
         </div>

--- a/frontend/src/app/components/SubagentCard.tsx
+++ b/frontend/src/app/components/SubagentCard.tsx
@@ -12,7 +12,12 @@ import { SubAgentIndicator } from "@/app/components/SubAgentIndicator";
 import { ToolCallBox } from "@/app/components/ToolCallBox";
 import { MarkdownContent } from "@/app/components/MarkdownContent";
 import type { SubAgent, ToolCall } from "@/app/types/types";
-import { extractSubAgentContent, parsePartialArgs, toResultString } from "@/app/utils/utils";
+import {
+  extractSubAgentContent,
+  parsePartialArgs,
+  toResultString,
+  unwrapToolPayload,
+} from "@/app/utils/utils";
 
 function mapSnapshotStatus(status: SubagentDiscoverySnapshot["status"]): SubAgent["status"] {
   if (status === "running") return "active";
@@ -48,7 +53,7 @@ export const SubagentCard = React.memo<SubagentCardProps>(({ stream, snapshot, t
         id: tc.id,
         name: tc.name,
         args: (tc.args ?? {}) as Record<string, unknown>,
-        result: toResultString(tc.output),
+        result: toResultString(unwrapToolPayload(tc.output)),
         status:
           tc.status === "error" ? "error" : tc.status === "finished" ? "completed" : "pending",
       }));
@@ -78,7 +83,7 @@ export const SubagentCard = React.memo<SubagentCardProps>(({ stream, snapshot, t
       input: taskToolCall.args,
       output:
         snapshot.output != null
-          ? { result: toResultString(snapshot.output) ?? "" }
+          ? { result: toResultString(unwrapToolPayload(snapshot.output)) ?? "" }
           : taskToolCall.result
             ? { result: taskToolCall.result }
             : undefined,

--- a/frontend/src/app/components/SubagentCard.tsx
+++ b/frontend/src/app/components/SubagentCard.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import React, { useMemo, useState } from "react";
+import { useMessages, useToolCalls, type AnyStream } from "@langchain/react";
+import type { SubagentDiscoverySnapshot } from "@langchain/langgraph-sdk/stream";
+import { type AIMessageChunk, isAIMessage } from "@langchain/core/messages";
+import { SubAgentIndicator } from "@/app/components/SubAgentIndicator";
+import { ToolCallBox } from "@/app/components/ToolCallBox";
+import { MarkdownContent } from "@/app/components/MarkdownContent";
+import type { SubAgent, ToolCall } from "@/app/types/types";
+import { extractSubAgentContent, parsePartialArgs, toResultString } from "@/app/utils/utils";
+
+function mapSnapshotStatus(status: SubagentDiscoverySnapshot["status"]): SubAgent["status"] {
+  if (status === "running") return "active";
+  if (status === "error") return "error";
+  return "completed";
+}
+
+interface SubagentCardProps {
+  stream: AnyStream;
+  snapshot: SubagentDiscoverySnapshot;
+  taskToolCall: ToolCall;
+}
+
+/**
+ * One subagent's progress card. Mounting subscribes to the subagent's
+ * namespaced projections (ref-counted; shared with any other consumer):
+ *
+ *  - `tools` — authoritative call lifecycle (`tool-started/finished/error`)
+ *    with parsed args and outputs. No arg deltas on this channel.
+ *  - `messages` — the subagent's own LLM stream; a call whose args are
+ *    still streaming exists only as `tool_call_chunks` here, so this is
+ *    what makes nested tool args grow token-by-token live.
+ */
+export const SubagentCard = React.memo<SubagentCardProps>(({ stream, snapshot, taskToolCall }) => {
+  const assembled = useToolCalls(stream, snapshot);
+  const messages = useMessages(stream, snapshot);
+  const [isExpanded, setIsExpanded] = useState(true);
+
+  const nestedToolCalls: ToolCall[] = useMemo(() => {
+    const fromTools: ToolCall[] = assembled
+      .filter((tc) => tc.name !== "task")
+      .map((tc) => ({
+        id: tc.id,
+        name: tc.name,
+        args: (tc.args ?? {}) as Record<string, unknown>,
+        result: toResultString(tc.output),
+        status:
+          tc.status === "error" ? "error" : tc.status === "finished" ? "completed" : "pending",
+      }));
+    const startedIds = new Set(assembled.map((tc) => tc.id));
+    const streaming: ToolCall[] = [];
+    for (const message of messages) {
+      if (!isAIMessage(message)) continue;
+      for (const chunk of (message as AIMessageChunk).tool_call_chunks ?? []) {
+        if (!chunk.id || !chunk.name || chunk.name === "task") continue;
+        if (startedIds.has(chunk.id)) continue;
+        streaming.push({
+          id: chunk.id,
+          name: chunk.name,
+          args: parsePartialArgs(chunk.args),
+          status: "pending",
+        });
+      }
+    }
+    return [...fromTools, ...streaming];
+  }, [assembled, messages]);
+
+  const subAgent: SubAgent = useMemo(
+    () => ({
+      id: snapshot.id,
+      name: taskToolCall.name,
+      subAgentName: snapshot.name,
+      input: taskToolCall.args,
+      output:
+        snapshot.output != null
+          ? { result: toResultString(snapshot.output) ?? "" }
+          : taskToolCall.result
+            ? { result: taskToolCall.result }
+            : undefined,
+      status: mapSnapshotStatus(snapshot.status),
+    }),
+    [snapshot, taskToolCall]
+  );
+
+  return (
+    <div className="flex w-full flex-col gap-3">
+      <div className="flex items-end gap-2">
+        <div className="w-[calc(100%-100px)]">
+          <SubAgentIndicator
+            subAgent={subAgent}
+            onClick={() => setIsExpanded((prev) => !prev)}
+            isExpanded={isExpanded}
+          />
+        </div>
+      </div>
+      {isExpanded && (
+        <div className="w-full max-w-full">
+          <div className="rounded-2xl border border-border bg-surface-raised p-4 shadow-sm">
+            <h4 className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+              Input
+            </h4>
+            <div className="mb-4 rounded-xl border border-border bg-background/50 p-3">
+              <MarkdownContent content={extractSubAgentContent(subAgent.input)} />
+            </div>
+            {nestedToolCalls.length > 0 && (
+              <>
+                <h4 className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                  Activity
+                </h4>
+                <div className="mb-4 flex flex-col gap-2 border-l border-border pl-3">
+                  {nestedToolCalls.map((tc) => (
+                    <ToolCallBox key={tc.id} toolCall={tc} />
+                  ))}
+                </div>
+              </>
+            )}
+            {subAgent.output && (
+              <>
+                <h4 className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                  Output
+                </h4>
+                <div className="rounded-xl border border-border bg-background/50 p-3">
+                  <MarkdownContent content={extractSubAgentContent(subAgent.output)} />
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+});
+
+SubagentCard.displayName = "SubagentCard";

--- a/frontend/src/app/components/SubagentCard.tsx
+++ b/frontend/src/app/components/SubagentCard.tsx
@@ -1,8 +1,12 @@
 "use client";
 
 import React, { useMemo, useState } from "react";
-import { useMessages, useToolCalls, type AnyStream } from "@langchain/react";
-import type { SubagentDiscoverySnapshot } from "@langchain/langgraph-sdk/stream";
+import {
+  useMessages,
+  useToolCalls,
+  type AnyStream,
+  type SubagentDiscoverySnapshot,
+} from "@langchain/react";
 import { type AIMessageChunk, isAIMessage } from "@langchain/core/messages";
 import { SubAgentIndicator } from "@/app/components/SubAgentIndicator";
 import { ToolCallBox } from "@/app/components/ToolCallBox";

--- a/frontend/src/app/components/ToolCallBox.tsx
+++ b/frontend/src/app/components/ToolCallBox.tsx
@@ -22,17 +22,13 @@ import {
 import { Button } from "@/components/ui/button";
 import { ToolCall, ActionRequest, ReviewConfig } from "@/app/types/types";
 import { cn } from "@/lib/utils";
-import { LoadExternalComponent } from "@langchain/langgraph-sdk/react-ui";
 import { ToolApprovalInterrupt } from "@/app/components/ToolApprovalInterrupt";
 
 interface ToolCallBoxProps {
   toolCall: ToolCall;
-  uiComponent?: any;
-  stream?: any;
-  graphId?: string;
   actionRequest?: ActionRequest;
   reviewConfig?: ReviewConfig;
-  onResume?: (value: any) => void;
+  onResume?: (value: unknown) => void;
   isLoading?: boolean;
 }
 
@@ -162,17 +158,8 @@ function previewValue(value: unknown): string | null {
 }
 
 export const ToolCallBox = React.memo<ToolCallBoxProps>(
-  ({
-    toolCall,
-    uiComponent,
-    stream,
-    graphId,
-    actionRequest,
-    reviewConfig,
-    onResume,
-    isLoading,
-  }) => {
-    const [isExpanded, setIsExpanded] = useState(() => !!uiComponent || !!actionRequest);
+  ({ toolCall, actionRequest, reviewConfig, onResume, isLoading }) => {
+    const [isExpanded, setIsExpanded] = useState(() => !!actionRequest);
     const [expandedArgs, setExpandedArgs] = useState<Record<string, boolean>>({});
 
     const { name, args, result, status } = useMemo(() => {
@@ -304,17 +291,7 @@ export const ToolCallBox = React.memo<ToolCallBoxProps>(
 
         {isExpanded && hasContent && (
           <div className="relative z-10 px-4 pb-4">
-            {uiComponent && stream && graphId ? (
-              <div className="mt-3 overflow-hidden rounded-lg border border-border bg-card p-2">
-                <LoadExternalComponent
-                  key={uiComponent.id}
-                  stream={stream}
-                  message={uiComponent}
-                  namespace={graphId}
-                  meta={{ status, args, result: result ?? "No Result Yet" }}
-                />
-              </div>
-            ) : actionRequest && onResume ? (
+            {actionRequest && onResume ? (
               // Show tool approval UI when there's an action request but no GenUI
               <div className="mt-3 overflow-hidden rounded-lg border border-amber-500/25 bg-amber-500/10 p-3">
                 <ToolApprovalInterrupt

--- a/frontend/src/app/components/Workspace.tsx
+++ b/frontend/src/app/components/Workspace.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useToolCalls, type AnyStream } from "@langchain/react";
-import type { SubagentDiscoverySnapshot } from "@langchain/langgraph-sdk/stream";
+import { useToolCalls, type AnyStream, type SubagentDiscoverySnapshot } from "@langchain/react";
 import { useChatContext } from "@/providers/ChatProvider";
 import { extractSources, extractSourcesFromToolCalls } from "@/app/utils/sources";
 import type { Source } from "@/app/types/types";

--- a/frontend/src/app/components/Workspace.tsx
+++ b/frontend/src/app/components/Workspace.tsx
@@ -1,14 +1,42 @@
 "use client";
 
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useToolCalls, type AnyStream } from "@langchain/react";
+import type { SubagentDiscoverySnapshot } from "@langchain/langgraph-sdk/stream";
 import { useChatContext } from "@/providers/ChatProvider";
-import { extractSources } from "@/app/utils/sources";
+import { extractSources, extractSourcesFromToolCalls } from "@/app/utils/sources";
+import type { Source } from "@/app/types/types";
 import { PlanSection } from "@/app/components/workspace/PlanSection";
 import { FilesSection } from "@/app/components/workspace/FilesSection";
 import { SourcesSection } from "@/app/components/workspace/SourcesSection";
 
+/**
+ * Invisible per-subagent subscription: search tool calls executed by
+ * subagents (e.g. hiring-recon's web_search) never reach the root
+ * `messages`, so each discovered subagent gets a probe that watches its
+ * scoped tool-call projection and reports extracted sources upward. The
+ * subscription is ref-counted and shared with the chat's SubagentCard.
+ */
+function SubagentSourcesProbe({
+  stream,
+  snapshot,
+  onSources,
+}: {
+  stream: AnyStream;
+  snapshot: SubagentDiscoverySnapshot;
+  onSources: (id: string, sources: Source[]) => void;
+}) {
+  const toolCalls = useToolCalls(stream, snapshot);
+  const sources = useMemo(() => extractSourcesFromToolCalls(toolCalls), [toolCalls]);
+  useEffect(() => {
+    onSources(snapshot.id, sources);
+  }, [snapshot.id, sources, onSources]);
+  return null;
+}
+
 export function Workspace() {
   const {
+    stream,
     todos,
     files,
     setFiles,
@@ -20,19 +48,46 @@ export function Workspace() {
     subagents,
   } = useChatContext();
 
-  // With `filterSubagentMessages: true`, search tool calls executed by
-  // subagents (e.g. researcher's web_search) no longer flow into the main
-  // `messages` array — they live on each subagent's own `messages`. Merge
-  // both sources so the Sources tab keeps working.
+  const [subagentSources, setSubagentSources] = useState<Map<string, Source[]>>(new Map());
+
+  const handleSubagentSources = useCallback((id: string, sources: Source[]) => {
+    setSubagentSources((prev) => {
+      const existing = prev.get(id);
+      const same =
+        existing &&
+        existing.length === sources.length &&
+        existing.every((s, i) => s.url === sources[i].url);
+      if (same || (!existing && sources.length === 0)) return prev;
+      const next = new Map(prev);
+      next.set(id, sources);
+      return next;
+    });
+  }, []);
+
+  // Drop entries for subagents that no longer exist (e.g. thread switch).
+  useEffect(() => {
+    setSubagentSources((prev) => {
+      if (![...prev.keys()].some((id) => !subagents.has(id))) return prev;
+      const next = new Map<string, Source[]>();
+      for (const [id, s] of prev) {
+        if (subagents.has(id)) next.set(id, s);
+      }
+      return next;
+    });
+  }, [subagents]);
+
   const sources = useMemo(() => {
-    const all = [...messages];
-    if (subagents) {
-      for (const sub of subagents.values()) {
-        if (Array.isArray(sub?.messages)) all.push(...sub.messages);
+    const merged = extractSources(messages);
+    const seen = new Set(merged.map((s) => s.url));
+    for (const list of subagentSources.values()) {
+      for (const s of list) {
+        if (seen.has(s.url)) continue;
+        seen.add(s.url);
+        merged.push(s);
       }
     }
-    return extractSources(all);
-  }, [messages, subagents]);
+    return merged;
+  }, [messages, subagentSources]);
 
   const [planOpen, setPlanOpen] = useState(false);
   const [filesOpen, setFilesOpen] = useState(true);
@@ -64,6 +119,14 @@ export function Workspace() {
 
   return (
     <div className="flex h-full flex-col border-l border-border bg-background">
+      {Array.from(subagents.values()).map((snapshot) => (
+        <SubagentSourcesProbe
+          key={snapshot.id}
+          stream={stream}
+          snapshot={snapshot}
+          onSources={handleSubagentSources}
+        />
+      ))}
       <div className="bg-surface/80 flex-shrink-0 border-b border-border px-6 py-4 backdrop-blur">
         <h2 className="text-xl font-bold tracking-tight text-foreground">Workspace</h2>
         <p className="text-sm text-muted-foreground">Plan, files, and sources</p>

--- a/frontend/src/app/hooks/useChat.ts
+++ b/frontend/src/app/hooks/useChat.ts
@@ -1,11 +1,10 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useStream } from "@langchain/langgraph-sdk/react";
-import { type Message, type Assistant, type Checkpoint } from "@langchain/langgraph-sdk";
-import { v4 as uuidv4 } from "uuid";
-import type { UseStream, UseStreamThread } from "@langchain/langgraph-sdk/react";
-import type { TodoItem } from "@/app/types/types";
+import { useStream } from "@langchain/react";
+import { type Assistant } from "@langchain/langgraph-sdk";
+import { BaseMessage, HumanMessage } from "@langchain/core/messages";
+import type { TodoItem, ToolApprovalInterruptData } from "@/app/types/types";
 import { useClient } from "@/providers/ClientProvider";
 import { useQueryState } from "nuqs";
 import {
@@ -29,7 +28,7 @@ function stateFileSignature(value: unknown): string {
 }
 
 export type StateType = {
-  messages: Message[];
+  messages: BaseMessage[];
   todos: TodoItem[];
   files: Record<string, string>;
   email?: {
@@ -37,104 +36,37 @@ export type StateType = {
     subject?: string;
     page_content?: string;
   };
-  ui?: any;
 };
 
 export function useChat({
   activeAssistant,
   onHistoryRevalidate,
-  thread,
 }: {
   activeAssistant: Assistant | null;
   onHistoryRevalidate?: () => void;
-  thread?: UseStreamThread<StateType>;
 }) {
   const [threadId, setThreadId] = useQueryState("threadId");
   const client = useClient();
 
-  // Cast to UseStream so the subagent-tracking surface (subagents,
-  // activeSubagents, getSubagent*) is visible to TypeScript. The runtime
-  // already exposes them, but the default ResolveStreamInterface for a
-  // plain StateType resolves to BaseStream (without those getters).
-  //
-  // `filterSubagentMessages: true` is the switch that actually populates
-  // the SubagentManager: without it, the SDK lets subagent messages flow
-  // into the main `messages` array and never matches subgraph namespaces
-  // to their parent `task` tool call (see ui/manager.js:402, 461). The
-  // option is part of AnyStreamOptions and accepted by useStreamLGP at
-  // runtime even though it isn't on the public UseStreamOptions type.
-  const stream = useStream<StateType>({
+  // The v2 stream runtime handles reattach-to-in-flight-runs and thread
+  // hydration automatically (no reconnectOnMount / fetchStateHistory), and
+  // its root projections are root-namespace-only, so subagent output never
+  // bleeds into `messages` (no filterSubagentMessages). Subagent progress
+  // is exposed via `stream.subagents` + the scoped selector hooks.
+  const stream = useStream<StateType, ToolApprovalInterruptData>({
     assistantId: activeAssistant?.assistant_id || "",
     client: client ?? undefined,
-    reconnectOnMount: true,
-    threadId: threadId ?? null,
+    // Until the assistant resolves, assistantId is "" and hydrating a thread
+    // would throw (ThreadStream requires an assistantId). Hold the thread
+    // back; the assistantId change recreates the controller, which then
+    // hydrates this thread on activate().
+    threadId: activeAssistant ? (threadId ?? null) : null,
     onThreadId: setThreadId,
-    defaultHeaders: { "x-auth-scheme": "langsmith" },
-    // Enable fetching state history when switching to existing threads
-    fetchStateHistory: true,
-    // Revalidate thread list when stream finishes, errors, or creates new thread
-    onFinish: onHistoryRevalidate,
-    onError: onHistoryRevalidate,
-    onCreated: onHistoryRevalidate,
-    experimental_thread: thread,
-    filterSubagentMessages: true,
-  } as any) as unknown as UseStream<StateType>;
-
-  // Hot-streaming detection: at least one running subagent has a pending
-  // tool call (its LLM is streaming tool-call args token-by-token). This is
-  // when `stream.messages` and `stream.subagents` churn at the highest rate
-  // — multiple subagents emitting in parallel can saturate the main thread
-  // and starve user input. While this is true we sample stream state at
-  // 80 ms instead of on every token; the trigger is tool-name agnostic so
-  // it covers any current or future subagent that streams long tool args.
-  let isHotStreaming = false;
-  if (stream.isLoading) {
-    const subagentsMap = (stream as unknown as { subagents?: unknown }).subagents;
-    const iter =
-      subagentsMap && typeof (subagentsMap as { values?: unknown }).values === "function"
-        ? ((subagentsMap as { values: () => Iterable<any> }).values() as Iterable<any>)
-        : null;
-    if (iter) {
-      for (const s of iter) {
-        if (s?.status !== "running" || !Array.isArray(s?.toolCalls)) continue;
-        if (s.toolCalls.some((tc: { state?: string }) => tc?.state === "pending")) {
-          isHotStreaming = true;
-          break;
-        }
-      }
-    }
-  }
-
-  // Throttled snapshot of `stream.messages`. Inside the hot window we sample
-  // the latest array at 80 ms via `setInterval`; outside it we pass through
-  // `stream.messages` directly so non-streaming updates remain instant.
-  // Downstream consumers (e.g. ChatInterface's message-processing useMemo,
-  // and every derived tool-call array) depend on this snapshot, so their
-  // expensive rebuilds run at ~12 fps during the hot window.
-  //
-  // Subtlety: both `stream.messages` and `stream.subagents` are exposed by
-  // the SDK as getters that return a fresh reference on every read. We
-  // therefore CANNOT use them as useEffect deps (an unstable dep + setState
-  // inside the effect = infinite re-render loop). The effect below depends
-  // only on `isHotStreaming` (a derived boolean that flips at most a few
-  // times per run); the ref pulls the latest messages at sample time.
-  const messagesRef = useRef(stream.messages);
-  messagesRef.current = stream.messages;
-  const [throttledMessages, setThrottledMessages] = useState(stream.messages);
-  useEffect(() => {
-    if (!isHotStreaming) return;
-    // Sync immediately on entry so consumers don't see a stale snapshot.
-    setThrottledMessages(messagesRef.current);
-    const id = window.setInterval(() => {
-      setThrottledMessages(messagesRef.current);
-    }, 80);
-    return () => {
-      window.clearInterval(id);
-      // Final flush so the last tokens land instantly when streaming ends.
-      setThrottledMessages(messagesRef.current);
-    };
-  }, [isHotStreaming]);
-  const messagesSnapshot = isHotStreaming ? throttledMessages : stream.messages;
+    // Thread-list freshness: run accepted + run ended (any terminal reason,
+    // including errors and interrupts).
+    onCreated: () => onHistoryRevalidate?.(),
+    onCompleted: () => onHistoryRevalidate?.(),
+  });
 
   // Build the `config` arg for every `stream.submit`. Merges:
   //   - assistant-level config (from the LangGraph API)
@@ -165,52 +97,16 @@ export function useChat({
 
   const sendMessage = useCallback(
     (content: string) => {
-      const newMessage: Message = { id: uuidv4(), type: "human", content };
-      stream.submit(
-        { messages: [newMessage] },
-        {
-          optimisticValues: (prev) => ({
-            messages: [...(prev.messages ?? []), newMessage],
-          }),
-          config: buildSubmitConfig({ recursion_limit: 100 }),
-          // Surface subgraph events (namespaced) so the SDK's SubagentManager
-          // can rebuild per-subagent streams from the `task`-spawned subgraphs.
-          streamSubgraphs: true,
-        }
+      // Optimistic echo is built in: the message renders immediately with a
+      // client-minted id that the server echo reconciles against.
+      void stream.submit(
+        { messages: [new HumanMessage(content)] },
+        { config: buildSubmitConfig({ recursion_limit: 100 }) }
       );
       // Update thread list immediately when sending a message
       onHistoryRevalidate?.();
     },
     [stream, buildSubmitConfig, onHistoryRevalidate]
-  );
-
-  const runSingleStep = useCallback(
-    (
-      messages: Message[],
-      checkpoint?: Checkpoint,
-      isRerunningSubagent?: boolean,
-      optimisticMessages?: Message[]
-    ) => {
-      if (checkpoint) {
-        stream.submit(undefined, {
-          ...(optimisticMessages ? { optimisticValues: { messages: optimisticMessages } } : {}),
-          config: buildSubmitConfig(),
-          checkpoint: checkpoint,
-          streamSubgraphs: true,
-          ...(isRerunningSubagent ? { interruptAfter: ["tools"] } : { interruptBefore: ["tools"] }),
-        });
-      } else {
-        stream.submit(
-          { messages },
-          {
-            config: buildSubmitConfig(),
-            interruptBefore: ["tools"],
-            streamSubgraphs: true,
-          }
-        );
-      }
-    },
-    [stream, buildSubmitConfig]
   );
 
   const graphId = activeAssistant?.graph_id ?? null;
@@ -436,35 +332,11 @@ export function useChat({
     setFocusComposerNonce((n) => n + 1);
   }, []);
 
-  const continueStream = useCallback(
-    (hasTaskToolCall?: boolean) => {
-      stream.submit(undefined, {
-        config: buildSubmitConfig({ recursion_limit: 100 }),
-        streamSubgraphs: true,
-        ...(hasTaskToolCall ? { interruptAfter: ["tools"] } : { interruptBefore: ["tools"] }),
-      });
-      // Update thread list when continuing stream
-      onHistoryRevalidate?.();
-    },
-    [stream, buildSubmitConfig, onHistoryRevalidate]
-  );
-
-  const markCurrentThreadAsResolved = useCallback(() => {
-    stream.submit(null, {
-      command: { goto: "__end__", update: null },
-      streamSubgraphs: true,
-    });
-    // Update thread list when marking thread as resolved
-    onHistoryRevalidate?.();
-  }, [stream, onHistoryRevalidate]);
-
   const resumeInterrupt = useCallback(
-    (value: any) => {
-      stream.submit(null, {
-        command: { resume: value },
-        config: buildSubmitConfig(),
-        streamSubgraphs: true,
-      });
+    (value: unknown) => {
+      // Resumes the newest unresolved interrupt; our HITL flow raises a
+      // single interrupt carrying all action_requests, so no interruptId.
+      void stream.respond(value, { config: buildSubmitConfig() });
       // Update thread list when resuming from interrupt
       onHistoryRevalidate?.();
     },
@@ -472,7 +344,7 @@ export function useChat({
   );
 
   const stopStream = useCallback(() => {
-    stream.stop();
+    void stream.stop();
   }, [stream]);
 
   return {
@@ -480,7 +352,6 @@ export function useChat({
     todos: stream.values.todos ?? [],
     files: filesMap,
     email: stream.values.email,
-    ui: stream.values.ui,
     setFiles,
     refreshFiles,
     removeFile,
@@ -489,24 +360,16 @@ export function useChat({
     setInput,
     appendUploadNote,
     focusComposerNonce,
-    messages: messagesSnapshot,
-    isHotStreaming,
+    messages: stream.messages,
     isLoading: stream.isLoading,
     isThreadLoading: stream.isThreadLoading,
     interrupt: stream.interrupt,
-    getMessagesMetadata: stream.getMessagesMetadata,
     sendMessage,
-    runSingleStep,
-    continueStream,
     stopStream,
-    markCurrentThreadAsResolved,
     resumeInterrupt,
-    // Subagent progress surface from the SDK. Reading these getters is what
-    // adds "updates" + "messages-tuple" to stream_mode (both backend-supported).
+    // Subagent discovery map, keyed by the `task` tool-call id that spawned
+    // each subagent. Content (nested tool calls) is fetched lazily via the
+    // scoped selector hooks (`useToolCalls(stream, snapshot)`).
     subagents: stream.subagents,
-    activeSubagents: stream.activeSubagents,
-    getSubagent: stream.getSubagent,
-    getSubagentsByMessage: stream.getSubagentsByMessage,
-    getSubagentsByType: stream.getSubagentsByType,
   };
 }

--- a/frontend/src/app/utils/sources.ts
+++ b/frontend/src/app/utils/sources.ts
@@ -1,5 +1,5 @@
 import { type BaseMessage, isAIMessage, isToolMessage } from "@langchain/core/messages";
-import type { AssembledToolCall } from "@langchain/langgraph-sdk/stream";
+import type { AssembledToolCall } from "@langchain/react";
 import type { Source } from "@/app/types/types";
 import { extractStringFromMessageContent } from "@/app/utils/utils";
 

--- a/frontend/src/app/utils/sources.ts
+++ b/frontend/src/app/utils/sources.ts
@@ -1,4 +1,5 @@
-import { Message } from "@langchain/langgraph-sdk";
+import { type BaseMessage, isAIMessage, isToolMessage } from "@langchain/core/messages";
+import type { AssembledToolCall } from "@langchain/langgraph-sdk/stream";
 import type { Source } from "@/app/types/types";
 import { extractStringFromMessageContent } from "@/app/utils/utils";
 
@@ -8,7 +9,7 @@ const MARKDOWN_BLOCK = /^##\s+(.+?)\s*\n\*\*URL:\*\*\s+(\S+)/gm;
 
 type ToolCallRef = { name: string };
 
-function parseFromString(raw: string, toolCallId: string): Array<{ title: string; url: string }> {
+function parseFromString(raw: string): Array<{ title: string; url: string }> {
   const trimmed = raw.trim();
   if (!trimmed) return [];
 
@@ -73,26 +74,12 @@ function extractFromJsonShape(data: unknown): Array<{ title: string; url: string
   return out;
 }
 
-export function extractSources(messages: Message[]): Source[] {
+export function extractSources(messages: BaseMessage[]): Source[] {
   const searchToolCalls = new Map<string, ToolCallRef>();
 
   for (const message of messages) {
-    if (message.type !== "ai") continue;
-    const calls: Array<{ id?: string; name?: string }> = [];
-    if (Array.isArray(message.tool_calls)) {
-      calls.push(...message.tool_calls);
-    } else if (Array.isArray(message.additional_kwargs?.tool_calls)) {
-      calls.push(
-        ...(
-          message.additional_kwargs.tool_calls as Array<{
-            id?: string;
-            function?: { name?: string };
-            name?: string;
-          }>
-        ).map((c) => ({ id: c.id, name: c.function?.name ?? c.name }))
-      );
-    }
-    for (const call of calls) {
+    if (!isAIMessage(message)) continue;
+    for (const call of message.tool_calls ?? []) {
       if (!call.id || !call.name) continue;
       if (SEARCH_TOOL_NAMES.has(call.name)) {
         searchToolCalls.set(call.id, { name: call.name });
@@ -104,11 +91,11 @@ export function extractSources(messages: Message[]): Source[] {
   const sources: Source[] = [];
 
   for (const message of messages) {
-    if (message.type !== "tool") continue;
+    if (!isToolMessage(message)) continue;
     const id = message.tool_call_id;
     if (!id || !searchToolCalls.has(id)) continue;
     const raw = extractStringFromMessageContent(message);
-    const parsed = parseFromString(raw, id);
+    const parsed = parseFromString(raw);
     parsed.forEach((entry, idx) => {
       if (seen.has(entry.url)) return;
       seen.add(entry.url);
@@ -117,6 +104,33 @@ export function extractSources(messages: Message[]): Source[] {
         title: entry.title,
         url: entry.url,
         toolCallId: id,
+      });
+    });
+  }
+
+  return sources;
+}
+
+/**
+ * Sources from a scoped tool-call projection (e.g. a subagent's calls via
+ * `useToolCalls(stream, snapshot)`), where outputs arrive already parsed.
+ */
+export function extractSourcesFromToolCalls(toolCalls: AssembledToolCall[]): Source[] {
+  const seen = new Set<string>();
+  const sources: Source[] = [];
+
+  for (const tc of toolCalls) {
+    if (!SEARCH_TOOL_NAMES.has(tc.name) || tc.status !== "finished") continue;
+    const parsed =
+      typeof tc.output === "string" ? parseFromString(tc.output) : extractFromJsonShape(tc.output);
+    parsed.forEach((entry, idx) => {
+      if (seen.has(entry.url)) return;
+      seen.add(entry.url);
+      sources.push({
+        id: `${tc.id}:${idx}`,
+        title: entry.title,
+        url: entry.url,
+        toolCallId: tc.id,
       });
     });
   }

--- a/frontend/src/app/utils/utils.ts
+++ b/frontend/src/app/utils/utils.ts
@@ -43,6 +43,37 @@ export function extractSubAgentContent(data: unknown): string {
   return JSON.stringify(data, null, 2);
 }
 
+/**
+ * Unwrap a ToolMessage-shaped wire envelope to its content. The v2 `tools`
+ * channel's `tool-finished` event carries the full serialized ToolMessage
+ * (`content` + `additional_kwargs`/`response_metadata`/`tool_call_id`/...).
+ * The SDK strips it for `AssembledToolCall.output`, but
+ * `SubagentDiscoverySnapshot.output` is the raw payload — without this,
+ * the whole envelope JSON leaks into the subagent Output panel.
+ */
+export function unwrapToolPayload(value: unknown): unknown {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    const v = value as Record<string, unknown>;
+    if (v.type === "tool" && "content" in v) {
+      const content = v.content;
+      if (typeof content === "string") return content;
+      if (Array.isArray(content)) {
+        return content
+          .map((block) =>
+            typeof block === "string"
+              ? block
+              : block && typeof block === "object" && "text" in block
+                ? String((block as { text?: unknown }).text ?? "")
+                : ""
+          )
+          .join("");
+      }
+      return content;
+    }
+  }
+  return value;
+}
+
 export function toResultString(value: unknown): string | undefined {
   if (value == null) return undefined;
   if (typeof value === "string") return value;

--- a/frontend/src/app/utils/utils.ts
+++ b/frontend/src/app/utils/utils.ts
@@ -1,4 +1,5 @@
-import { Message } from "@langchain/langgraph-sdk";
+import { BaseMessage } from "@langchain/core/messages";
+import { parsePartialJson } from "@langchain/core/output_parsers";
 import { type ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
 
@@ -6,28 +7,9 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
-export function extractStringFromMessageContent(message: Message): string {
-  return typeof message.content === "string"
-    ? message.content
-    : Array.isArray(message.content)
-      ? message.content
-          .filter(
-            (c: unknown) =>
-              (typeof c === "object" &&
-                c !== null &&
-                "type" in c &&
-                (c as { type: string }).type === "text") ||
-              typeof c === "string"
-          )
-          .map((c: unknown) =>
-            typeof c === "string"
-              ? c
-              : typeof c === "object" && c !== null && "text" in c
-                ? (c as { text?: string }).text || ""
-                : ""
-          )
-          .join("")
-      : "";
+export function extractStringFromMessageContent(message: BaseMessage): string {
+  // Core's `.text` accessor joins string content and `{type: "text"}` blocks.
+  return message.text;
 }
 
 export function extractSubAgentContent(data: unknown): string {
@@ -61,95 +43,21 @@ export function extractSubAgentContent(data: unknown): string {
   return JSON.stringify(data, null, 2);
 }
 
-export function isPreparingToCallTaskTool(messages: Message[]): boolean {
-  const lastMessage = messages[messages.length - 1];
-  return (
-    (lastMessage.type === "ai" &&
-      lastMessage.tool_calls?.some((call: { name?: string }) => call.name === "task")) ||
-    false
-  );
+export function toResultString(value: unknown): string | undefined {
+  if (value == null) return undefined;
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
 }
 
-export function formatMessageForLLM(message: Message): string {
-  let role: string;
-  if (message.type === "human") {
-    role = "Human";
-  } else if (message.type === "ai") {
-    role = "Assistant";
-  } else if (message.type === "tool") {
-    role = `Tool Result`;
-  } else {
-    role = message.type || "Unknown";
-  }
-
-  const timestamp = message.id ? ` (${message.id.slice(0, 8)})` : "";
-
-  let contentText = "";
-
-  // Extract content text
-  if (typeof message.content === "string") {
-    contentText = message.content;
-  } else if (Array.isArray(message.content)) {
-    const textParts: string[] = [];
-
-    message.content.forEach((part: any) => {
-      if (typeof part === "string") {
-        textParts.push(part);
-      } else if (part && typeof part === "object" && part.type === "text") {
-        textParts.push(part.text || "");
-      }
-      // Ignore other types like tool_use in content - we handle tool calls separately
-    });
-
-    contentText = textParts.join("\n\n").trim();
-  }
-
-  // For tool messages, include additional tool metadata
-  if (message.type === "tool") {
-    const toolName = (message as any).name || "unknown_tool";
-    const toolCallId = (message as any).tool_call_id || "";
-    role = `Tool Result [${toolName}]`;
-    if (toolCallId) {
-      role += ` (call_id: ${toolCallId.slice(0, 8)})`;
-    }
-  }
-
-  // Handle tool calls from .tool_calls property (for AI messages)
-  const toolCallsText: string[] = [];
-  if (
-    message.type === "ai" &&
-    message.tool_calls &&
-    Array.isArray(message.tool_calls) &&
-    message.tool_calls.length > 0
-  ) {
-    message.tool_calls.forEach((call: any) => {
-      const toolName = call.name || "unknown_tool";
-      const toolArgs = call.args ? JSON.stringify(call.args, null, 2) : "{}";
-      toolCallsText.push(`[Tool Call: ${toolName}]\nArguments: ${toolArgs}`);
-    });
-  }
-
-  // Combine content and tool calls
-  const parts: string[] = [];
-  if (contentText) {
-    parts.push(contentText);
-  }
-  if (toolCallsText.length > 0) {
-    parts.push(...toolCallsText);
-  }
-
-  if (parts.length === 0) {
-    return `${role}${timestamp}: [Empty message]`;
-  }
-
-  if (parts.length === 1) {
-    return `${role}${timestamp}: ${parts[0]}`;
-  }
-
-  return `${role}${timestamp}:\n${parts.join("\n\n")}`;
-}
-
-export function formatConversationForLLM(messages: Message[]): string {
-  const formattedMessages = messages.map(formatMessageForLLM);
-  return formattedMessages.join("\n\n---\n\n");
+/** Best-effort object from a streaming tool_call_chunk args string. */
+export function parsePartialArgs(raw: string | undefined): Record<string, unknown> {
+  if (!raw) return {};
+  const parsed = parsePartialJson(raw);
+  return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+    ? (parsed as Record<string, unknown>)
+    : {};
 }

--- a/frontend/src/providers/ChatProvider.tsx
+++ b/frontend/src/providers/ChatProvider.tsx
@@ -2,23 +2,20 @@
 
 import { ReactNode, createContext, useContext } from "react";
 import { Assistant } from "@langchain/langgraph-sdk";
-import { type StateType, useChat } from "@/app/hooks/useChat";
-import type { UseStreamThread } from "@langchain/langgraph-sdk/react";
+import { useChat } from "@/app/hooks/useChat";
 
 interface ChatProviderProps {
   children: ReactNode;
   activeAssistant: Assistant | null;
   onHistoryRevalidate?: () => void;
-  thread?: UseStreamThread<StateType>;
 }
 
 export function ChatProvider({
   children,
   activeAssistant,
   onHistoryRevalidate,
-  thread,
 }: ChatProviderProps) {
-  const chat = useChat({ activeAssistant, onHistoryRevalidate, thread });
+  const chat = useChat({ activeAssistant, onHistoryRevalidate });
   return <ChatContext.Provider value={chat}>{children}</ChatContext.Provider>;
 }
 

--- a/frontend/src/providers/ClientProvider.tsx
+++ b/frontend/src/providers/ClientProvider.tsx
@@ -23,23 +23,6 @@ export function ClientProvider({ children, deploymentUrl, apiKey }: ClientProvid
         "Content-Type": "application/json",
         "X-Api-Key": apiKey,
       },
-      // langgraph-api 0.8.1 rejects stream_mode "tools"; the JS SDK 1.8.9
-      // auto-tracks it from internal getter access. Strip it on the way out.
-      onRequest: (_url, init) => {
-        if (typeof init.body !== "string") return init;
-        try {
-          const body = JSON.parse(init.body);
-          if (!Array.isArray(body?.stream_mode)) return init;
-          if (!body.stream_mode.includes("tools")) return init;
-          const filtered = body.stream_mode.filter((m: string) => m !== "tools");
-          return {
-            ...init,
-            body: JSON.stringify({ ...body, stream_mode: filtered }),
-          };
-        } catch {
-          return init;
-        }
-      },
     });
   }, [deploymentUrl, apiKey]);
 


### PR DESCRIPTION
# Why

PRD 16 disabled subagent token streaming because the legacy `@langchain/langgraph-sdk/react` `useStream` re-ran an O(n²) per-token `concat` (`MessageTupleManager.add` → `AIMessageChunk.concat`), freezing the browser whenever `resume-tailor` + `interview-coach` streamed large tool-call args in parallel. The new `@langchain/react` package ships a v2-native stream runtime that removes that bottleneck structurally — so this PR migrates the frontend onto it and flips streaming back on.

# What

## Commit 1 — frontend migration (`@langchain/react@1.0.20`)

- **Protocol**: the v2 runtime speaks the agent-server protocol (`POST /threads/{id}/stream/events`), supported by our `langgraph-api 0.9.0`. The legacy `/runs/stream` path and its `stream_mode` body-rewrite workaround in `ClientProvider` are gone.
- **`useChat`**: new `useStream` options (`onCreated`/`onCompleted` for thread-list revalidation; hydration + reattach automatic). Interrupt resume via `respond()`. Messages are now `@langchain/core` `BaseMessage` instances (v1 content blocks). `threadId` is held back until the assistant resolves — hydrating with an empty `assistantId` throws in the v2 runtime (found in browser testing).
- **PRD 05 throttle deleted**: the runtime accumulates content-block fragments in arrays (rope concat per block) and batches store flushes per macrotask, so the O(n²) and its 80 ms render workaround are both gone.
- **Subagent UI**: new `SubagentCard` mounts scoped selector hooks (`useToolCalls` / `useMessages`) keyed on `stream.subagents` discovery snapshots (map key = spawning `task` tool-call id). In-flight tool args render live from `tool_call_chunks` via `parsePartialJson`. `Workspace` gets a per-subagent `SubagentSourcesProbe` for the Sources panel.
- **Dead surface removed** (zero UI consumers, confirmed): `runSingleStep`, `continueStream`, `markCurrentThreadAsResolved`, `getMessagesMetadata`, the GenUI `LoadExternalComponent` path (backend never emits `values.ui`), `experimental_thread`, `uuid` dep.
- **Deps**: direct `@langchain/langgraph-sdk` pinned to `1.9.20` (the exact copy `@langchain/react` uses — one SDK instance, `Client` identity safe), `@langchain/core` → `^1.1.48` per peer ranges.

## Commit 2 — backend flip

- `DISABLE_SUBAGENT_STREAMING: True → False` in `career_agent/middleware.py`; comments rewritten as rollback-lever docs. **No logic changes** — the toggle machinery stays verbatim (module default or per-run `configurable.disable_subagent_streaming`).
- Tests updated: new default asserts pass-through; both rollback paths (module monkeypatch + per-run configurable) and override-with-rollback covered. 13/13 green.
- PRD 16 marked superseded with a status note.

# Verification (agent-browser, real flows)

**Gate A — migrated FE, streaming still disabled (baseline):** full SAP-JD pipeline ran end-to-end; subagent cards per-step; files sidebar, thread switch, hard-reload hydration all good. 2 longtasks total (worst 88 ms), worst input delay 7 ms, 0 page errors. Found + fixed the `assistantId` hydrate race.

**Gate B — streaming enabled, the historical freeze scenario:** state reset (store wipe + UI file deletes), fresh thread, same prompt. During the parallel `resume-tailor` + `interview-coach` phase (both writing large files):

- **Zero longtasks during the parallel window** (8 total across 3 runs in the session, worst **79 ms** — PASS threshold was 1 s; historical failure was a multi-ten-second total freeze)
- Worst input delay **8 ms**; rAF gap ≤ 106 ms; probe evals never stalled; 0 page errors
- Live streaming proven at the wire (**1189 incremental arg deltas in the subagent namespace** via `/stream/events` replay) and in the UI (`overwrite_file`/`write_file`/`edit_file` boxes render Running with growing args inside subagent cards)
- Full artifact set regenerated (tailored resume PDF/YAML, interview prep, battlecard PDF/JSON, research, processed docs)

**Observation (upstream, not blocking):** langgraph-api 0.9.0's v2 bridge emits tool-call args as incremental deltas but narration text arrives whole-per-block (no `text` deltas on the wire) — so main-agent prose appears per-block rather than per-token. Tool args — the payload that caused the freeze — stream fine.

# Rollback

One line: `DISABLE_SUBAGENT_STREAMING = True` (hot-reloads, effective on the next subagent model call), or per-run `configurable.disable_subagent_streaming: true`. The FE handles both cadences transparently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)