### PR TITLE
chore: scope CI workflows by path and add hygiene pipeline

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -1,0 +1,47 @@
+name: CI
+
+# Backend unit tests only run when backend code changes (or a workflow file
+# does). Frontend-only and doc-only changes skip this pipeline entirely.
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "backend/**"
+      - ".github/workflows/**"
+  push:
+    branches: [main]
+    paths:
+      - "backend/**"
+      - ".github/workflows/**"
+
+# Cancel superseded runs on the same ref (e.g. new push to a PR branch).
+concurrency:
+  group: ci-backend-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  # Backend tests: the default suite (unit tests). Integration tests
+  # (`-m integration`) need a live Postgres/Redis stack and run separately.
+  backend-tests:
+    name: backend-tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0 # no moving v8 major tag is published; pin the exact release
+        with:
+          enable-cache: true
+
+      - name: Sync backend
+        run: uv sync
+
+      - name: Run unit tests
+        run: uv run pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,31 +1,43 @@
 name: CI
 
+# Code-quality runs the code linters on any change that isn't purely
+# documentation. Doc-only PRs (Markdown, docs/, LICENSE) skip it — these
+# linters are all scoped to code paths and never touch docs. File hygiene and
+# secret scanning (for every change, docs included) live in the hygiene
+# pipeline instead.
 on:
   pull_request:
     branches: [main]
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - "LICENSE"
   push:
     branches: [main]
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - "LICENSE"
 
 # Cancel superseded runs on the same ref (e.g. new push to a PR branch).
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
+  group: ci-code-quality-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
   contents: read
 
 jobs:
-  # Code quality: the exact same pre-commit gate contributors run locally —
-  # ruff (lint + format), ty (backend types), eslint + prettier + tsc
-  # (frontend), gitleaks, and the file hygiene hooks.
+  # Code quality: the code linters from the pre-commit gate — ruff (lint +
+  # format), ty (backend types), eslint + prettier + tsc (frontend). File
+  # hygiene + gitleaks run in the hygiene pipeline (SKIP-ped here so they don't
+  # run twice on code changes).
   code-quality:
     name: code-quality
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 0 # gitleaks scans full history
 
       - name: Install uv
         uses: astral-sh/setup-uv@v8.1.0 # no moving v8 major tag is published; pin the exact release
@@ -61,27 +73,7 @@ jobs:
       - name: Run pre-commit
         env:
           UV_PROJECT: backend # makes the `uv run ty check` hook resolve backend/ from repo root
+          # File-hygiene hooks + gitleaks run in the hygiene pipeline, not here.
+          # Keep in sync with hygiene.yml — the two SKIP lists partition the hooks.
+          SKIP: trailing-whitespace,end-of-file-fixer,check-yaml,check-added-large-files,gitleaks
         run: uv run pre-commit run --all-files --show-diff-on-failure --color always
-
-  # Backend tests: the default suite (unit tests). Integration tests
-  # (`-m integration`) need a live Postgres/Redis stack and run separately.
-  backend-tests:
-    name: backend-tests
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: backend
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0 # no moving v8 major tag is published; pin the exact release
-        with:
-          enable-cache: true
-
-      - name: Sync backend
-        run: uv sync
-
-      - name: Run unit tests
-        run: uv run pytest

--- a/.github/workflows/hygiene.yml
+++ b/.github/workflows/hygiene.yml
@@ -26,8 +26,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 0 # gitleaks scans full history
 
       - name: Install uv
         uses: astral-sh/setup-uv@v8.1.0 # no moving v8 major tag is published; pin the exact release

--- a/.github/workflows/hygiene.yml
+++ b/.github/workflows/hygiene.yml
@@ -1,0 +1,48 @@
+name: CI
+
+# File hygiene + secret scanning run on EVERY change, docs included — these
+# hooks apply to all file types, so (unlike code-quality) this pipeline is not
+# skipped for doc-only PRs. It stays lightweight: pre-commit runs via uvx with
+# no backend/frontend toolchain install; the code linters are SKIP-ped here and
+# run in the code-quality pipeline instead.
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+# Cancel superseded runs on the same ref (e.g. new push to a PR branch).
+concurrency:
+  group: ci-hygiene-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  hygiene:
+    name: hygiene
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # gitleaks scans full history
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0 # no moving v8 major tag is published; pin the exact release
+        with:
+          enable-cache: true
+
+      - name: Cache pre-commit hook environments
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-hygiene-${{ hashFiles('.pre-commit-config.yaml') }}
+
+      - name: Run file-hygiene hooks
+        env:
+          # Code linters run in the code-quality pipeline, not here. Keep this in
+          # sync with the SKIP list in ci.yml — the two partition the hook set.
+          SKIP: ruff-check,ruff-format,backend-typecheck,frontend-lint,frontend-format,frontend-typecheck,frontend-langchain-sdk-sync
+        run: uvx pre-commit run --all-files --show-diff-on-failure --color always


### PR DESCRIPTION
## Problem

Every push/PR ran the full CI workflow, so doc-only changes (e.g. a README edit) triggered `code-quality` and `backend-tests` even though neither validates Markdown.

## Change

Split CI into three path-scoped pipelines (all still reported as `CI / <job>`):

| Workflow | Job | Triggers on |
|---|---|---|
| `hygiene.yml` (new) | `hygiene` | everything, incl. docs |
| `ci.yml` | `code-quality` | non-docs (`paths-ignore`) |
| `backend-tests.yml` | `backend-tests` | `backend/**`, workflows |

`hygiene` runs the file-hygiene hooks + gitleaks via `uvx pre-commit` with no backend/frontend toolchain install. `code-quality` keeps the code linters. The 12 pre-commit hooks are partitioned across the two `SKIP` lists, so no hook runs twice (and `code-quality` no longer needs `fetch-depth: 0`).

## Result

| Change | hygiene | code-quality | backend-tests |
|---|:---:|:---:|:---:|
| README / `docs/**` / `LICENSE` | ✓ | — | — |
| frontend only | ✓ | ✓ | — |
| backend code | ✓ | ✓ | ✓ |
| any workflow file | ✓ | ✓ | ✓ |

Doc-only changes now run only the lightweight hygiene check; whitespace / EOF / secret scanning is still enforced everywhere.

## Notes

- No required status checks exist today, so skipped pipelines don't block merges. With native `paths` filters a non-matching workflow reports **no** check (not a skipped one) — worth knowing if branch protection is added later.
- The three workflows share `name: CI` to keep check names stable, so the Actions tab lists three "CI" entries.
- The two `SKIP` lists must stay partitioned; cross-referencing comments are in both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
