### PR TITLE
fix: show full paths in bulk-delete dialog to avoid duplicate react keys

### DIFF
--- a/docs/prd/19_bulk_delete_dialog_full_paths.md
+++ b/docs/prd/19_bulk_delete_dialog_full_paths.md
@@ -8,7 +8,7 @@
 
 ## What the user sees
 
-The `Delete N files?` dialog now lists each selected file by its **full virtual path** (`/tailored_resume/<slug>/<jd-slug>.pdf`), one row per file, wrapping long paths mid-token (`break-all`) inside the existing scrollable list. The 5-row cap with `and N more` is unchanged. The single-file dialog (`Delete file?`) still shows just the basename, exactly as before.
+The `Delete N files?` dialog now lists each selected file by its **full virtual path** (`/tailored_resume/<slug>/<jd-slug>.pdf`), one row per file, in a dialog widened to `sm:max-w-2xl` for the multi-file case. Paths wrap at hyphen boundaries (`break-words`), and the taller list (`max-h-72`) fits all five preview rows without scrolling. The 5-row cap with `and N more` is unchanged. The single-file dialog (`Delete file?`) keeps the compact width and still shows just the basename, exactly as before.
 
 ## How — the key architectural choice
 
@@ -25,7 +25,7 @@ The `Delete N files?` dialog now lists each selected file by its **full virtual 
 
 - **Keys come from `pendingDelete`, never from derived display strings.** The paths are unique by construction (spread from the `selected` `Set`). Any display transform — basename, truncation — can collide, which was exactly the v1 bug. A repo-wide grep confirmed this list was the only basename-keyed render; the file-card grid already keys by path.
 - **Single-file dialog keeps the basename.** PRD 14 promised "single-delete reads exactly as before", and a lone `<span>` can't key-collide. The basename now comes from the existing `splitFilePath` helper instead of an inline `split("/").pop()`.
-- **`break-all` on rows, not a wider dialog.** Virtual paths are long, mono, and hyphen-heavy; mid-token wrapping inside `max-w-md` preserves the `max-h-40 overflow-y-auto` scroll behavior. Widening the dialog for one list wasn't worth diverging from the app's dialog sizing.
+- **Wider fixed dialog + `break-words`, not a user-resizable one.** The first cut kept `max-w-md` and wrapped with `break-all`, which chopped paths mid-token and forced scrolling at three rows — hard to read in exactly the dialog that guards a permanent delete. The bulk branch now widens to `sm:max-w-2xl`; the `sm:` prefix matters, because the shadcn `DialogContent` base carries `sm:max-w-lg` and tailwind-merge only replaces same-variant classes — an unprefixed `max-w-*` override silently loses on desktop (the pre-existing `max-w-md` was in fact rendering at `lg`). Rows wrap at hyphen boundaries via `break-words` (slugs are hyphen-heavy, so lines break legibly; over-long unbroken runs still force-break). Drag-to-resize was considered and rejected: native CSS `resize` fights Radix's `translate(-50%,-50%)` centering — the box re-centers while dragging so the handle drifts away from the cursor — and a clean version needs custom handles, position pinning, and size persistence: a lot of interaction surface for a confirmation glanced at for seconds. Content is bounded anyway (`DELETE_PREVIEW_LIMIT` = 5 rows), so a fixed wider cap fits everything.
 
 ## Deferred (intentional non-goals for v1)
 
@@ -35,5 +35,5 @@ The `Delete N files?` dialog now lists each selected file by its **full virtual 
 
 1. Open a thread whose workspace holds two same-named files in different directories (a battlecard + tailored-resume run produces `<jd-slug>.pdf` in both folders).
 2. Select both (plus others) in Workspace > Files and click `Delete` in the action bar.
-3. The dialog lists full paths — the two same-named files are distinguishable. The browser console (relayed to `docker compose logs frontend` as `[browser]` lines) shows no `Encountered two children with the same key` error, and the dev overlay shows no issue badge.
+3. The dialog lists full paths in the widened box — the two same-named files are distinguishable, all five rows visible without scrolling, lines breaking at hyphens. The browser console (relayed to `docker compose logs frontend` as `[browser]` lines) shows no `Encountered two children with the same key` error, and the dev overlay shows no issue badge.
 4. Cancel → the selection is preserved. The per-card trash icon still opens the single-file dialog showing only the basename.

