### PR TITLE
chore: gate required CI checks with job-level conditionals

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -1,18 +1,17 @@
 name: CI
 
-# Backend unit tests only run when backend code changes (or a workflow file
-# does). Frontend-only and doc-only changes skip this pipeline entirely.
+# Backend unit tests run only when backend code (or a workflow file) changes.
+# The workflow ALWAYS triggers so the required `backend-tests` check is always
+# reported; the expensive job is gated by a job-level `if:`. A job skipped by a
+# conditional reports "Success" and satisfies the required check, whereas a
+# workflow-level `paths:` skip leaves the check stuck in "Expected" and blocks
+# the merge:
+# https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks
 on:
   pull_request:
     branches: [main]
-    paths:
-      - "backend/**"
-      - ".github/workflows/**"
   push:
     branches: [main]
-    paths:
-      - "backend/**"
-      - ".github/workflows/**"
 
 # Cancel superseded runs on the same ref (e.g. new push to a PR branch).
 concurrency:
@@ -23,10 +22,32 @@ permissions:
   contents: read
 
 jobs:
+  # Cheap gate (~10s) deciding whether the backend suite needs to run. Its own
+  # check (`detect-backend`) is not required; it only feeds the `if:` below.
+  detect-backend:
+    runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Detect backend changes
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        with:
+          filters: |
+            backend:
+              - "backend/**"
+              - ".github/workflows/**"
+
   # Backend tests: the default suite (unit tests). Integration tests
   # (`-m integration`) need a live Postgres/Redis stack and run separately.
+  # Skipped (→ reports success) on frontend-only and doc-only changes.
   backend-tests:
     name: backend-tests
+    needs: detect-backend
+    if: needs.detect-backend.outputs.backend == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,23 +1,16 @@
 name: CI
 
 # Code-quality runs the code linters on any change that isn't purely
-# documentation. Doc-only PRs (Markdown, docs/, LICENSE) skip it — these
-# linters are all scoped to code paths and never touch docs. File hygiene and
-# secret scanning (for every change, docs included) live in the hygiene
-# pipeline instead.
+# documentation. The workflow ALWAYS triggers so the required `code-quality`
+# check is always reported; a job-level `if:` skips the linters (→ reports
+# success) for doc-only PRs. A workflow-level `paths-ignore:` skip would instead
+# leave the required check stuck in "Expected" and block the merge:
+# https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks
 on:
   pull_request:
     branches: [main]
-    paths-ignore:
-      - "**/*.md"
-      - "docs/**"
-      - "LICENSE"
   push:
     branches: [main]
-    paths-ignore:
-      - "**/*.md"
-      - "docs/**"
-      - "LICENSE"
 
 # Cancel superseded runs on the same ref (e.g. new push to a PR branch).
 concurrency:
@@ -28,12 +21,38 @@ permissions:
   contents: read
 
 jobs:
+  # Cheap gate (~10s): is there any non-doc change? `predicate-quantifier: every`
+  # makes a file count only when it matches ALL patterns, so `code` is true
+  # unless every changed file is Markdown / under docs/ / LICENSE. Its own check
+  # (`detect-code`) is not required; it only feeds the `if:` below.
+  detect-code:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Detect non-doc changes
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        with:
+          predicate-quantifier: "every"
+          filters: |
+            code:
+              - "**"
+              - "!**/*.md"
+              - "!docs/**"
+              - "!LICENSE"
+
   # Code quality: the code linters from the pre-commit gate — ruff (lint +
   # format), ty (backend types), eslint + prettier + tsc (frontend). File
   # hygiene + gitleaks run in the hygiene pipeline (SKIP-ped here so they don't
-  # run twice on code changes).
+  # run twice on code changes). Skipped (→ reports success) on doc-only PRs.
   code-quality:
     name: code-quality
+    needs: detect-code
+    if: needs.detect-code.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Problem

Required status checks that are path-filtered at the workflow `on:` level get stuck. When a frontend-only PR (e.g. #31) doesn't touch `backend/**`, the whole `backend-tests` workflow is skipped, so GitHub never reports a `backend-tests` status — it sits at **"Expected — Waiting for status to be reported"** and blocks the merge forever.

Per [GitHub's docs](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks):

> If a workflow is skipped due to path filtering, branch filtering or a commit message, then checks associated with that workflow will remain in a "Pending" state… if a job within a workflow is skipped due to a conditional, it will report its status as "Success". **You should not use path or branch filtering to skip workflow runs if the workflow is required… Instead, use job-level conditionals.**

`code-quality` (in `ci.yml`) has the same latent bug for **docs-only** PRs (it filters with `paths-ignore: ["**/*.md", "docs/**", "LICENSE"]`).

## Fix

Move the filtering from the workflow trigger into a job-level `if:`. Each workflow now **always triggers** and gates its expensive job behind a cheap `dorny/paths-filter` detect job (~10s). When there's nothing to do, the required job is skipped → reports **success** → satisfies the required check.

- **`backend-tests`** runs only when `backend/**` or `.github/workflows/**` change.
- **`code-quality`** runs unless *every* changed file is docs (`md` / `docs/` / `LICENSE`), using `predicate-quantifier: every` (under the default `some`, a broad `**` positive would still match docs files).

The required context names (`backend-tests`, `code-quality`) are unchanged, so **no branch-protection edits are needed**. `hygiene` already runs unconditionally.

| PR touches | detect-backend | backend-tests | detect-code | code-quality | hygiene |
|---|---|---|---|---|---|
| backend | true | ✅ runs | true | ✅ runs | ✅ runs |
| frontend only | false | ⏭️ skip → success | true | ✅ runs | ✅ runs |
| docs only | false | ⏭️ skip → success | false | ⏭️ skip → success | ✅ runs |

## Notes

- `dorny/paths-filter` is SHA-pinned to `v4.0.1` (`fbd0ab8`); repo Actions policy is `allowed_actions: all`.
- This PR touches `.github/workflows/**`, so `backend-tests` runs **for real** here and self-validates the change.
- Unblocks #31: after this lands, **Update branch** on #31 and `backend-tests` will auto-skip-to-success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)