--- a/docs/prd/19_bulk_delete_dialog_full_paths.md
+++ b/docs/prd/19_bulk_delete_dialog_full_paths.md
@@ -1,0 +1,39 @@
+# PRD: Bulk-Delete Dialog Shows Full Paths (v1)
+
+**Status:** shipped · **Scope:** Workspace > Files panel · **Extends:** [Multi-Select Delete for Workspace Files](14_multi_select_file_delete.md)
+
+## Why
+
+[PRD 14](14_multi_select_file_delete.md) specified the bulk-delete confirmation dialog as "a bulleted list of basenames". That spec hid a collision: the agent routinely writes same-named artifacts into different directories — a battlecard run and a tailored-resume run both emit `<jd-slug>.pdf` under their own folders. Selecting both for deletion rendered two `<li>` rows keyed by the same basename string, and React flagged it (`Encountered two children with the same key…`), surfacing as a `1 Issue` dev-overlay badge ([#13](https://github.com/tam159/next-role/issues/13)). Beyond the warning, non-unique keys let React duplicate or omit rows — and the user saw two identical lines in a permanent-deletion preview with no way to tell which file was which.
+
+## What the user sees
+
+The `Delete N files?` dialog now lists each selected file by its **full virtual path** (`/tailored_resume/<slug>/<jd-slug>.pdf`), one row per file, wrapping long paths mid-token (`break-all`) inside the existing scrollable list. The 5-row cap with `and N more` is unchanged. The single-file dialog (`Delete file?`) still shows just the basename, exactly as before.
+
+## How — the key architectural choice
+
+**Render full paths for every row, keyed by path — not collision-only disambiguation.** Three shapes were considered: (a) key rows by path but keep displaying basenames — fixes the React error yet still shows two identical lines for a destructive action; (b) key by path and show a dimmed directory prefix only on colliding basenames — cleanest list, but needs a collision-counting pass and gives the same list two visual modes; (c) always show full paths. (c) was chosen (explicit user call): in a permanent-deletion preview, ambiguity is worse than noise, the full path is what the file cards' tooltips already show, and the implementation *removes* code (the basename-mapping `pendingNames` memo) instead of adding a counting pass.
+
+## Files of interest
+
+| Concern | Path |
+|---|---|
+| Dialog rows keyed + rendered by full path; `pendingNames` memo → plain `pendingPaths` | `frontend/src/app/components/TasksFilesSidebar.tsx` (`FilesPopover` delete dialog, lines ~270–400) |
+| Basename for the unchanged single-file copy | `frontend/src/app/lib/fileCategories.ts` (`splitFilePath`) |
+
+## Decisions worth remembering
+
+- **Keys come from `pendingDelete`, never from derived display strings.** The paths are unique by construction (spread from the `selected` `Set`). Any display transform — basename, truncation — can collide, which was exactly the v1 bug. A repo-wide grep confirmed this list was the only basename-keyed render; the file-card grid already keys by path.
+- **Single-file dialog keeps the basename.** PRD 14 promised "single-delete reads exactly as before", and a lone `<span>` can't key-collide. The basename now comes from the existing `splitFilePath` helper instead of an inline `split("/").pop()`.
+- **`break-all` on rows, not a wider dialog.** Virtual paths are long, mono, and hyphen-heavy; mid-token wrapping inside `max-w-md` preserves the `max-h-40 overflow-y-auto` scroll behavior. Widening the dialog for one list wasn't worth diverging from the app's dialog sizing.
+
+## Deferred (intentional non-goals for v1)
+
+- **Smart path truncation (middle-ellipsis, common-prefix folding).** Raw paths read fine at current workspace depth (2–3 segments). Revisit if nesting grows or paths start drowning the dialog.
+
+## How to verify end-to-end
+
+1. Open a thread whose workspace holds two same-named files in different directories (a battlecard + tailored-resume run produces `<jd-slug>.pdf` in both folders).
+2. Select both (plus others) in Workspace > Files and click `Delete` in the action bar.
+3. The dialog lists full paths — the two same-named files are distinguishable. The browser console (relayed to `docker compose logs frontend` as `[browser]` lines) shows no `Encountered two children with the same key` error, and the dev overlay shows no issue badge.
+4. Cancel → the selection is preserved. The per-card trash icon still opens the single-file dialog showing only the basename.

--- a/frontend/src/app/components/TasksFilesSidebar.tsx
+++ b/frontend/src/app/components/TasksFilesSidebar.tsx
@@ -271,10 +271,7 @@ export function FilesPopover({
 
   const requestDelete = useCallback((path: string) => setPendingDelete([path]), []);
 
-  const pendingNames = useMemo(
-    () => (pendingDelete ?? []).map((p) => p.split("/").pop() || p),
-    [pendingDelete]
-  );
+  const pendingPaths = pendingDelete ?? [];
 
   return (
     <>
@@ -376,10 +373,12 @@ export function FilesPopover({
           </DialogTitle>
           <DialogDescription asChild>
             <div>
-              {pendingDelete && pendingDelete.length === 1 ? (
+              {pendingPaths.length === 1 ? (
                 <>
-                  <span className="font-mono text-foreground">{pendingNames[0]}</span> will be
-                  permanently removed. This cannot be undone.
+                  <span className="font-mono text-foreground">
+                    {splitFilePath(pendingPaths[0]).basename}
+                  </span>{" "}
+                  will be permanently removed. This cannot be undone.
                 </>
               ) : (
                 <>
@@ -387,13 +386,15 @@ export function FilesPopover({
                     The following files will be permanently removed. This cannot be undone.
                   </span>
                   <ul className="mt-2 max-h-40 list-disc space-y-0.5 overflow-y-auto pl-5 font-mono text-foreground">
-                    {pendingNames.slice(0, DELETE_PREVIEW_LIMIT).map((n) => (
-                      <li key={n}>{n}</li>
+                    {pendingPaths.slice(0, DELETE_PREVIEW_LIMIT).map((p) => (
+                      <li key={p} className="break-all">
+                        {p}
+                      </li>
                     ))}
                   </ul>
-                  {pendingNames.length > DELETE_PREVIEW_LIMIT && (
+                  {pendingPaths.length > DELETE_PREVIEW_LIMIT && (
                     <span className="mt-1 block text-xs text-muted-foreground">
-                      and {pendingNames.length - DELETE_PREVIEW_LIMIT} more
+                      and {pendingPaths.length - DELETE_PREVIEW_LIMIT} more
                     </span>
                   )}
                 </>

--- a/frontend/src/app/components/TasksFilesSidebar.tsx
+++ b/frontend/src/app/components/TasksFilesSidebar.tsx
@@ -365,7 +365,7 @@ export function FilesPopover({
           if (!open && !deleting) setPendingDelete(null);
         }}
       >
-        <DialogContent className="max-w-md">
+        <DialogContent className={pendingPaths.length > 1 ? "sm:max-w-2xl" : "max-w-md"}>
           <DialogTitle>
             {pendingDelete && pendingDelete.length > 1
               ? `Delete ${pendingDelete.length} files?`
@@ -385,9 +385,9 @@ export function FilesPopover({
                   <span>
                     The following files will be permanently removed. This cannot be undone.
                   </span>
-                  <ul className="mt-2 max-h-40 list-disc space-y-0.5 overflow-y-auto pl-5 font-mono text-foreground">
+                  <ul className="mt-2 max-h-72 list-disc space-y-1 overflow-y-auto pl-5 font-mono text-foreground">
                     {pendingPaths.slice(0, DELETE_PREVIEW_LIMIT).map((p) => (
-                      <li key={p} className="break-all">
+                      <li key={p} className="break-words">
                         {p}
                       </li>
                     ))}


### PR DESCRIPTION
## What & why

Closes #13.

Multi-selecting workspace files that share a basename across directories (e.g. `/interview_battlecard/<slug>/<jd>.pdf` + `/tailored_resume/<slug>/<jd>.pdf`) and clicking **Delete** threw a React duplicate-key error — the confirmation dialog keyed its `<li>` rows by basename. Besides the `1 Issue` dev-overlay badge, non-unique keys let React duplicate/omit rows, and the dialog showed two identical lines in a permanent-deletion preview with no way to tell the files apart.

Fix, in two commits:

1. **Key and render each row by the full virtual path.** Paths are unique by construction (spread from the `selected` `Set`), and full paths double as disambiguation. The single-file dialog copy is unchanged (still basename, now via the existing `splitFilePath` helper); the `pendingNames` memo is gone.
2. **Make the paths readable.** The multi-file dialog widens to `sm:max-w-2xl` (the `sm:` prefix matters — the shadcn `DialogContent` base carries `sm:max-w-lg`, and tailwind-merge only replaces same-variant classes, so an unprefixed `max-w-*` silently loses on desktop). Rows wrap at hyphen boundaries (`break-words` instead of mid-token `break-all`), and the `max-h-72` list fits all five preview rows without scrolling. The single-file dialog keeps its compact width. A drag-resizable dialog was considered and rejected — rationale in the PRD.

Documented in `docs/prd/19_bulk_delete_dialog_full_paths.md`, which extends [PRD 14](https://github.com/tam159/next-role/blob/main/docs/prd/14_multi_select_file_delete.md) (its "bulleted list of basenames" spec is superseded).

## Type of change

- [x] 🐛 `fix` — bug fix
- [ ] ✨ `feat` — new feature
- [ ] 📝 `docs` — documentation only
- [ ] ♻️ `refactor` — no behavior change
- [ ] 🧹 `chore` / `test` — tooling, deps, tests

## How was it tested?

Manual repro on the local Docker stack (frontend dev mode, hot reload), driving headless Chrome — once per commit:

1. Selected the exact 5 files from the bug report, including the two colliding `sap-senior-agentic-ai-engineer-jd.pdf` files, and clicked **Delete**.
2. The `Delete 5 files?` dialog lists full paths in the widened box — the two same-named PDFs are distinguishable, all five rows visible without scrolling, lines breaking at hyphens.
3. No `Encountered two children with the same key` in the browser console (relayed `[browser]` lines in `docker compose logs frontend`; relay confirmed active during the session) and no dev-overlay issue badge.
4. **Cancel** keeps the selection (PRD 14 semantics); the per-card trash icon still opens the compact basename-only single-file dialog.

`pre-commit run --all-files` passes (ESLint, Prettier, `tsc`, plus backend hooks).

## Checklist

- [x] PR is focused on a single logical change
- [ ] Added/updated tests for changed behavior (`cd backend && uv run pytest` passes) — N/A: backend untouched; frontend has no unit-test infrastructure
- [x] Ran the quality gate locally (`pre-commit run --all-files`)
- [x] Updated docs (README / `CLAUDE.md` / `docs/prd/`) if behavior changed
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] No secrets or user uploads (CVs/JDs) committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)