### PR TITLE
test: add comprehensive frontend test suite with required CI check

### DIFF
--- a/.claude/skills/upgrade-frontend-deps/SKILL.md
+++ b/.claude/skills/upgrade-frontend-deps/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: upgrade-frontend-deps
-description: Upgrade the Next.js frontend's pnpm dependencies to their latest versions in verified waves. Inventories with `pnpm outdated`, removes verified-unused deps, batches safe minor/patch bumps, handles the @langchain/react + langgraph-sdk lockstep pair, takes majors one commit at a time with registry peer-dep checks, gates every wave on type-check + lint + build + an agent-browser check against baseline screenshots, then dedupes, audits for duplicate versions, and opens a PR. Use when the user says "upgrade frontend libs", "bump frontend deps", "update npm/pnpm packages", or `pnpm outdated` shows a backlog. Backend deps are a separate flow (`upgrade-backend-deps`).
+description: Upgrade the Next.js frontend's pnpm dependencies to their latest versions in verified waves. Inventories with `pnpm outdated`, removes verified-unused deps, batches safe minor/patch bumps, handles the @langchain/react + langgraph-sdk lockstep pair, takes majors one commit at a time with registry peer-dep checks, gates every wave on type-check + lint + unit tests + build + an agent-browser check against baseline screenshots, then dedupes, audits for duplicate versions, and opens a PR. Use when the user says "upgrade frontend libs", "bump frontend deps", "update npm/pnpm packages", or `pnpm outdated` shows a backlog. Backend deps are a separate flow (`upgrade-backend-deps`).
 ---
 
 Upgrade the frontend's pnpm dependencies in revertable waves, preserving exact-pin style and the single-resolved-version invariant, with browser verification against a pre-upgrade baseline.
@@ -12,6 +12,7 @@ Upgrade the frontend's pnpm dependencies in revertable waves, preserving exact-p
 - **One commit per wave** (majors: one per package) so any regression reverts surgically.
 - **Lockfile changes need `docker compose restart frontend`; source edits hot-reload.** Never restart for source-only changes; never skip the restart after `pnpm add/remove`.
 - **`@types/node` tracks the Docker runtime**, not npm `latest`. Read the major from `frontend/Dockerfile`'s `FROM node:XX-alpine` and stay on `@types/node@^XX`. Document it under "Held back".
+- **`vitest` + `@vitest/coverage-v8` are an exact-version lockstep pair** (coverage is an exact peer of the runner) — bump both together in one command; a split pair breaks `pnpm test:coverage`.
 
 ## Workflow
 
@@ -34,7 +35,7 @@ Gate examples that have mattered: typescript-eslint's `typescript: <X` upper bou
 ```bash
 git switch -c chore/upgrade-frontend-deps
 cd frontend && pnpm install --frozen-lockfile   # host node_modules current (pre-commit hooks need it)
-pnpm type-check && pnpm lint && pnpm build      # "Gate G" — must be green BEFORE touching anything
+pnpm type-check && pnpm lint && pnpm test && pnpm build   # "Gate G" — must be green BEFORE touching anything
 ```
 
 Record the current lint warning count — you'll need to distinguish pre-existing warnings from upgrade fallout later.
@@ -110,7 +111,7 @@ Full visual checklist vs baseline (light + dark, dialogs, selects, hover, print 
 pnpm --dir frontend dedupe
 pnpm --dir frontend run check:sdk-sync          # dedupe must not split the SDK copy
 pnpm --dir frontend outdated                    # expect: empty, or only documented hold-backs
-cd frontend && pnpm quality && pnpm build
+cd frontend && pnpm quality && pnpm test && pnpm build
 docker compose restart frontend
 pnpm --dir frontend why clsx react react-dom @langchain/langgraph-sdk   # one version each
 ```

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,7 +24,7 @@ See CONTRIBUTING.md for the full workflow.
 ## Checklist
 
 - [ ] PR is focused on a single logical change
-- [ ] Added/updated tests for changed behavior (`cd backend && uv run pytest` passes)
+- [ ] Added/updated tests for changed behavior (backend: `cd backend && uv run pytest`; frontend: `cd frontend && pnpm test`)
 - [ ] Ran the quality gate locally (`pre-commit run --all-files`)
 - [ ] Updated docs (README / `CLAUDE.md` / `docs/prd/`) if behavior changed
 - [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -1,0 +1,74 @@
+name: CI
+
+# Frontend unit tests run only when frontend code (or a workflow file) changes.
+# The workflow ALWAYS triggers so the required `frontend-tests` check is always
+# reported; the expensive job is gated by a job-level `if:`. A job skipped by a
+# conditional reports "Success" and satisfies the required check, whereas a
+# workflow-level `paths:` skip leaves the check stuck in "Expected" and blocks
+# the merge:
+# https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+# Cancel superseded runs on the same ref (e.g. new push to a PR branch).
+concurrency:
+  group: ci-frontend-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  # Cheap gate (~10s) deciding whether the frontend suite needs to run. Its own
+  # check (`detect-frontend`) is not required; it only feeds the `if:` below.
+  detect-frontend:
+    runs-on: ubuntu-latest
+    outputs:
+      frontend: ${{ steps.filter.outputs.frontend }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Detect frontend changes
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        with:
+          filters: |
+            frontend:
+              - "frontend/**"
+              - ".github/workflows/**"
+
+  # Frontend tests: the Vitest unit + component suite (node + jsdom projects).
+  # Skipped (→ reports success) on backend-only and doc-only changes.
+  frontend-tests:
+    name: frontend-tests
+    needs: detect-frontend
+    if: needs.detect-frontend.outputs.frontend == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          package_json_file: frontend/package.json
+
+      - name: Install Node
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: frontend/.nvmrc
+          cache: pnpm
+          cache-dependency-path: frontend/pnpm-lock.yaml
+
+      - name: Install frontend deps
+        run: pnpm install --frozen-lockfile
+
+      - name: Run unit tests
+        run: pnpm test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,9 +68,10 @@ Stack-specific tooling lives in the per-app guides — read these before diving 
 4. **Run the quality gate locally** before pushing (see below) — this is exactly what CI enforces.
 5. **Push** to your fork and **open a PR** against `tam159/next-role:main`. Fill in the PR template
    so reviewers have context.
-6. **CI must pass.** Every PR runs two required checks:
+6. **CI must pass.** Every PR runs three required checks:
    - `code-quality` — the full pre-commit gate (ruff, ty, eslint, prettier, gitleaks, file hygiene).
    - `backend-tests` — the default backend unit-test suite.
+   - `frontend-tests` — the frontend Vitest unit + component suite.
 7. Address review feedback by pushing more commits to the same branch. Squash/cleanup happens at
    merge time, so don't worry about a messy intermediate history.
 
@@ -92,14 +93,24 @@ And run the backend tests (matches the CI `backend-tests` job):
 cd backend && uv run pytest
 ```
 
+And the frontend tests (matches the CI `frontend-tests` job):
+
+```bash
+cd frontend && pnpm test
+```
+
 If a hook auto-fixes a file (ruff format, prettier, end-of-file fixer), re-stage the change and
 commit again.
 
 ## Testing
 
-We currently run **unit tests + integration tests against a local DB**; LLM evals are deferred. Full
-details (layout, markers, async mode) are in [`backend/CLAUDE.md`](backend/CLAUDE.md#testing). The
-essentials:
+Both apps have unit-test suites that run as required CI checks; the backend adds local-DB
+integration tests, and LLM evals are deferred.
+
+### Backend (pytest)
+
+Full details (layout, markers, async mode) are in [`backend/CLAUDE.md`](backend/CLAUDE.md#testing).
+The essentials:
 
 - Tests mirror the source tree: `app/<pkg>/<module>.py` → `tests/<pkg>/test_<module>.py`.
 - **Add/update unit tests by default** when you change code. Mock external dependencies; never
@@ -114,6 +125,25 @@ cd backend
 uv run pytest                              # default: fast unit tests (what CI runs)
 uv run pytest tests/career_agent/test_tools.py   # a single file
 uv run pytest -m integration               # integration tests (needs the local stack up)
+```
+
+### Frontend (Vitest)
+
+Full details (environments, mocking conventions) are in
+[`frontend/CLAUDE.md`](frontend/CLAUDE.md#testing). The essentials:
+
+- Tests are **colocated**: `src/**/<module>.test.ts(x)` sits next to the file it covers.
+- The file extension picks the environment: `.test.ts` runs in node (pure modules, API route
+  handlers), `.test.tsx` runs in jsdom (anything that renders or touches `window`).
+- **Add/update unit tests by default** when you change code. Mock the LangGraph SDK/stream and
+  `fetch` — tests never hit the network.
+
+```bash
+cd frontend
+pnpm test                                  # full suite (what CI runs)
+pnpm test:watch                            # watch mode
+pnpm exec vitest run src/lib/config.test.ts   # a single file
+pnpm test:coverage                         # v8 coverage report
 ```
 
 ## Coding conventions

--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ Set `LANGCHAIN_API_KEY` and `LANGCHAIN_TRACING_V2=true` in `.env`, and every run
 
 ## Contributing
 
-PRs and issues are welcome! Start with **[`CONTRIBUTING.md`](CONTRIBUTING.md)** — it walks through the fork → PR workflow, local setup, the CI quality gate (pre-commit + backend tests), testing, and conventions. Stack-specific details live in [`backend/CLAUDE.md`](backend/CLAUDE.md) and [`frontend/CLAUDE.md`](frontend/CLAUDE.md); commits follow [Conventional Commits](https://www.conventionalcommits.org/).
+PRs and issues are welcome! Start with **[`CONTRIBUTING.md`](CONTRIBUTING.md)** — it walks through the fork → PR workflow, local setup, the CI quality gate (pre-commit + backend tests + frontend tests), testing, and conventions. Stack-specific details live in [`backend/CLAUDE.md`](backend/CLAUDE.md) and [`frontend/CLAUDE.md`](frontend/CLAUDE.md); commits follow [Conventional Commits](https://www.conventionalcommits.org/).
 
 New here? Issues labelled [`good first issue`](https://github.com/tam159/next-role/labels/good%20first%20issue) are a gentle place to start, and questions are welcome in [Discussions](https://github.com/tam159/next-role/discussions).
 

--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ Set `LANGCHAIN_API_KEY` and `LANGCHAIN_TRACING_V2=true` in `.env`, and every run
 
 ## Contributing
 
-PRs and issues are welcome! Start with **[`CONTRIBUTING.md`](CONTRIBUTING.md)** — it walks through the fork → PR workflow, local setup, the CI quality gate (pre-commit + backend tests + frontend tests), testing, and conventions. Stack-specific details live in [`backend/CLAUDE.md`](backend/CLAUDE.md) and [`frontend/CLAUDE.md`](frontend/CLAUDE.md); commits follow [Conventional Commits](https://www.conventionalcommits.org/).
+PRs and issues are welcome! Start with **[`CONTRIBUTING.md`](CONTRIBUTING.md)** — it walks through the fork → PR workflow, local setup, the CI quality gate (code quality + backend tests + frontend tests), testing, and conventions. Stack-specific details live in [`backend/CLAUDE.md`](backend/CLAUDE.md) and [`frontend/CLAUDE.md`](frontend/CLAUDE.md); commits follow [Conventional Commits](https://www.conventionalcommits.org/).
 
 New here? Issues labelled [`good first issue`](https://github.com/tam159/next-role/labels/good%20first%20issue) are a gentle place to start, and questions are welcome in [Discussions](https://github.com/tam159/next-role/discussions).
 

--- a/docs/prd/22_frontend_test_suite.md
+++ b/docs/prd/22_frontend_test_suite.md
@@ -1,0 +1,59 @@
+# PRD: Frontend Test Suite + Required CI Check (v1)
+
+**Status:** shipped · **Scope:** frontend + CI + `upgrade-frontend-deps` skill
+
+## Why
+
+The backend has had pytest and a required `backend-tests` check since early on; the frontend had literally zero test infrastructure — no runner, no `test` script. Every frontend change (including the dependency-upgrade waves the `upgrade-frontend-deps` skill automates) was verified only by type-check + lint + build + manual browser checks, which catch API drift but not behavior regressions in the parsing/routing logic the app has accumulated (source extraction, tool-error parsing, agent-file routing, path-traversal guards). This ships a 367-test Vitest suite, wires it in as a third required CI check, and adds tests to the skill's per-wave gate ("Gate G").
+
+## What the user sees
+
+Developer-facing only. `pnpm test` / `test:watch` / `test:coverage` in `frontend/`; test files colocated next to their source (`foo.test.ts(x)`); a `frontend-tests` check on every PR that **skip-passes on backend-only and docs-only changes**. The PR template's test checklist now names both stacks, and testing docs live in `frontend/CLAUDE.md#testing` (conventions), `CONTRIBUTING.md#testing` (workflow), and `frontend/README.md`. Deliberately absent: tests do **not** run in pre-commit (matches the backend convention — tests are CI's job, hooks stay fast) and there is no coverage threshold gate.
+
+## How — the key architectural choices
+
+**Vitest 4, not Jest.** The app depends on ESM-only packages (`react-markdown@10`, `remark-gfm@4`, deep-ESM `react-syntax-highlighter` imports) and is itself `"type": "module"`; Jest would need `transformIgnorePatterns` surgery and ESM flags. Vitest handles ESM natively, and the repo already ships Vitest 4 in `backend/server/api/js`.
+
+**Two projects split by file extension.** `.test.ts` runs in node (pure modules, route handlers); `.test.tsx` runs in jsdom (rendering, browser APIs) with a shared setup file (jest-dom + Radix polyfills). Vitest 4 removed `environmentMatchGlobs`, so `test.projects` is the supported mechanism — and the extension-as-switch means no per-file `@vitest-environment` docblocks. A `.tsx` test without JSX is fine when jsdom is needed.
+
+**Real temp-dir sandbox for the `/api/files/*` handlers, not fs mocks.** `_lib.ts` computes `REPO_ROOT` from `process.cwd()` **at import time**, so tests spy on `process.cwd()`, mock `@/app/config/agentFiles` with a fixture, and only then dynamically `await import("./route")`. Real filesystem resolution keeps the security assertions honest — the traversal/sibling-prefix cases test what `path.resolve` actually does, not what a mock was told to do.
+
+**Required check via detect-job + job-level `if`.** `frontend-tests.yml` clones `backend-tests.yml`'s shape (paths-filter detect job feeding a job `if:`) — never `on:`-level path filtering, which leaves a required check stuck "Expected" (see PRD-less lesson recorded in the workflow headers and `.claude` memory from PR #32).
+
+## Files of interest
+
+| Concern | Path |
+|---|---|
+| Runner config (projects split, alias, coverage) | `frontend/vitest.config.ts` |
+| jsdom polyfills + jest-dom | `frontend/vitest.setup.ts` |
+| Sandbox pattern anchor (traversal guards) | `frontend/src/app/api/files/_lib.test.ts` |
+| Heaviest mock surface (`useStream`, file CRUD matrix) | `frontend/src/app/hooks/useChat.test.tsx` |
+| Extracted-for-testing parsers | `frontend/src/app/utils/toolErrors.ts`, `frontend/src/app/print/file/printPayload.ts` |
+| Required check workflow | `.github/workflows/frontend-tests.yml` |
+| Gate G now includes `pnpm test` | `.claude/skills/upgrade-frontend-deps/SKILL.md` (§2, §8) |
+
+## Decisions worth remembering
+
+- **Colocated tests, not a `tests/` mirror tree.** Deliberate divergence from the backend's convention (user's call): it's the frontend-ecosystem norm, imports stay short, and the filename extension doubles as the environment switch. The Next.js build ignores colocated non-route files, verified via `pnpm build`.
+- **`globals: true`.** RTL's auto-cleanup only activates when a global `afterEach` exists; globals give it for free and jest-dom extends the global `expect` via one setup import. Cost is one tsconfig `types` entry (`vitest/globals`).
+- **Testability refactor kept to three moves.** `parseToolError`/`previewValue` out of `ToolCallBox`, print-payload parsing out of the print route page (which also stopped `FileViewDialog` importing from a route module), and an exported `formatTime`. Everything else embedded in components is covered through rendered output — no export-for-tests sprawl.
+- **`vitest` ↔ `@vitest/coverage-v8` are an exact-version lockstep pair** (coverage is an exact peer of the runner) — same failure shape as the `@langchain/react`/SDK pair; recorded as an `upgrade-frontend-deps` ground rule so `pnpm update` doesn't split them.
+- **The new workflow reads Node from `frontend/.nvmrc` (24)** instead of hardcoding; `ci.yml` still pins 22 — left alone deliberately to keep the PR reviewable (follow-up chore).
+- **Never enable global `restoreMocks`** — it silently undoes `beforeAll` spies (the sandbox's `process.cwd` spy) after the first test.
+- **Tests follow code, not the plan.** Writing them surfaced real quirks, asserted as-is rather than "fixed": an unreachable state-routing branch in `useChat.setFiles`, two distinct `useThreads` fallback titles (`Untitled Thread` vs `Thread <id8>`), delete's `EISDIR` branch being Linux-only (darwin throws `EPERM`, so it's covered via a mocked `unlink`), and the composer attach button being dead code behind `COMPOSER_ATTACH_ENABLED = false`.
+
+## Deferred (intentional non-goals for v1)
+
+- **Playwright/browser E2E.** The `agent-browser` skill already covers visual + full-flow verification (and the upgrade skill's baseline-screenshot workflow); a second browser harness isn't worth the CI weight until component tests prove insufficient.
+- **Coverage thresholds.** `pnpm test:coverage` reports (text + html); gating on a number invites threshold-gaming before the suite's shape has settled.
+- **A `frontend-build` CI job.** CI still never runs `next build`; kept out of `frontend-tests` to keep the required check fast (~35s). Revisit if a build-only breakage ever slips through.
+- **`page.tsx` / `layout.tsx` tests.** Whole-app integration (and `next/font` mocking) for near-zero logic — agent-browser territory.
+- **Minor skipped branches** — clipboard copy (no `navigator.clipboard` in jsdom), shift-range file selection, docx error states.
+
+## How to verify end-to-end
+
+1. `cd frontend && pnpm test` — 33 files / 367 tests green in ~2s, reporter shows both `node` and `jsdom` project labels.
+2. `pnpm test:coverage` — report renders; `coverage/` stays untracked (gitignored) and unlinted.
+3. `pnpm type-check && pnpm lint && pnpm build` — clean; build's route list contains no `.test.` entries.
+4. Open a PR touching only `frontend/**` — `frontend-tests` executes; `backend-tests` reports success via skip. A docs-only PR shows `frontend-tests` success-via-skip (not stuck "Expected").
+5. Post-merge: `gh api repos/tam159/next-role/branches/main/protection/required_status_checks/contexts` lists `code-quality`, `backend-tests`, `frontend-tests`.

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -19,6 +19,41 @@ Tokens live in `src/app/globals.css` (CSS variables: app `--color-*`/`--brand-ac
 - **All-in-one**: `pnpm quality` runs lint + format + type-check.
 - **Adding a dependency**: `pnpm --dir frontend add <pkg>` on the host, then `docker compose restart frontend`. The container's startup runs `pnpm install --frozen-lockfile` (see `docker-compose.yml`), so the lockfile change syncs into the container's `node_modules` volume on next boot — no image rebuild, no volume nuking.
 
+## Testing
+
+Vitest 4 + React Testing Library. Tests are **colocated** (`<module>.test.ts(x)` next to its
+source) and run in CI's required `frontend-tests` check — deliberately not in pre-commit.
+
+- **Run**: `pnpm test` (full suite), `pnpm test:watch`, `pnpm test:coverage` (v8),
+  `pnpm exec vitest run <path>` (one file).
+- **Environment by extension** (`vitest.config.ts` projects): `.test.ts` → node (pure modules,
+  API route handlers, fetch wrappers); `.test.tsx` → jsdom (anything that renders or touches
+  `window`/storage — a `.tsx` test without JSX is fine when jsdom is needed).
+- **Globals are on** (`describe`/`it`/`expect`/`vi` need no imports; tsconfig has
+  `vitest/globals`); RTL auto-cleanup is active.
+- **`vitest.setup.ts` owns the jsdom polyfills** (ResizeObserver, matchMedia, pointer capture,
+  scrollIntoView/scrollTo, PointerEvent) plus jest-dom matchers. Extend it rather than shimming
+  per-test.
+- **Mocking conventions** — never hit the network or the real backend:
+  - `@langchain/react`: `vi.mock` with the `importOriginal` spread, stubbing only `useStream` /
+    the scoped selector hooks the component uses.
+  - SDK `Client`: mock the class where it's constructed (`ClientProvider`, `useThreads`).
+    `app/lib/agentFiles.ts` receives the client as a parameter (type-only import) — pass a plain
+    stub object, no module mock.
+  - `nuqs`: `NuqsTestingAdapter` for components, `vi.mock("nuqs")` for hooks. `swr`: never mock —
+    wrap in a fresh-cache `<SWRConfig value={{ provider: () => new Map() }}>`. `fetch`:
+    `vi.stubGlobal("fetch", ...)` + `vi.unstubAllGlobals()` in afterEach. `sonner`: mock `toast`.
+- **Import-time state**: `src/lib/config.ts` reads env vars and `src/app/api/files/_lib.ts`
+  computes `REPO_ROOT` from `process.cwd()` at module load — stub first (`vi.stubEnv` /
+  `vi.spyOn(process, "cwd")`), then dynamically `await import(...)`. Never enable global
+  `restoreMocks` (it silently kills `beforeAll` spies).
+- **Route-handler tests** use a real temp-dir sandbox, not fs mocks: mock
+  `@/app/config/agentFiles` with a fixture config, point `process.cwd()` at `<tmp>/frontend`,
+  create fixtures with `node:fs`, then dynamically import the route
+  (see `src/app/api/files/*/route.test.ts`).
+- **Upgrade rule**: `vitest` + `@vitest/coverage-v8` are an exact-version lockstep pair — bump
+  together (see the `upgrade-frontend-deps` skill).
+
 ## Style
 
 - **Line length: 100** (Prettier `printWidth`). Matches the backend; keep them in sync.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,88 @@
+# NextRole Frontend
+
+The chat + live-workspace UI for NextRole's multi-agent backend: **Next.js 16 (App Router, Turbopack) · React 19 · TypeScript · Tailwind 4**, streaming from LangGraph via `@langchain/react`.
+
+<img alt="NextRole UI — chat on the left, live artifact workspace on the right" src="../docs/images/next-role-hero-image.png" width="100%">
+
+## What it does
+
+- 💬 **Streaming chat** with the career agent — token streaming, tool-call boxes with live arg previews, and nested **subagent activity cards** (`ChatInterface`, `ToolCallBox`, `SubagentCard`).
+- 🗂️ **Live workspace** beside the chat — the agent's plan (todos), produced artifacts, and research sources update as the run progresses (`Workspace`, `workspace/*`, `TasksFilesSidebar`).
+- ✋ **Human-in-the-loop approvals** — when the agent pauses on a protected tool call, approve / edit / reject inline (`ToolApprovalInterrupt`).
+- 📄 **File preview & editing** — markdown, code, images, and `.docx` (via `mammoth`) in a dialog with edit-and-save, plus a dedicated **print-to-PDF** route (`FileViewDialog`, `/print/file`).
+- 🔗 **File-linkified markdown** — agent replies mentioning `/processed/cv.md` become clickable links straight into the preview (`MarkdownContent` + the `remarkFilePaths` plugin).
+- 🧵 **Threads drawer** — slide-over history, pinnable to a docked column; thread selection lives in the URL (`nuqs`), so runs are shareable/bookmarkable.
+- ⚙️ **Runtime configuration** — deployment URL, assistant, and main/subagent models are set in-app and persisted to `localStorage`; no rebuild to swap LLMs (`ConfigDialog`).
+- 🎨 **Theming** — light/dark via `next-themes` plus a user-selectable accent (`data-accent` on `<html>`); the design system is specified in [`DESIGN.md`](DESIGN.md).
+
+## How it talks to the backend
+
+```mermaid
+flowchart LR
+    UI["React components"] --> Chat["useChat · ChatProvider"]
+    Chat -->|"useStream (@langchain/react)"| LG["LangGraph agent server"]
+    Chat -->|"Client: threads / store APIs"| LG
+    UI --> Files["/api/files/* route handlers"]
+    Files -->|"allowlisted fs access"| Disk["repo disk artifacts<br/>(upload · tailored_resume · interview_battlecard)"]
+```
+
+- **Streaming**: `useChat` (`src/app/hooks/useChat.ts`) wraps `@langchain/react`'s `useStream` v2 runtime — messages, values, interrupts, and per-subagent channels — and exposes it app-wide through `ChatProvider`.
+- **Data**: the LangGraph SDK `Client` (created once in `ClientProvider`) serves thread history (`useThreads` + SWR) and the Postgres-backed store files; text artifacts live there.
+- **Disk artifacts** (binary uploads, rendered PDFs) are read/written through the app's own `/api/files/{list,read,write,upload,delete}` route handlers, which resolve paths against a strict allowlist (`src/app/api/files/_lib.ts`) — path traversal is rejected server-side.
+- Agent-file routing (which store a given virtual path belongs to) is configured in `src/app/config/agentFiles.ts`.
+
+## Layout
+
+```
+src/
+├── app/
+│   ├── page.tsx              # Two resizable panels (chat + workspace), threads drawer, config gate
+│   ├── api/files/            # Disk-artifact route handlers + allowlist (_lib.ts)
+│   ├── print/file/           # Standalone print-to-PDF page (reads a sessionStorage payload)
+│   ├── components/           # Chat, workspace, dialogs (tests colocated as *.test.tsx)
+│   ├── hooks/                # useChat (streaming + file CRUD), useThreads (SWR pagination)
+│   ├── lib/ · utils/         # File categories/sources, upload client, parsers, remark plugin
+│   └── config/               # Agent file-source routing table
+├── providers/                # Client, Chat, FilePreview, Accent, Theme
+├── components/ui/            # shadcn/Radix primitives
+└── lib/                      # Runtime config (env defaults + localStorage overrides)
+```
+
+## Development
+
+The normal path is the root [Quick Start](../README.md#quick-start) — `docker compose up -d` runs everything, and source edits hot-reload into the container. To run the frontend directly on the host instead:
+
+```bash
+nvm use              # Node 24 (.nvmrc)
+pnpm install
+pnpm dev             # Turbopack dev server
+```
+
+Configuration comes from `NEXT_PUBLIC_*` env vars (see [`.env.example`](../.env.example)) or the in-app Configuration dialog (which wins, via `localStorage`):
+
+| Variable                               | Purpose                                       |
+| -------------------------------------- | --------------------------------------------- |
+| `NEXT_PUBLIC_LANGGRAPH_DEPLOYMENT_URL` | Agent server URL (the backend's host port)    |
+| `NEXT_PUBLIC_LANGGRAPH_ASSISTANT_ID`   | Assistant/graph id (`career_agent`)           |
+| `NEXT_PUBLIC_LANGSMITH_API_KEY`        | Optional — only for authenticated deployments |
+
+Everyday scripts (pnpm only — the version is pinned via `packageManager`):
+
+| Command                                                | What it does                                          |
+| ------------------------------------------------------ | ----------------------------------------------------- |
+| `pnpm dev` / `pnpm build` / `pnpm start`               | Turbopack dev server / production build / serve       |
+| `pnpm test` / `pnpm test:watch` / `pnpm test:coverage` | Vitest suite (what CI runs) / watch / v8 coverage     |
+| `pnpm lint:fix` · `pnpm format` · `pnpm type-check`    | ESLint · Prettier · `tsc --noEmit`                    |
+| `pnpm quality`                                         | lint + format + type-check + SDK-sync check in one go |
+
+## Testing
+
+Vitest 4 + React Testing Library. Tests are **colocated** with their source; the extension picks the environment — `.test.ts` runs in node (pure modules, the `/api/files/*` handlers against a real temp-dir sandbox), `.test.tsx` in jsdom (hooks, providers, components). The suite is a required CI check (`frontend-tests`) and never touches the network.
+
+Conventions, mocking rules, and gotchas live in [`CLAUDE.md`](CLAUDE.md#testing); the contributor workflow is in the root [`CONTRIBUTING.md`](../CONTRIBUTING.md#testing).
+
+## Related docs
+
+- [`CLAUDE.md`](CLAUDE.md) — stack conventions: tooling, style, testing, and the `@langchain/react` ↔ `@langchain/langgraph-sdk` lockstep upgrade rule.
+- [`DESIGN.md`](DESIGN.md) — the design system: tokens, typography, spacing, and per-component specs.
+- [Root README](../README.md) — product overview, architecture, and quick start.

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -5,7 +5,7 @@ import reactRefresh from "eslint-plugin-react-refresh";
 import tseslint from "typescript-eslint";
 
 export default tseslint.config(
-  { ignores: ["dist", ".next", "node_modules"] },
+  { ignores: ["dist", ".next", "node_modules", "coverage"] },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
     files: ["**/*.{ts,tsx}"],

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,9 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "type-check": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
     "quality": "pnpm lint:fix && pnpm format && pnpm type-check && pnpm check:sdk-sync",
     "check:sdk-sync": "node scripts/check-langchain-sdk-sync.mjs"
   },
@@ -54,19 +57,27 @@
     "@eslint/js": "^10.0.1",
     "@tailwindcss/forms": "^0.5.11",
     "@tailwindcss/postcss": "^4.3.1",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^24.13.2",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^5.2.0",
+    "@vitest/coverage-v8": "^4.1.10",
     "eslint": "^10.6.0",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.3",
     "globals": "^17.7.0",
+    "jsdom": "^29.1.1",
     "postcss": "^8.5.15",
     "prettier": "^3.8.5",
     "prettier-plugin-tailwindcss": "^0.8.0",
     "tailwindcss": "^4.3.1",
     "tw-animate-css": "^1.4.0",
     "typescript": "^6.0.3",
-    "typescript-eslint": "^8.62.0"
+    "typescript-eslint": "^8.62.0",
+    "vitest": "^4.1.10"
   }
 }

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -114,6 +114,18 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4.3.1
         version: 4.3.1
+      '@testing-library/dom':
+        specifier: ^10.4.1
+        version: 10.4.1
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/node':
         specifier: ^24.13.2
         version: 24.13.2
@@ -123,6 +135,12 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.17)
+      '@vitejs/plugin-react':
+        specifier: ^5.2.0
+        version: 5.2.0(vite@8.1.3(@types/node@24.13.2)(jiti@2.7.0)(sass@1.99.0))
+      '@vitest/coverage-v8':
+        specifier: ^4.1.10
+        version: 4.1.10(vitest@4.1.10)
       eslint:
         specifier: ^10.6.0
         version: 10.6.0(jiti@2.7.0)
@@ -135,6 +153,9 @@ importers:
       globals:
         specifier: ^17.7.0
         version: 17.7.0
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1
       postcss:
         specifier: ^8.5.15
         version: 8.5.15
@@ -156,12 +177,33 @@ importers:
       typescript-eslint:
         specifier: ^8.62.0
         version: 8.62.0(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@24.13.2)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.1.3(@types/node@24.13.2)(jiti@2.7.0)(sass@1.99.0))
 
 packages:
+
+  '@adobe/css-tools@4.5.0':
+    resolution: {integrity: sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==}
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@asamuzakjp/css-color@5.1.11':
+    resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    resolution: {integrity: sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/generational-cache@1.0.1':
+    resolution: {integrity: sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -197,6 +239,10 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
+  '@babel/helper-plugin-utils@7.29.7':
+    resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-string-parser@7.29.7':
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
     engines: {node: '>=6.9.0'}
@@ -218,6 +264,18 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  '@babel/plugin-transform-react-jsx-self@7.29.7':
+    resolution: {integrity: sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.29.7':
+    resolution: {integrity: sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/runtime@7.29.2':
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
     engines: {node: '>=6.9.0'}
@@ -234,11 +292,64 @@ packages:
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
+
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
   '@cfworker/json-schema@4.1.1':
     resolution: {integrity: sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==}
 
+  '@csstools/color-helpers@6.1.0':
+    resolution: {integrity: sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.2.1':
+    resolution: {integrity: sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.1.9':
+    resolution: {integrity: sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.6':
+    resolution: {integrity: sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
+
+  '@emnapi/core@1.11.1':
+    resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
+
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
+  '@emnapi/runtime@1.11.1':
+    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
+
+  '@emnapi/wasi-threads@1.2.2':
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
   '@eslint-community/eslint-utils@4.9.1':
     resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
@@ -278,6 +389,15 @@ packages:
   '@eslint/plugin-kit@0.7.2':
     resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@exodus/bytes@1.15.1':
+    resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
@@ -514,6 +634,12 @@ packages:
       '@langchain/core': ^1.1.48
       react: ^18 || ^19
 
+  '@napi-rs/wasm-runtime@1.1.6':
+    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
   '@next/env@16.2.9':
     resolution: {integrity: sha512-ki5VxxXfzD/9TDe13wyeTKIjQTAwBVpnr8KhRDUr8ltMUq1/NBpWNT5tiPoxiGl+PHM4X2ahSOiPk6iAimIzPg==}
 
@@ -568,6 +694,9 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
+
+  '@oxc-project/types@0.138.0':
+    resolution: {integrity: sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==}
 
   '@parcel/watcher-android-arm64@2.5.6':
     resolution: {integrity: sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==}
@@ -1013,6 +1142,107 @@ packages:
   '@radix-ui/rect@1.1.2':
     resolution: {integrity: sha512-xnXE7wG13PI+cxieVssYXlQJuYVRhH9NBoxt3KNwzghDIA69GMm7d4wXRouHIYjE+KvS6U/MsMO73NdS2MH9ZA==}
 
+  '@rolldown/binding-android-arm64@1.1.4':
+    resolution: {integrity: sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.1.4':
+    resolution: {integrity: sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.1.4':
+    resolution: {integrity: sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.1.4':
+    resolution: {integrity: sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.4':
+    resolution: {integrity: sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.1.4':
+    resolution: {integrity: sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.1.4':
+    resolution: {integrity: sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.1.4':
+    resolution: {integrity: sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.1.4':
+    resolution: {integrity: sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.1.4':
+    resolution: {integrity: sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.1.4':
+    resolution: {integrity: sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.1.4':
+    resolution: {integrity: sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.1.4':
+    resolution: {integrity: sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.1.4':
+    resolution: {integrity: sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.1.4':
+    resolution: {integrity: sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-rc.3':
+    resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
@@ -1119,8 +1349,61 @@ packages:
   '@tailwindcss/postcss@4.3.1':
     resolution: {integrity: sha512-dNJuNbdEJT/SWRuXTYP1WSamelsz3ztkUsdtWQPjrexysrTpaEPM40P/71knXiXLYEojqPOEGitVLLpPMS5T6A==}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
@@ -1229,6 +1512,50 @@ packages:
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
     deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
+  '@vitejs/plugin-react@5.2.0':
+    resolution: {integrity: sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  '@vitest/coverage-v8@4.1.10':
+    resolution: {integrity: sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==}
+    peerDependencies:
+      '@vitest/browser': 4.1.10
+      vitest: 4.1.10
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
+
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
@@ -1246,12 +1573,34 @@ packages:
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
 
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
+  aria-query@5.3.2:
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@1.0.4:
+    resolution: {integrity: sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==}
 
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
@@ -1267,6 +1616,9 @@ packages:
     resolution: {integrity: sha512-I2NkZOOrj2XuguvWCK6OVh9GavsNjZjK908Rq3mIBK25+GD8vPX5w2WdxVqnQ7xx3SrZJiCiZFu+/Oz50oSYSA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
   bluebird@3.4.7:
     resolution: {integrity: sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==}
@@ -1285,6 +1637,10 @@ packages:
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   character-entities-html4@2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
@@ -1325,8 +1681,19 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   date-fns@4.4.0:
     resolution: {integrity: sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==}
@@ -1339,6 +1706,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
@@ -1363,6 +1733,12 @@ packages:
   dingbat-to-unicode@1.0.1:
     resolution: {integrity: sha512-98l0sW87ZT58pU4i61wa2OHwxbiYSbuxsCBozaVnYX2iCnr3bLM3fIes1/ej7h1YdOKuKt/MLs706TVnALA65w==}
 
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
   duck@0.1.12:
     resolution: {integrity: sha512-wkctla1O6VfP89gQ+J/yDesM0S7B7XLXjKGzXxMDVFg7uEn706niAtyYovKbyq1oT9YwDcly721/iUWoc8MVRg==}
 
@@ -1372,6 +1748,13 @@ packages:
   enhanced-resolve@5.21.6:
     resolution: {integrity: sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==}
     engines: {node: '>=10.13.0'}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
+
+  es-module-lexer@2.3.0:
+    resolution: {integrity: sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==}
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -1437,6 +1820,9 @@ packages:
   estree-util-is-identifier-name@3.0.0:
     resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -1446,6 +1832,10 @@ packages:
 
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -1490,6 +1880,11 @@ packages:
     resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
     engines: {node: '>=0.4.x'}
 
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
@@ -1508,6 +1903,10 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
 
   hast-util-parse-selector@4.0.0:
     resolution: {integrity: sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==}
@@ -1533,6 +1932,13 @@ packages:
   highlightjs-vue@1.0.0:
     resolution: {integrity: sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA==}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
@@ -1553,6 +1959,10 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -1588,11 +1998,26 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   isarray@1.0.0:
     resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
 
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
@@ -1601,8 +2026,20 @@ packages:
   js-tiktoken@1.0.21:
     resolution: {integrity: sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==}
 
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  jsdom@29.1.1:
+    resolution: {integrity: sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -1746,6 +2183,10 @@ packages:
   lowlight@1.20.0:
     resolution: {integrity: sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==}
 
+  lru-cache@11.5.1:
+    resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -1754,8 +2195,19 @@ packages:
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.5.3:
+    resolution: {integrity: sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   mammoth@1.12.0:
     resolution: {integrity: sha512-cwnK1RIcRdDMi2HRx2EXGYlxqIEh0Oo3bLhorgnsVJi2UkbX1+jKxuBNR9PC5+JaX7EkmJxFPmo6mjLpqShI2w==}
@@ -1809,6 +2261,9 @@ packages:
 
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
@@ -1894,6 +2349,10 @@ packages:
   micromark@4.0.2:
     resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
+
   mini-svg-data-uri@1.4.4:
     resolution: {integrity: sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==}
     hasBin: true
@@ -1971,6 +2430,10 @@ packages:
       react-router-dom:
         optional: true
 
+  obug@2.1.3:
+    resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
+    engines: {node: '>=12.20.0'}
+
   option@0.2.4:
     resolution: {integrity: sha512-pkEqbDyl8ou5cpq+VsnQbe/WlEy5qS7xPzMS1U55OCG9KPvwFD46zDbxQIj3egJSFc3D+XhYOPUzz49zQAVy7A==}
 
@@ -2016,6 +2479,9 @@ packages:
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
 
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -2027,6 +2493,9 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -2041,6 +2510,10 @@ packages:
 
   postcss@8.5.15:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.16:
+    resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -2107,6 +2580,10 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   prismjs@1.30.0:
     resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
     engines: {node: '>=6'}
@@ -2126,11 +2603,18 @@ packages:
     peerDependencies:
       react: ^19.2.7
 
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
   react-markdown@10.1.0:
     resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
     peerDependencies:
       '@types/react': '>=18'
       react: '>=18'
+
+  react-refresh@0.18.0:
+    resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
+    engines: {node: '>=0.10.0'}
 
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
@@ -2185,6 +2669,10 @@ packages:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
 
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+
   refractor@5.0.0:
     resolution: {integrity: sha512-QXOrHQF5jOpjjLfiNk5GFnWhRXvxjUVnlFxkeDmewR5sXkr3iM46Zo+CnRR8B+MDVqkULW4EcLVcRBNOPXHosw==}
 
@@ -2200,6 +2688,15 @@ packages:
   remark-stringify@11.0.0:
     resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
+  rolldown@1.1.4:
+    resolution: {integrity: sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
 
@@ -2207,6 +2704,10 @@ packages:
     resolution: {integrity: sha512-kgW13M54DUB7IsIRM5LvJkNlpH+WhMpooUcaWGFARkF1Tc82v9mIWkCbCYf+MBvpIUBSeSOTilpZjEPr2VYE6Q==}
     engines: {node: '>=14.0.0'}
     hasBin: true
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -2235,6 +2736,9 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   sonner@2.0.7:
     resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
     peerDependencies:
@@ -2251,11 +2755,21 @@ packages:
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
+
   string_decoder@1.1.1:
     resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
 
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
 
   style-to-js@1.1.21:
     resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
@@ -2276,10 +2790,17 @@ packages:
       babel-plugin-macros:
         optional: true
 
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
   swr@2.4.2:
     resolution: {integrity: sha512-ej644Y2bvkIajfR32KGeSSdBXQW+ScjGjkybZgSE7kFpk9eGnV44XY9FJylXi+W75pavSX1PVNB57W5EbhGIYw==}
     peerDependencies:
       react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
   tailwind-merge@3.6.0:
     resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
@@ -2291,9 +2812,39 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
+  tldts-core@7.4.6:
+    resolution: {integrity: sha512-TkQNGJIhlEphpHCjKodMTSe23egUZr/g+flI2qkLgiJ/maAzSgXypSLRTNH3nCmqgayEmtcJBiLcfODSAr1xoA==}
+
+  tldts@7.4.6:
+    resolution: {integrity: sha512-rbP0Gyx8b3Ae9yO//CU2wbSnQNoQ66m1nJdSbSHmnwKwzkkz/u8mERYU8T2rmlmy+bJvRNn84yNCW8gYqox44Q==}
+    hasBin: true
+
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -2334,6 +2885,10 @@ packages:
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+    engines: {node: '>=20.18.1'}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -2401,18 +2956,130 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
+  vite@8.1.3:
+    resolution: {integrity: sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.3.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
   xmlbuilder@10.1.1:
     resolution: {integrity: sha512-OyzrcFLL/nb6fMGHbiRDuPup9ljBycsdCypwuyg5AAHvyWzGfChJpCXMG88AGTIMFhGZ9RccFN1e6lhg3hkwKg==}
     engines: {node: '>=4.0'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -2435,7 +3102,29 @@ packages:
 
 snapshots:
 
+  '@adobe/css-tools@4.5.0': {}
+
   '@alloc/quick-lru@5.2.0': {}
+
+  '@asamuzakjp/css-color@5.1.11':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.9(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+
+  '@asamuzakjp/generational-cache@1.0.1': {}
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@babel/code-frame@7.29.7':
     dependencies:
@@ -2499,6 +3188,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-plugin-utils@7.29.7': {}
+
   '@babel/helper-string-parser@7.29.7': {}
 
   '@babel/helper-validator-identifier@7.29.7': {}
@@ -2513,6 +3204,16 @@ snapshots:
   '@babel/parser@7.29.7':
     dependencies:
       '@babel/types': 7.29.7
+
+  '@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-react-jsx-source@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/runtime@7.29.2': {}
 
@@ -2539,9 +3240,55 @@ snapshots:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
 
+  '@bcoe/v8-coverage@1.0.2': {}
+
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
   '@cfworker/json-schema@4.1.1': {}
 
+  '@csstools/color-helpers@6.1.0': {}
+
+  '@csstools/css-calc@3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.1.9(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.1.0
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.6(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
+
+  '@emnapi/core@1.11.1':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.2
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.11.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.2':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -2579,6 +3326,8 @@ snapshots:
     dependencies:
       '@eslint/core': 1.2.1
       levn: 0.4.1
+
+  '@exodus/bytes@1.15.1': {}
 
   '@floating-ui/core@1.7.5':
     dependencies:
@@ -2768,6 +3517,13 @@ snapshots:
       - svelte
       - vue
 
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
   '@next/env@16.2.9': {}
 
   '@next/swc-darwin-arm64@16.2.9':
@@ -2793,6 +3549,8 @@ snapshots:
 
   '@next/swc-win32-x64-msvc@16.2.9':
     optional: true
+
+  '@oxc-project/types@0.138.0': {}
 
   '@parcel/watcher-android-arm64@2.5.6':
     optional: true
@@ -3199,6 +3957,59 @@ snapshots:
 
   '@radix-ui/rect@1.1.2': {}
 
+  '@rolldown/binding-android-arm64@1.1.4':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.1.4':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.1.4':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.1.4':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.4':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.1.4':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.1.4':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.1.4':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.1.4':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.1.4':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.1.4':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.1.4':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.1.4':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.1.4':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.1.4':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-rc.3': {}
+
+  '@rolldown/pluginutils@1.0.1': {}
+
   '@standard-schema/spec@1.0.0': {}
 
   '@standard-schema/spec@1.1.0': {}
@@ -3281,9 +4092,78 @@ snapshots:
       postcss: 8.5.15
       tailwindcss: 4.3.1
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/runtime': 7.29.2
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.5.0
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@testing-library/dom': 10.4.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
+  '@tybys/wasm-util@0.10.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@types/aria-query@5.0.4': {}
+
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/esrecurse@4.3.1': {}
 
@@ -3420,6 +4300,73 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
+  '@vitejs/plugin-react@5.2.0(vite@8.1.3(@types/node@24.13.2)(jiti@2.7.0)(sass@1.99.0))':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7)
+      '@rolldown/pluginutils': 1.0.0-rc.3
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.18.0
+      vite: 8.1.3(@types/node@24.13.2)(jiti@2.7.0)(sass@1.99.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vitest/coverage-v8@4.1.10(vitest@4.1.10)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.10
+      ast-v8-to-istanbul: 1.0.4
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.3
+      obug: 2.1.3
+      std-env: 4.1.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.10(@types/node@24.13.2)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.1.3(@types/node@24.13.2)(jiti@2.7.0)(sass@1.99.0))
+
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.10(vite@8.1.3(@types/node@24.13.2)(jiti@2.7.0)(sass@1.99.0))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.1.3(@types/node@24.13.2)(jiti@2.7.0)(sass@1.99.0)
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   '@xmldom/xmldom@0.8.13': {}
 
   acorn-jsx@5.3.2(acorn@8.16.0):
@@ -3435,6 +4382,10 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@5.2.0: {}
+
   argparse@1.0.10:
     dependencies:
       sprintf-js: 1.0.3
@@ -3443,6 +4394,20 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
+  aria-query@5.3.2: {}
+
+  assertion-error@2.0.1: {}
+
+  ast-v8-to-istanbul@1.0.4:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
+
   bail@2.0.2: {}
 
   balanced-match@4.0.4: {}
@@ -3450,6 +4415,10 @@ snapshots:
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.10.24: {}
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
 
   bluebird@3.4.7: {}
 
@@ -3468,6 +4437,8 @@ snapshots:
   caniuse-lite@1.0.30001791: {}
 
   ccount@2.0.1: {}
+
+  chai@6.2.2: {}
 
   character-entities-html4@2.1.0: {}
 
@@ -3502,13 +4473,29 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
+  css.escape@1.5.1: {}
+
   csstype@3.2.3: {}
+
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   date-fns@4.4.0: {}
 
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   decode-named-character-reference@1.3.0:
     dependencies:
@@ -3528,6 +4515,10 @@ snapshots:
 
   dingbat-to-unicode@1.0.1: {}
 
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
+
   duck@0.1.12:
     dependencies:
       underscore: 1.13.8
@@ -3538,6 +4529,10 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3
+
+  entities@8.0.0: {}
+
+  es-module-lexer@2.3.0: {}
 
   escalade@3.2.0: {}
 
@@ -3626,11 +4621,17 @@ snapshots:
 
   estree-util-is-identifier-name@3.0.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
 
   eventemitter3@4.0.7: {}
 
   eventemitter3@5.0.4: {}
+
+  expect-type@1.4.0: {}
 
   extend@3.0.2: {}
 
@@ -3666,6 +4667,9 @@ snapshots:
 
   format@0.2.2: {}
 
+  fsevents@2.3.3:
+    optional: true
+
   gensync@1.0.0-beta.2: {}
 
   get-nonce@1.0.1: {}
@@ -3677,6 +4681,8 @@ snapshots:
   globals@17.7.0: {}
 
   graceful-fs@4.2.11: {}
+
+  has-flag@4.0.0: {}
 
   hast-util-parse-selector@4.0.0:
     dependencies:
@@ -3724,6 +4730,14 @@ snapshots:
 
   highlightjs-vue@1.0.0: {}
 
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  html-escaper@2.0.2: {}
+
   html-url-attributes@3.0.1: {}
 
   ignore@5.3.2: {}
@@ -3736,6 +4750,8 @@ snapshots:
     optional: true
 
   imurmurhash@0.1.4: {}
+
+  indent-string@4.0.0: {}
 
   inherits@2.0.4: {}
 
@@ -3762,9 +4778,24 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   isarray@1.0.0: {}
 
   isexe@2.0.0: {}
+
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
 
   jiti@2.7.0: {}
 
@@ -3772,7 +4803,35 @@ snapshots:
     dependencies:
       base64-js: 1.5.1
 
+  js-tokens@10.0.0: {}
+
   js-tokens@4.0.0: {}
+
+  jsdom@29.1.1:
+    dependencies:
+      '@asamuzakjp/css-color': 5.1.11
+      '@asamuzakjp/dom-selector': 7.1.1
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.6(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.1
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.1
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.1
+      undici: 7.28.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   jsesc@3.1.0: {}
 
@@ -3876,6 +4935,8 @@ snapshots:
       fault: 1.0.4
       highlight.js: 10.7.3
 
+  lru-cache@11.5.1: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -3884,9 +4945,21 @@ snapshots:
     dependencies:
       react: 19.2.7
 
+  lz-string@1.5.0: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.5.3:
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.4
 
   mammoth@1.12.0:
     dependencies:
@@ -4055,6 +5128,8 @@ snapshots:
   mdast-util-to-string@4.0.0:
     dependencies:
       '@types/mdast': 4.0.4
+
+  mdn-data@2.27.1: {}
 
   micromark-core-commonmark@2.0.3:
     dependencies:
@@ -4247,6 +5322,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  min-indent@1.0.1: {}
+
   mini-svg-data-uri@1.4.4: {}
 
   minimatch@10.2.5:
@@ -4303,6 +5380,8 @@ snapshots:
     optionalDependencies:
       next: 16.2.9(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.99.0)
 
+  obug@2.1.3: {}
+
   option@0.2.4: {}
 
   optionator@0.9.4:
@@ -4356,11 +5435,17 @@ snapshots:
       is-decimal: 2.0.1
       is-hexadecimal: 2.0.1
 
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
+
   path-exists@4.0.0: {}
 
   path-is-absolute@1.0.1: {}
 
   path-key@3.1.1: {}
+
+  pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
 
@@ -4378,6 +5463,12 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  postcss@8.5.16:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
   prelude-ls@1.2.1: {}
 
   prettier-plugin-tailwindcss@0.8.0(prettier@3.8.5):
@@ -4385,6 +5476,12 @@ snapshots:
       prettier: 3.8.5
 
   prettier@3.8.5: {}
+
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
 
   prismjs@1.30.0: {}
 
@@ -4398,6 +5495,8 @@ snapshots:
     dependencies:
       react: 19.2.7
       scheduler: 0.27.0
+
+  react-is@17.0.2: {}
 
   react-markdown@10.1.0(@types/react@19.2.17)(react@19.2.7):
     dependencies:
@@ -4416,6 +5515,8 @@ snapshots:
       vfile: 6.0.3
     transitivePeerDependencies:
       - supports-color
+
+  react-refresh@0.18.0: {}
 
   react-remove-scroll-bar@2.3.8(@types/react@19.2.17)(react@19.2.7):
     dependencies:
@@ -4474,6 +5575,11 @@ snapshots:
   readdirp@4.1.2:
     optional: true
 
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
+
   refractor@5.0.0:
     dependencies:
       '@types/hast': 3.0.4
@@ -4515,6 +5621,29 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
+  require-from-string@2.0.2: {}
+
+  rolldown@1.1.4:
+    dependencies:
+      '@oxc-project/types': 0.138.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.1.4
+      '@rolldown/binding-darwin-arm64': 1.1.4
+      '@rolldown/binding-darwin-x64': 1.1.4
+      '@rolldown/binding-freebsd-x64': 1.1.4
+      '@rolldown/binding-linux-arm-gnueabihf': 1.1.4
+      '@rolldown/binding-linux-arm64-gnu': 1.1.4
+      '@rolldown/binding-linux-arm64-musl': 1.1.4
+      '@rolldown/binding-linux-ppc64-gnu': 1.1.4
+      '@rolldown/binding-linux-s390x-gnu': 1.1.4
+      '@rolldown/binding-linux-x64-gnu': 1.1.4
+      '@rolldown/binding-linux-x64-musl': 1.1.4
+      '@rolldown/binding-openharmony-arm64': 1.1.4
+      '@rolldown/binding-wasm32-wasi': 1.1.4
+      '@rolldown/binding-win32-arm64-msvc': 1.1.4
+      '@rolldown/binding-win32-x64-msvc': 1.1.4
+
   safe-buffer@5.1.2: {}
 
   sass@1.99.0:
@@ -4525,6 +5654,10 @@ snapshots:
     optionalDependencies:
       '@parcel/watcher': 2.5.6
     optional: true
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.27.0: {}
 
@@ -4572,6 +5705,8 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  siginfo@2.0.0: {}
+
   sonner@2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       react: 19.2.7
@@ -4583,6 +5718,10 @@ snapshots:
 
   sprintf-js@1.0.3: {}
 
+  stackback@0.0.2: {}
+
+  std-env@4.1.0: {}
+
   string_decoder@1.1.1:
     dependencies:
       safe-buffer: 5.1.2
@@ -4591,6 +5730,10 @@ snapshots:
     dependencies:
       character-entities-html4: 2.1.0
       character-entities-legacy: 3.0.0
+
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
 
   style-to-js@1.1.21:
     dependencies:
@@ -4607,11 +5750,17 @@ snapshots:
     optionalDependencies:
       '@babel/core': 7.29.7
 
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
   swr@2.4.2(react@19.2.7):
     dependencies:
       dequal: 2.0.3
       react: 19.2.7
       use-sync-external-store: 1.6.0(react@19.2.7)
+
+  symbol-tree@3.2.4: {}
 
   tailwind-merge@3.6.0: {}
 
@@ -4619,10 +5768,35 @@ snapshots:
 
   tapable@2.3.3: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.2.4: {}
+
   tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
+
+  tldts-core@7.4.6: {}
+
+  tldts@7.4.6:
+    dependencies:
+      tldts-core: 7.4.6
+
+  tough-cookie@6.0.1:
+    dependencies:
+      tldts: 7.4.6
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   trim-lines@3.0.1: {}
 
@@ -4656,6 +5830,8 @@ snapshots:
   underscore@1.13.8: {}
 
   undici-types@7.18.2: {}
+
+  undici@7.28.0: {}
 
   unified@11.0.5:
     dependencies:
@@ -4735,13 +5911,80 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  vite@8.1.3(@types/node@24.13.2)(jiti@2.7.0)(sass@1.99.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.16
+      rolldown: 1.1.4
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 24.13.2
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      sass: 1.99.0
+
+  vitest@4.1.10(@types/node@24.13.2)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.1.3(@types/node@24.13.2)(jiti@2.7.0)(sass@1.99.0)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.1.3(@types/node@24.13.2)(jiti@2.7.0)(sass@1.99.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.0
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.1.3(@types/node@24.13.2)(jiti@2.7.0)(sass@1.99.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.13.2
+      '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
+      jsdom: 29.1.1
+    transitivePeerDependencies:
+      - msw
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
 
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
   word-wrap@1.2.5: {}
 
+  xml-name-validator@5.0.0: {}
+
   xmlbuilder@10.1.1: {}
+
+  xmlchars@2.2.0: {}
 
   yallist@3.1.1: {}
 

--- a/frontend/src/app/api/files/_lib.test.ts
+++ b/frontend/src/app/api/files/_lib.test.ts
@@ -1,0 +1,162 @@
+import path from "node:path";
+
+// AGENT_FILE_SOURCES is mocked so these tests stay stable if the real career_agent
+// config evolves. _lib reads the allowlist at module scope and computes REPO_ROOT
+// from process.cwd() at import time — hence the cwd spy in beforeAll and the
+// dynamic import (never a static import of the module under test).
+vi.mock("@/app/config/agentFiles", () => ({
+  AGENT_FILE_SOURCES: {
+    test_agent: {
+      disk: { root: "backend/agents/test_agent", includeDirs: ["upload", "outputs"] },
+    },
+  },
+}));
+
+// resolveSafe/resolveDir are pure path math — no filesystem is touched, so the
+// repo root can be entirely virtual. Documented limitation (no test): symlinks
+// are NOT resolved (no realpath); containment is checked on the lexical path only.
+const FAKE_REPO = path.join(path.sep, "virtual-nextrole-repo");
+const AGENT_ROOT = "backend/agents/test_agent";
+const UPLOAD_ABS = path.join(FAKE_REPO, AGENT_ROOT, "upload");
+const OUTPUTS_ABS = path.join(FAKE_REPO, AGENT_ROOT, "outputs");
+
+let lib: typeof import("./_lib");
+
+beforeAll(async () => {
+  vi.spyOn(process, "cwd").mockReturnValue(path.join(FAKE_REPO, "frontend"));
+  lib = await import("./_lib");
+});
+
+afterAll(() => {
+  vi.restoreAllMocks();
+});
+
+describe("REPO_ROOT", () => {
+  it("resolves to the parent of cwd at import time", () => {
+    expect(lib.REPO_ROOT).toBe(FAKE_REPO);
+  });
+});
+
+describe("resolveSafe", () => {
+  it("resolves a path inside an allowed bucket to an absolute path", () => {
+    expect(lib.resolveSafe(`${AGENT_ROOT}/upload/x.md`)).toBe(path.join(UPLOAD_ABS, "x.md"));
+  });
+
+  it("resolves nested paths inside an allowed bucket", () => {
+    expect(lib.resolveSafe(`${AGENT_ROOT}/upload/a/b/c.md`)).toBe(
+      path.join(UPLOAD_ABS, "a", "b", "c.md")
+    );
+  });
+
+  it("rejects ../ traversal that escapes the allowlist", () => {
+    expect(lib.resolveSafe(`${AGENT_ROOT}/upload/../../../../etc/passwd`)).toBeNull();
+    expect(lib.resolveSafe(`${AGENT_ROOT}/upload/../../../../../../../etc/passwd`)).toBeNull();
+    expect(lib.resolveSafe("/etc/passwd")).toBeNull();
+  });
+
+  it("allows a path that uses .. but lands inside another allowed bucket", () => {
+    // Traversal is judged by the resolved destination, not by the presence of "..".
+    expect(lib.resolveSafe(`${AGENT_ROOT}/upload/../outputs/x.md`)).toBe(
+      path.join(OUTPUTS_ABS, "x.md")
+    );
+  });
+
+  it("rejects sibling dirs sharing the allowed dir as a string prefix", () => {
+    // Guarded by startsWith(allowed + path.sep), not bare startsWith(allowed).
+    expect(lib.resolveSafe(`${AGENT_ROOT}/uploadX/f.md`)).toBeNull();
+    expect(lib.resolveSafe(`${AGENT_ROOT}/outputs-evil/f.md`)).toBeNull();
+  });
+
+  it("allows a path exactly equal to the allowed dir", () => {
+    expect(lib.resolveSafe(`${AGENT_ROOT}/upload`)).toBe(UPLOAD_ABS);
+  });
+
+  it("strips leading slashes", () => {
+    expect(lib.resolveSafe(`/${AGENT_ROOT}/upload/x.md`)).toBe(path.join(UPLOAD_ABS, "x.md"));
+    expect(lib.resolveSafe(`///${AGENT_ROOT}/upload/x.md`)).toBe(path.join(UPLOAD_ABS, "x.md"));
+  });
+
+  it("rejects empty and non-string input", () => {
+    expect(lib.resolveSafe("")).toBeNull();
+    expect(lib.resolveSafe(42 as unknown as string)).toBeNull();
+    expect(lib.resolveSafe(null as unknown as string)).toBeNull();
+    expect(lib.resolveSafe(undefined as unknown as string)).toBeNull();
+  });
+
+  it("rejects paths under roots that are not allowlisted", () => {
+    expect(lib.resolveSafe("backend/other/upload/x.md")).toBeNull();
+  });
+
+  it("rejects paths under an allowed root but outside its includeDirs", () => {
+    expect(lib.resolveSafe(`${AGENT_ROOT}/secrets/x.md`)).toBeNull();
+    expect(lib.resolveSafe(`${AGENT_ROOT}/x.md`)).toBeNull();
+  });
+});
+
+describe("resolveDir", () => {
+  it("resolves an allowlisted root/dir bucket", () => {
+    expect(lib.resolveDir(AGENT_ROOT, "upload")).toBe(UPLOAD_ABS);
+    expect(lib.resolveDir(AGENT_ROOT, "outputs")).toBe(OUTPUTS_ABS);
+  });
+
+  it("rejects roots not registered in any agent config", () => {
+    expect(lib.resolveDir("backend/agents/unknown", "upload")).toBeNull();
+  });
+
+  it("rejects roots that escape REPO_ROOT", () => {
+    expect(lib.resolveDir("../outside", "upload")).toBeNull();
+    expect(lib.resolveDir("/etc", "upload")).toBeNull();
+  });
+
+  it("rejects dirs not in the root's includeDirs", () => {
+    expect(lib.resolveDir(AGENT_ROOT, "secrets")).toBeNull();
+    // includeDirs membership is an exact string match — traversal spellings miss it.
+    expect(lib.resolveDir(AGENT_ROOT, "../upload")).toBeNull();
+    expect(lib.resolveDir(AGENT_ROOT, "upload/../outputs")).toBeNull();
+  });
+});
+
+describe("extOf", () => {
+  it("lowercases the extension", () => {
+    expect(lib.extOf("notes.MD")).toBe("md");
+    expect(lib.extOf("photo.PNG")).toBe("png");
+  });
+
+  it("returns the segment after the final dot", () => {
+    expect(lib.extOf("archive.tar.gz")).toBe("gz");
+    expect(lib.extOf(".env")).toBe("env");
+  });
+
+  it("returns the whole lowercased string when there is no dot", () => {
+    // Actual behavior: split(".").pop() of a dotless string is the string itself.
+    expect(lib.extOf("README")).toBe("readme");
+    expect(lib.extOf("dir/file")).toBe("dir/file");
+  });
+
+  it("returns an empty string for a trailing dot", () => {
+    expect(lib.extOf("file.")).toBe("");
+  });
+});
+
+describe("isBinaryPath", () => {
+  it("flags known binary extensions, case-insensitively", () => {
+    expect(lib.isBinaryPath("a.png")).toBe(true);
+    expect(lib.isBinaryPath("a.PDF")).toBe(true);
+    expect(lib.isBinaryPath("a.tar.gz")).toBe(true);
+  });
+
+  it("treats everything else as text", () => {
+    expect(lib.isBinaryPath("a.md")).toBe(false);
+    expect(lib.isBinaryPath("a.txt")).toBe(false);
+    expect(lib.isBinaryPath("README")).toBe(false);
+  });
+});
+
+describe("encodingFor", () => {
+  it("uses utf-8 for text and base64 for binary", () => {
+    expect(lib.encodingFor("a.md")).toBe("utf-8");
+    expect(lib.encodingFor("a.json")).toBe("utf-8");
+    expect(lib.encodingFor("a.png")).toBe("base64");
+    expect(lib.encodingFor("a.docx")).toBe("base64");
+  });
+});

--- a/frontend/src/app/api/files/delete/route.test.ts
+++ b/frontend/src/app/api/files/delete/route.test.ts
@@ -1,0 +1,96 @@
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { NextRequest } from "next/server";
+
+// Stable allowlist for tests, independent of the real career_agent config.
+vi.mock("@/app/config/agentFiles", () => ({
+  AGENT_FILE_SOURCES: {
+    test_agent: {
+      disk: { root: "backend/agents/test_agent", includeDirs: ["upload", "outputs"] },
+    },
+  },
+}));
+
+const AGENT_ROOT = "backend/agents/test_agent";
+
+let tmp: string;
+let route: typeof import("./route");
+
+function delReq(repoRel?: string): NextRequest {
+  const url = new URL("http://localhost/api/files/delete");
+  if (repoRel !== undefined) url.searchParams.set("path", repoRel);
+  return new NextRequest(url, { method: "DELETE" });
+}
+
+beforeAll(async () => {
+  tmp = await fs.mkdtemp(path.join(os.tmpdir(), "files-api-delete-"));
+  await fs.mkdir(path.join(tmp, AGENT_ROOT, "upload"), { recursive: true });
+  // REPO_ROOT is computed from cwd at _lib import time: spy first, import after.
+  vi.spyOn(process, "cwd").mockReturnValue(path.join(tmp, "frontend"));
+  route = await import("./route");
+});
+
+afterAll(async () => {
+  vi.restoreAllMocks();
+  await fs.rm(tmp, { recursive: true, force: true });
+});
+
+describe("DELETE /api/files/delete", () => {
+  it("400 when the path param is missing", async () => {
+    const res = await route.DELETE(delReq());
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Missing 'path'" });
+  });
+
+  it("403 for paths outside the allowlist", async () => {
+    for (const repoRel of [
+      `${AGENT_ROOT}/upload/../../../../etc/passwd`,
+      "backend/other/upload/x.md",
+    ]) {
+      const res = await route.DELETE(delReq(repoRel));
+      expect(res.status).toBe(403);
+      expect(await res.json()).toEqual({ error: "Forbidden path" });
+    }
+  });
+
+  it("404 for a missing file inside an allowed dir", async () => {
+    const res = await route.DELETE(delReq(`${AGENT_ROOT}/upload/ghost.md`));
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "Not found" });
+  });
+
+  it("400 when the target is a directory (EISDIR)", async () => {
+    // fs.unlink on a directory yields EISDIR on Linux but EPERM on macOS (where
+    // the real call would fall through to the 500 branch), so the EISDIR branch
+    // is exercised deterministically via a mock.
+    const dirRel = `${AGENT_ROOT}/upload/somedir`;
+    await fs.mkdir(path.join(tmp, dirRel), { recursive: true });
+    const eisdir = Object.assign(new Error("EISDIR: illegal operation on a directory"), {
+      code: "EISDIR",
+    });
+    const spy = vi.spyOn(fs, "unlink").mockRejectedValueOnce(eisdir);
+    try {
+      const res = await route.DELETE(delReq(dirRel));
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({ error: "Path is a directory" });
+      expect(spy).toHaveBeenCalledWith(path.join(tmp, dirRel));
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("200 deletes the file, and a second delete 404s", async () => {
+    const repoRel = `${AGENT_ROOT}/upload/doomed.md`;
+    const abs = path.join(tmp, repoRel);
+    await fs.writeFile(abs, "goodbye\n");
+
+    const res = await route.DELETE(delReq(repoRel));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    await expect(fs.access(abs)).rejects.toThrow();
+
+    const again = await route.DELETE(delReq(repoRel));
+    expect(again.status).toBe(404);
+  });
+});

--- a/frontend/src/app/api/files/list/route.test.ts
+++ b/frontend/src/app/api/files/list/route.test.ts
@@ -1,0 +1,141 @@
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { NextRequest } from "next/server";
+
+// Stable allowlist for tests, independent of the real career_agent config.
+// "missing" is allowlisted but never created on disk (ENOENT walk case).
+vi.mock("@/app/config/agentFiles", () => ({
+  AGENT_FILE_SOURCES: {
+    test_agent: {
+      disk: {
+        root: "backend/agents/test_agent",
+        includeDirs: ["upload", "outputs", "missing"],
+      },
+    },
+  },
+}));
+
+const AGENT_ROOT = "backend/agents/test_agent";
+const PNG_BYTES = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x00]);
+
+type Entry = { path: string; size: number; isBinary: boolean; modifiedAt: string };
+
+let tmp: string;
+let route: typeof import("./route");
+
+function listReq(params: Record<string, string>): NextRequest {
+  const url = new URL("http://localhost/api/files/list");
+  for (const [key, value] of Object.entries(params)) url.searchParams.set(key, value);
+  return new NextRequest(url);
+}
+
+async function getFiles(params: Record<string, string>): Promise<Entry[]> {
+  const res = await route.GET(listReq(params));
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as { files: Entry[] };
+  return body.files;
+}
+
+beforeAll(async () => {
+  tmp = await fs.mkdtemp(path.join(os.tmpdir(), "files-api-list-"));
+  const upload = path.join(tmp, AGENT_ROOT, "upload");
+  const outputs = path.join(tmp, AGENT_ROOT, "outputs");
+  await fs.mkdir(path.join(upload, "nested"), { recursive: true });
+  await fs.mkdir(path.join(upload, ".hiddendir"), { recursive: true });
+  await fs.mkdir(outputs, { recursive: true });
+  await fs.writeFile(path.join(upload, "b.md"), "bravo\n");
+  await fs.writeFile(path.join(upload, "a.md"), "alpha\n");
+  await fs.writeFile(path.join(upload, "pic.png"), PNG_BYTES);
+  await fs.writeFile(path.join(upload, ".hidden"), "secret\n");
+  await fs.writeFile(path.join(upload, ".hiddendir", "inner.md"), "invisible\n");
+  await fs.writeFile(path.join(upload, "nested", "c.md"), "charlie\n");
+  await fs.writeFile(path.join(outputs, "report.md"), "report\n");
+  // REPO_ROOT is computed from cwd at _lib import time: spy first, import after.
+  vi.spyOn(process, "cwd").mockReturnValue(path.join(tmp, "frontend"));
+  route = await import("./route");
+});
+
+afterAll(async () => {
+  vi.restoreAllMocks();
+  await fs.rm(tmp, { recursive: true, force: true });
+});
+
+describe("GET /api/files/list", () => {
+  it("400 when root or dirs is missing", async () => {
+    const incomplete: Record<string, string>[] = [{}, { root: AGENT_ROOT }, { dirs: "upload" }];
+    for (const params of incomplete) {
+      const res = await route.GET(listReq(params));
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({ error: "Missing 'root' or 'dirs'" });
+    }
+  });
+
+  it("403 for a dir outside the root's includeDirs", async () => {
+    const res = await route.GET(listReq({ root: AGENT_ROOT, dirs: "secrets" }));
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({
+      error: `Disallowed root/dir: ${AGENT_ROOT}/secrets`,
+    });
+  });
+
+  it("403 for unknown roots and traversal probes", async () => {
+    for (const params of [
+      { root: "backend/other", dirs: "upload" },
+      { root: "../outside", dirs: "upload" },
+      { root: AGENT_ROOT, dirs: "../../etc" },
+    ]) {
+      const res = await route.GET(listReq(params));
+      expect(res.status).toBe(403);
+    }
+  });
+
+  it("walks recursively, skips dotfiles and dot-dirs, sorts by path", async () => {
+    const files = await getFiles({ root: AGENT_ROOT, dirs: "upload" });
+    expect(files.map((f) => f.path)).toEqual([
+      `/${AGENT_ROOT}/upload/a.md`,
+      `/${AGENT_ROOT}/upload/b.md`,
+      `/${AGENT_ROOT}/upload/nested/c.md`,
+      `/${AGENT_ROOT}/upload/pic.png`,
+    ]);
+    // .hidden and .hiddendir/inner.md are excluded by the exact list above.
+    expect(files.some((f) => f.path.includes(".hidden"))).toBe(false);
+  });
+
+  it("reports size, isBinary per extension, and ISO modifiedAt", async () => {
+    const files = await getFiles({ root: AGENT_ROOT, dirs: "upload" });
+    const byPath = new Map(files.map((f) => [f.path, f]));
+    const text = byPath.get(`/${AGENT_ROOT}/upload/a.md`)!;
+    const binary = byPath.get(`/${AGENT_ROOT}/upload/pic.png`)!;
+    expect(text.size).toBe(6); // "alpha\n"
+    expect(text.isBinary).toBe(false);
+    expect(binary.size).toBe(PNG_BYTES.length);
+    expect(binary.isBinary).toBe(true);
+    for (const f of files) {
+      expect(new Date(f.modifiedAt).toISOString()).toBe(f.modifiedAt);
+    }
+  });
+
+  it("returns an empty result (not an error) for an allowed dir missing on disk", async () => {
+    const res = await route.GET(listReq({ root: AGENT_ROOT, dirs: "missing" }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ files: [] });
+  });
+
+  it("merges multiple dirs from a comma-separated dirs param, sorted", async () => {
+    const expected = [
+      `/${AGENT_ROOT}/outputs/report.md`,
+      `/${AGENT_ROOT}/upload/a.md`,
+      `/${AGENT_ROOT}/upload/b.md`,
+      `/${AGENT_ROOT}/upload/nested/c.md`,
+      `/${AGENT_ROOT}/upload/pic.png`,
+    ];
+    const files = await getFiles({ root: AGENT_ROOT, dirs: "upload,outputs" });
+    const paths = files.map((f) => f.path);
+    expect(paths).toEqual(expected);
+    expect(paths).toEqual([...paths].sort((a, b) => a.localeCompare(b)));
+    // Whitespace around segments is trimmed.
+    const spaced = await getFiles({ root: AGENT_ROOT, dirs: " upload , outputs " });
+    expect(spaced.map((f) => f.path)).toEqual(expected);
+  });
+});

--- a/frontend/src/app/api/files/read/route.test.ts
+++ b/frontend/src/app/api/files/read/route.test.ts
@@ -1,0 +1,82 @@
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { NextRequest } from "next/server";
+
+// Stable allowlist for tests, independent of the real career_agent config.
+vi.mock("@/app/config/agentFiles", () => ({
+  AGENT_FILE_SOURCES: {
+    test_agent: {
+      disk: { root: "backend/agents/test_agent", includeDirs: ["upload", "outputs"] },
+    },
+  },
+}));
+
+const AGENT_ROOT = "backend/agents/test_agent";
+const NOTE_CONTENT = "# Héllo\n\nRésumé — ✓ unicode round-trip\n";
+const PNG_BYTES = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x00]);
+
+let tmp: string;
+let route: typeof import("./route");
+
+function readReq(repoRel: string): NextRequest {
+  const url = new URL("http://localhost/api/files/read");
+  url.searchParams.set("path", repoRel);
+  return new NextRequest(url);
+}
+
+beforeAll(async () => {
+  tmp = await fs.mkdtemp(path.join(os.tmpdir(), "files-api-read-"));
+  const upload = path.join(tmp, AGENT_ROOT, "upload");
+  await fs.mkdir(upload, { recursive: true });
+  await fs.writeFile(path.join(upload, "note.md"), NOTE_CONTENT, "utf-8");
+  await fs.writeFile(path.join(upload, "pic.png"), PNG_BYTES);
+  // REPO_ROOT is computed from cwd at _lib import time: spy first, import after.
+  vi.spyOn(process, "cwd").mockReturnValue(path.join(tmp, "frontend"));
+  route = await import("./route");
+});
+
+afterAll(async () => {
+  vi.restoreAllMocks();
+  await fs.rm(tmp, { recursive: true, force: true });
+});
+
+describe("GET /api/files/read", () => {
+  it("400 when the path param is missing", async () => {
+    const res = await route.GET(new NextRequest("http://localhost/api/files/read"));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Missing 'path'" });
+  });
+
+  it("403 for ../ traversal escaping the allowlist", async () => {
+    const res = await route.GET(readReq(`${AGENT_ROOT}/upload/../../../../etc/passwd`));
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: "Forbidden path" });
+  });
+
+  it("403 for paths outside the allowlist", async () => {
+    const res = await route.GET(readReq("backend/other/upload/x.md"));
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: "Forbidden path" });
+  });
+
+  it("404 for a missing file inside an allowed dir", async () => {
+    const res = await route.GET(readReq(`${AGENT_ROOT}/upload/nope.md`));
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "Not found" });
+  });
+
+  it("200 with exact utf-8 content for text files", async () => {
+    const res = await route.GET(readReq(`${AGENT_ROOT}/upload/note.md`));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ content: NOTE_CONTENT, encoding: "utf-8" });
+  });
+
+  it("200 with base64 content for binary files", async () => {
+    const res = await route.GET(readReq(`${AGENT_ROOT}/upload/pic.png`));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { content: string; encoding: string };
+    expect(body.encoding).toBe("base64");
+    expect(Buffer.from(body.content, "base64").equals(PNG_BYTES)).toBe(true);
+  });
+});

--- a/frontend/src/app/api/files/upload/route.test.ts
+++ b/frontend/src/app/api/files/upload/route.test.ts
@@ -1,0 +1,156 @@
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { NextRequest } from "next/server";
+
+// Stable allowlist for tests, independent of the real career_agent config.
+vi.mock("@/app/config/agentFiles", () => ({
+  AGENT_FILE_SOURCES: {
+    test_agent: {
+      disk: { root: "backend/agents/test_agent", includeDirs: ["upload", "outputs"] },
+    },
+  },
+}));
+
+const AGENT_ROOT = "backend/agents/test_agent";
+const UPLOAD_DIR = `${AGENT_ROOT}/upload`;
+
+let tmp: string;
+let route: typeof import("./route");
+
+function uploadReq(form: FormData): NextRequest {
+  return new NextRequest("http://localhost/api/files/upload", { method: "POST", body: form });
+}
+
+/** Build a multipart form; the dir goes in the "path" field, files in "file". */
+function makeForm(dir: string | null, files: File[]): FormData {
+  const form = new FormData();
+  if (dir !== null) form.append("path", dir);
+  for (const file of files) form.append("file", file);
+  return form;
+}
+
+beforeAll(async () => {
+  tmp = await fs.mkdtemp(path.join(os.tmpdir(), "files-api-upload-"));
+  await fs.mkdir(path.join(tmp, AGENT_ROOT, "upload"), { recursive: true });
+  // REPO_ROOT is computed from cwd at _lib import time: spy first, import after.
+  vi.spyOn(process, "cwd").mockReturnValue(path.join(tmp, "frontend"));
+  route = await import("./route");
+});
+
+afterAll(async () => {
+  vi.restoreAllMocks();
+  await fs.rm(tmp, { recursive: true, force: true });
+});
+
+describe("POST /api/files/upload", () => {
+  it("400 for a non-multipart body", async () => {
+    const res = await route.POST(
+      new NextRequest("http://localhost/api/files/upload", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ path: UPLOAD_DIR }),
+      })
+    );
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Expected multipart/form-data" });
+  });
+
+  it("400 when the 'path' (target dir) field is missing or empty", async () => {
+    for (const dir of [null, ""]) {
+      const res = await route.POST(uploadReq(makeForm(dir, [new File(["x"], "ok.md")])));
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({ error: "Missing 'path' field" });
+    }
+  });
+
+  it("400 when no files are provided (string entries don't count)", async () => {
+    const res = await route.POST(uploadReq(makeForm(UPLOAD_DIR, [])));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "No files provided" });
+
+    const formWithString = makeForm(UPLOAD_DIR, []);
+    formWithString.append("file", "not-a-file");
+    const res2 = await route.POST(uploadReq(formWithString));
+    expect(res2.status).toBe(400);
+    expect(await res2.json()).toEqual({ error: "No files provided" });
+  });
+
+  it("rejects disallowed extensions per file", async () => {
+    const res = await route.POST(uploadReq(makeForm(UPLOAD_DIR, [new File(["mz"], "virus.exe")])));
+    expect(res.status).toBe(400); // all files rejected → 400
+    expect(await res.json()).toEqual({
+      uploaded: [],
+      errors: [{ name: "virus.exe", reason: "Unsupported extension: .exe" }],
+    });
+  });
+
+  it("rejects files over the 10 MB limit", async () => {
+    const big = new File([new Uint8Array(10 * 1024 * 1024 + 1)], "big.md");
+    const res = await route.POST(uploadReq(makeForm(UPLOAD_DIR, [big])));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      uploaded: [],
+      errors: [{ name: "big.md", reason: "File exceeds 10 MB limit" }],
+    });
+  });
+
+  it("rejects filenames with path separators or a leading dot", async () => {
+    // Names must carry an allowed extension to get past the extension check,
+    // which runs before the filename check.
+    const res = await route.POST(
+      uploadReq(
+        makeForm(UPLOAD_DIR, [
+          new File(["a"], "evil/../x.md"),
+          new File(["b"], "evil\\x.md"),
+          new File(["c"], ".hidden.md"),
+        ])
+      )
+    );
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      uploaded: [],
+      errors: [
+        { name: "evil/../x.md", reason: "Invalid filename" },
+        { name: "evil\\x.md", reason: "Invalid filename" },
+        { name: ".hidden.md", reason: "Invalid filename" },
+      ],
+    });
+  });
+
+  it("checks extension before filename: a bare dotfile reads as an extension", async () => {
+    const res = await route.POST(uploadReq(makeForm(UPLOAD_DIR, [new File(["x"], ".hidden")])));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      uploaded: [],
+      errors: [{ name: ".hidden", reason: "Unsupported extension: .hidden" }],
+    });
+  });
+
+  it("rejects target dirs outside the allowlist with a per-file error", async () => {
+    for (const dir of ["backend/other/upload", `${AGENT_ROOT}/upload/../../../../etc`]) {
+      const res = await route.POST(uploadReq(makeForm(dir, [new File(["x"], "ok.md")])));
+      expect(res.status).toBe(400); // per-file "Forbidden path", not a top-level 403
+      expect(await res.json()).toEqual({
+        uploaded: [],
+        errors: [{ name: "ok.md", reason: "Forbidden path" }],
+      });
+    }
+  });
+
+  it("200 for a mixed batch: uploads good files, reports errors for the rest", async () => {
+    const content = "hello upload";
+    const res = await route.POST(
+      uploadReq(
+        // Trailing slash on the dir is trimmed before building the target path.
+        makeForm(`${UPLOAD_DIR}/`, [new File([content], "ok.md"), new File(["mz"], "virus.exe")])
+      )
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      uploaded: [{ path: `${UPLOAD_DIR}/ok.md`, size: content.length }],
+      errors: [{ name: "virus.exe", reason: "Unsupported extension: .exe" }],
+    });
+    expect(await fs.readFile(path.join(tmp, UPLOAD_DIR, "ok.md"), "utf-8")).toBe(content);
+  });
+});

--- a/frontend/src/app/api/files/write/route.test.ts
+++ b/frontend/src/app/api/files/write/route.test.ts
@@ -1,0 +1,95 @@
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { NextRequest } from "next/server";
+
+// Stable allowlist for tests, independent of the real career_agent config.
+vi.mock("@/app/config/agentFiles", () => ({
+  AGENT_FILE_SOURCES: {
+    test_agent: {
+      disk: { root: "backend/agents/test_agent", includeDirs: ["upload", "outputs"] },
+    },
+  },
+}));
+
+const AGENT_ROOT = "backend/agents/test_agent";
+
+let tmp: string;
+let route: typeof import("./route");
+
+/** Build a PUT request; pass a string to send a raw (possibly invalid-JSON) body. */
+function writeReq(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/files/write", {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  });
+}
+
+beforeAll(async () => {
+  tmp = await fs.mkdtemp(path.join(os.tmpdir(), "files-api-write-"));
+  await fs.mkdir(path.join(tmp, AGENT_ROOT, "upload"), { recursive: true });
+  // REPO_ROOT is computed from cwd at _lib import time: spy first, import after.
+  vi.spyOn(process, "cwd").mockReturnValue(path.join(tmp, "frontend"));
+  route = await import("./route");
+});
+
+afterAll(async () => {
+  vi.restoreAllMocks();
+  await fs.rm(tmp, { recursive: true, force: true });
+});
+
+describe("PUT /api/files/write", () => {
+  it("400 for an invalid JSON body", async () => {
+    const res = await route.PUT(writeReq("not json{"));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid JSON" });
+  });
+
+  it("400 when path or content is missing, or content is not a string", async () => {
+    for (const body of [
+      { content: "x" },
+      { path: `${AGENT_ROOT}/upload/x.md` },
+      { path: `${AGENT_ROOT}/upload/x.md`, content: 42 },
+    ]) {
+      const res = await route.PUT(writeReq(body));
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({ error: "Missing 'path' or 'content'" });
+    }
+  });
+
+  it("403 for ../ traversal escaping the allowlist", async () => {
+    const res = await route.PUT(
+      writeReq({ path: `${AGENT_ROOT}/upload/../../../../etc/pwn`, content: "x" })
+    );
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: "Forbidden path" });
+  });
+
+  it("403 for paths outside the allowlist", async () => {
+    const res = await route.PUT(writeReq({ path: "backend/other/upload/x.md", content: "x" }));
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: "Forbidden path" });
+  });
+
+  it("200 writes utf-8 content, creating nested dirs", async () => {
+    const repoRel = `${AGENT_ROOT}/upload/nested/deep/new.md`;
+    const content = "# Écrit — ✓\n";
+    const res = await route.PUT(writeReq({ path: repoRel, content }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(await fs.readFile(path.join(tmp, repoRel), "utf-8")).toBe(content);
+  });
+
+  it("200 decodes base64 content to exact bytes", async () => {
+    const repoRel = `${AGENT_ROOT}/outputs/raw.bin`;
+    const bytes = Buffer.from([0x00, 0x01, 0x02, 0xfa, 0xff, 0x80]);
+    const res = await route.PUT(
+      writeReq({ path: repoRel, content: bytes.toString("base64"), encoding: "base64" })
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    const onDisk = await fs.readFile(path.join(tmp, repoRel));
+    expect(onDisk.equals(bytes)).toBe(true);
+  });
+});

--- a/frontend/src/app/components/ChatInterface.test.tsx
+++ b/frontend/src/app/components/ChatInterface.test.tsx
@@ -1,0 +1,194 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import { AIMessage, HumanMessage, type BaseMessage } from "@langchain/core/messages";
+import type { Assistant } from "@langchain/langgraph-sdk";
+import { ChatInterface } from "./ChatInterface";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+// ChatInterface owns no composer state — `input`/`setInput` live on the chat
+// context — so the mock hook keeps the input in real React state to make
+// typing, suggestion fills, and post-send clearing observable.
+const sendMessage = vi.fn();
+const stopStream = vi.fn();
+const resumeInterrupt = vi.fn();
+const refreshFiles = vi.fn(async () => {});
+const appendUploadNote = vi.fn();
+
+const ctx: { messages: BaseMessage[]; isLoading: boolean; isThreadLoading: boolean } = {
+  messages: [],
+  isLoading: false,
+  isThreadLoading: false,
+};
+
+function useMockChatContext() {
+  const [input, setInput] = React.useState("");
+  return {
+    stream: null,
+    messages: ctx.messages,
+    isLoading: ctx.isLoading,
+    isThreadLoading: ctx.isThreadLoading,
+    interrupt: undefined,
+    sendMessage,
+    stopStream,
+    resumeInterrupt,
+    input,
+    setInput,
+    focusComposerNonce: 0,
+    refreshFiles,
+    appendUploadNote,
+  };
+}
+
+vi.mock("@/providers/ChatProvider", () => ({
+  useChatContext: () => useMockChatContext(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn(), info: vi.fn() },
+  Toaster: () => null,
+}));
+
+const uploadAgentFilesMock = vi.hoisted(() =>
+  vi.fn(async () => ({ uploaded: [] as { path: string; size: number }[], errors: [] }))
+);
+vi.mock("@/app/lib/uploadFiles", () => ({
+  CAREER_AGENT_UPLOAD_DIR: "backend/agents/career_agent/upload",
+  uploadAgentFiles: uploadAgentFilesMock,
+}));
+
+vi.mock("@/app/components/ChatMessage", () => ({
+  ChatMessage: ({ message }: { message: BaseMessage }) => (
+    <div data-testid="chat-message">{message.id}</div>
+  ),
+}));
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const assistant = { assistant_id: "assistant-1", graph_id: "career_agent" } as unknown as Assistant;
+
+function renderChat() {
+  // use-stick-to-bottom runs for real in every render (ResizeObserver/scrollTo
+  // polyfills come from vitest.setup.ts) — rendering without crashing is the
+  // smoke assertion for it.
+  return render(<ChatInterface assistant={assistant} />);
+}
+
+const composer = () => screen.getByPlaceholderText(/Message NextRole/);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  ctx.messages = [];
+  ctx.isLoading = false;
+  ctx.isThreadLoading = false;
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ChatInterface", () => {
+  it("sends the trimmed composer text on Enter and clears the input", async () => {
+    const user = userEvent.setup();
+    renderChat();
+    const textarea = composer();
+
+    await user.type(textarea, "  hello world  ");
+    await user.keyboard("{Enter}");
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage).toHaveBeenCalledWith("hello world");
+    expect(textarea).toHaveValue("");
+  });
+
+  it("inserts a newline on Shift+Enter instead of sending", async () => {
+    const user = userEvent.setup();
+    renderChat();
+    const textarea = composer();
+
+    await user.type(textarea, "line one");
+    await user.keyboard("{Shift>}{Enter}{/Shift}line two");
+
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(textarea).toHaveValue("line one\nline two");
+  });
+
+  it("disables Send and ignores Enter while the composer is empty or whitespace", async () => {
+    const user = userEvent.setup();
+    renderChat();
+    const sendButton = screen.getByRole("button", { name: "Send" });
+    expect(sendButton).toBeDisabled();
+
+    const textarea = composer();
+    await user.type(textarea, "   ");
+    expect(sendButton).toBeDisabled();
+
+    await user.keyboard("{Enter}");
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(textarea).toHaveValue("   ");
+  });
+
+  it("shows the stop control while streaming and stops the stream on click", async () => {
+    const user = userEvent.setup();
+    ctx.isLoading = true;
+    renderChat();
+
+    expect(screen.getByText(/NextRole is working/)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Send" })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Stop" }));
+    expect(stopStream).toHaveBeenCalledTimes(1);
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("renders one ChatMessage per human/AI message, in order", () => {
+    ctx.messages = [
+      new HumanMessage({ id: "h1", content: "hi" }),
+      new AIMessage({ id: "a1", content: "hello" }),
+    ];
+    renderChat();
+
+    const stubs = screen.getAllByTestId("chat-message");
+    expect(stubs).toHaveLength(2);
+    expect(stubs[0]).toHaveTextContent("h1");
+    expect(stubs[1]).toHaveTextContent("a1");
+    expect(screen.queryByRole("heading", { name: /land your next role/i })).not.toBeInTheDocument();
+  });
+
+  it("shows the welcome empty state and fills the composer from a suggestion chip", async () => {
+    const user = userEvent.setup();
+    renderChat();
+
+    expect(screen.getByRole("heading", { name: /land your next role/i })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /tailor my resume/i }));
+    expect(composer()).toHaveValue("Tailor my resume to a specific job description.");
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("shows the thread-loading placeholder instead of messages or the hero", () => {
+    ctx.isThreadLoading = true;
+    renderChat();
+
+    expect(screen.getByText("Loading…")).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: /land your next role/i })).not.toBeInTheDocument();
+  });
+
+  // COMPOSER_ATTACH_ENABLED is hardcoded to false in the component, so the
+  // hidden file input never renders and the uploadAgentFiles/appendUploadNote
+  // path is unreachable from the composer. Documented here as the flag-off
+  // behavior; the upload flow itself lives in Workspace > Files.
+  it("renders no attach control while the composer paperclip flag is off", () => {
+    renderChat();
+
+    expect(screen.queryByTitle("Attach a file")).not.toBeInTheDocument();
+    expect(document.querySelector('input[type="file"]')).toBeNull();
+    expect(uploadAgentFilesMock).not.toHaveBeenCalled();
+    expect(appendUploadNote).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/components/ChatMessage.test.tsx
+++ b/frontend/src/app/components/ChatMessage.test.tsx
@@ -1,0 +1,171 @@
+import { render, screen } from "@testing-library/react";
+import { AIMessage, HumanMessage } from "@langchain/core/messages";
+import type { BaseMessage } from "@langchain/core/messages";
+import type { AnyStream, SubagentDiscoverySnapshot } from "@langchain/react";
+import { ChatMessage } from "@/app/components/ChatMessage";
+import type { ActionRequest, ToolCall } from "@/app/types/types";
+
+vi.mock("@/app/components/MarkdownContent", () => ({
+  MarkdownContent: ({ content }: { content: string }) => (
+    <div data-testid="markdown">{content}</div>
+  ),
+}));
+
+vi.mock("@/app/components/ToolCallBox", () => ({
+  ToolCallBox: ({
+    toolCall,
+    actionRequest,
+    onResume,
+  }: {
+    toolCall: ToolCall;
+    actionRequest?: ActionRequest;
+    onResume?: (value: unknown) => void;
+  }) => (
+    <div
+      data-testid={`tool-call-box-${toolCall.id}`}
+      data-name={toolCall.name}
+      data-action-request={actionRequest?.name ?? ""}
+      data-has-resume={onResume ? "yes" : "no"}
+    />
+  ),
+}));
+
+vi.mock("@/app/components/SubagentCard", () => ({
+  SubagentCard: ({
+    snapshot,
+    taskToolCall,
+  }: {
+    snapshot: SubagentDiscoverySnapshot;
+    taskToolCall: ToolCall;
+  }) => <div data-testid={`subagent-card-${taskToolCall.id}`} data-snapshot-name={snapshot.name} />,
+}));
+
+vi.mock("@/app/components/SubAgentIndicator", () => ({
+  SubAgentIndicator: ({ subAgent }: { subAgent: { id: string; status: string } }) => (
+    <div data-testid={`subagent-indicator-${subAgent.id}`} data-status={subAgent.status} />
+  ),
+}));
+
+function makeStream(subagents = new Map<string, SubagentDiscoverySnapshot>()): AnyStream {
+  return { subagents } as unknown as AnyStream;
+}
+
+function renderMessage(
+  message: BaseMessage,
+  props: Partial<React.ComponentProps<typeof ChatMessage>> = {}
+) {
+  return render(<ChatMessage message={message} toolCalls={[]} stream={makeStream()} {...props} />);
+}
+
+const toolCall = (overrides: Partial<ToolCall> = {}): ToolCall => ({
+  id: "call-1",
+  name: "internet_search",
+  args: { query: "acme" },
+  status: "completed",
+  ...overrides,
+});
+
+describe("ChatMessage", () => {
+  it("renders a human message as a plain user bubble", () => {
+    renderMessage(new HumanMessage("Please review my CV"));
+
+    const text = screen.getByText("Please review my CV");
+    expect(text.tagName).toBe("P");
+    // User text is not routed through MarkdownContent and gets no avatar.
+    expect(screen.queryByTestId("markdown")).not.toBeInTheDocument();
+    expect(screen.queryByAltText("NextRole")).not.toBeInTheDocument();
+  });
+
+  it("renders AI text through MarkdownContent with the avatar", () => {
+    renderMessage(new AIMessage("## Summary\nLooks solid overall."));
+
+    expect(screen.getByTestId("markdown")).toHaveTextContent("Summary Looks solid overall.");
+    expect(screen.getByAltText("NextRole")).toBeInTheDocument();
+  });
+
+  it("renders one ToolCallBox per non-task tool call", () => {
+    renderMessage(new AIMessage(""), {
+      toolCalls: [
+        toolCall({ id: "a1", name: "internet_search" }),
+        toolCall({ id: "b2", name: "read_file", args: { path: "/x" } }),
+      ],
+    });
+
+    expect(screen.getByTestId("tool-call-box-a1")).toHaveAttribute("data-name", "internet_search");
+    expect(screen.getByTestId("tool-call-box-b2")).toHaveAttribute("data-name", "read_file");
+  });
+
+  it("routes the action request to the tool call box whose tool name matches", () => {
+    const actionRequest: ActionRequest = { name: "write_file", args: { path: "/tmp/a.md" } };
+    const onResumeInterrupt = vi.fn();
+    renderMessage(new AIMessage(""), {
+      toolCalls: [
+        toolCall({ id: "a1", name: "write_file", status: "interrupted" }),
+        toolCall({ id: "b2", name: "execute" }),
+      ],
+      actionRequestsMap: new Map([["write_file", actionRequest]]),
+      onResumeInterrupt,
+    });
+
+    // actionRequestsMap is keyed by tool NAME in the component, so the
+    // write_file box gets the request and every box receives onResume.
+    const interrupted = screen.getByTestId("tool-call-box-a1");
+    expect(interrupted).toHaveAttribute("data-action-request", "write_file");
+    expect(interrupted).toHaveAttribute("data-has-resume", "yes");
+    expect(screen.getByTestId("tool-call-box-b2")).toHaveAttribute("data-action-request", "");
+  });
+
+  it("renders a SubagentCard for a task call once its discovery snapshot exists", () => {
+    const task = toolCall({
+      id: "task-1",
+      name: "task",
+      args: { subagent_type: "researcher", description: "Dig into Acme" },
+      status: "pending",
+    });
+    const snapshot = { id: "task-1", name: "researcher" } as SubagentDiscoverySnapshot;
+    renderMessage(new AIMessage(""), {
+      toolCalls: [task],
+      stream: makeStream(new Map([["task-1", snapshot]])),
+    });
+
+    expect(screen.getByTestId("subagent-card-task-1")).toHaveAttribute(
+      "data-snapshot-name",
+      "researcher"
+    );
+    // Task calls never render as plain tool call boxes.
+    expect(screen.queryByTestId("tool-call-box-task-1")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("subagent-indicator-task-1")).not.toBeInTheDocument();
+  });
+
+  it("renders a queued SubAgentIndicator for a task call before discovery lands", () => {
+    const task = toolCall({
+      id: "task-1",
+      name: "task",
+      args: { subagent_type: "researcher" },
+      status: "pending",
+    });
+    renderMessage(new AIMessage(""), { toolCalls: [task] });
+
+    expect(screen.getByTestId("subagent-indicator-task-1")).toHaveAttribute(
+      "data-status",
+      "pending"
+    );
+    expect(screen.queryByTestId("subagent-card-task-1")).not.toBeInTheDocument();
+  });
+
+  it("ignores task calls that have no subagent_type yet", () => {
+    renderMessage(new AIMessage(""), {
+      toolCalls: [toolCall({ id: "task-1", name: "task", args: {} })],
+    });
+
+    expect(screen.queryByTestId("subagent-card-task-1")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("subagent-indicator-task-1")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("tool-call-box-task-1")).not.toBeInTheDocument();
+  });
+
+  it("shows the thinking indicator while loading with no content or tool calls", () => {
+    renderMessage(new AIMessage(""), { isLoading: true });
+
+    expect(screen.getByText("Working through your request")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/components/FileViewDialog.test.tsx
+++ b/frontend/src/app/components/FileViewDialog.test.tsx
@@ -1,0 +1,227 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { SWRConfig } from "swr";
+import { PRINT_FILE_STORAGE_KEY, parsePayload } from "@/app/print/file/printPayload";
+import type { FileItem } from "@/app/types/types";
+import { FileViewDialog } from "./FileViewDialog";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+// The component loads mammoth via `await import("mammoth")`; vi.mock also
+// intercepts dynamic imports, so this factory is what that await resolves to.
+const convertToHtml = vi.hoisted(() =>
+  vi.fn(async (_input: { arrayBuffer: ArrayBuffer }) => ({ value: "<p>docx html</p>" }))
+);
+vi.mock("mammoth", () => ({ convertToHtml }));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn(), info: vi.fn() },
+  Toaster: () => null,
+}));
+
+vi.mock("@/app/components/MarkdownContent", () => ({
+  MarkdownContent: ({ content }: { content: string }) => (
+    <div data-testid="markdown-content">{content}</div>
+  ),
+}));
+
+// react-syntax-highlighter drags in a large grammar bundle; the dialog only
+// needs "a code renderer" for non-markdown text files.
+vi.mock("react-syntax-highlighter", () => ({
+  Prism: ({ children }: { children: string }) => (
+    <pre data-testid="syntax-highlighter">{children}</pre>
+  ),
+}));
+vi.mock("react-syntax-highlighter/dist/esm/styles/prism", () => ({ oneDark: {} }));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function renderDialog(file: FileItem | null, overrides: { editDisabled?: boolean } = {}) {
+  const onSaveFile = vi.fn(async () => {});
+  const onDelete = vi.fn();
+  const onClose = vi.fn();
+  render(
+    // Fresh SWR cache per test — useSWRMutation drives the save flow.
+    <SWRConfig value={{ provider: () => new Map() }}>
+      <FileViewDialog
+        file={file}
+        onSaveFile={onSaveFile}
+        onDelete={onDelete}
+        onClose={onClose}
+        editDisabled={overrides.editDisabled ?? false}
+      />
+    </SWRConfig>
+  );
+  return { onSaveFile, onDelete, onClose };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  sessionStorage.clear();
+  document.title = "";
+  // The print flow appends its iframe to document.body, outside the RTL
+  // container — RTL cleanup won't remove it.
+  document.querySelectorAll("iframe").forEach((el) => el.remove());
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("FileViewDialog", () => {
+  it("renders markdown files through MarkdownContent", () => {
+    renderDialog({ path: "research/notes.md", content: "# Hello" });
+
+    expect(screen.getByTestId("markdown-content")).toHaveTextContent("# Hello");
+    // Path appears in both the sr-only dialog title and the visible header.
+    expect(screen.getAllByText("research/notes.md").length).toBeGreaterThan(0);
+  });
+
+  it("renders non-markdown text files through the syntax highlighter", () => {
+    renderDialog({ path: "scripts/tool.py", content: "print(1)" });
+
+    expect(screen.getByTestId("syntax-highlighter")).toHaveTextContent("print(1)");
+  });
+
+  it("saves edited content through onSaveFile and leaves edit mode", async () => {
+    const user = userEvent.setup();
+    const { onSaveFile } = renderDialog({ path: "notes.md", content: "# Hello" });
+
+    await user.click(screen.getByRole("button", { name: "Edit" }));
+    const textarea = screen.getByPlaceholderText("Enter file content...");
+    expect(textarea).toHaveValue("# Hello");
+
+    const saveButton = screen.getByRole("button", { name: "Save" });
+    await user.clear(textarea);
+    expect(saveButton).toBeDisabled();
+
+    await user.type(textarea, "updated body");
+    expect(saveButton).toBeEnabled();
+    await user.click(saveButton);
+
+    await waitFor(() => expect(onSaveFile).toHaveBeenCalledWith("notes.md", "updated body"));
+    expect(onSaveFile).toHaveBeenCalledTimes(1);
+    await waitFor(() =>
+      expect(screen.queryByPlaceholderText("Enter file content...")).not.toBeInTheDocument()
+    );
+  });
+
+  it("renders image files as a base64 data-URL <img> and disables editing", () => {
+    renderDialog({ path: "upload/pic.png", content: "iVBORw0KGgoAAA" });
+
+    const img = screen.getByAltText("upload/pic.png");
+    const src = img.getAttribute("src") ?? "";
+    expect(src.startsWith("data:image/png;base64,")).toBe(true);
+    expect(src).toBe("data:image/png;base64,iVBORw0KGgoAAA");
+    expect(screen.getByRole("button", { name: "Edit" })).toBeDisabled();
+    expect(screen.queryByRole("button", { name: "Print" })).not.toBeInTheDocument();
+  });
+
+  it("decodes docx base64 into the exact bytes for mammoth and renders the HTML", async () => {
+    const bytes = [0x50, 0x4b, 0x03, 0x04, 0x00, 0xff, 0x10, 0x80];
+    const b64 = btoa(String.fromCharCode(...bytes));
+    renderDialog({ path: "upload/resume.docx", content: b64 });
+
+    expect(await screen.findByText("docx html")).toBeInTheDocument();
+    expect(convertToHtml).toHaveBeenCalledTimes(1);
+    const arg = convertToHtml.mock.calls[0][0];
+    expect(arg.arrayBuffer).toBeInstanceOf(ArrayBuffer);
+    expect(Array.from(new Uint8Array(arg.arrayBuffer))).toEqual(bytes);
+  });
+
+  it("stores a print payload and opens a hidden /print/file iframe on Print", async () => {
+    const user = userEvent.setup();
+    renderDialog({ path: "research/acme/notes.md", content: "# Hello\n\nBody." });
+
+    await user.click(screen.getByRole("button", { name: "Print" }));
+
+    const payload = parsePayload(sessionStorage.getItem(PRINT_FILE_STORAGE_KEY));
+    expect(payload).toEqual({
+      path: "research/acme/notes.md",
+      kind: "markdown",
+      content: "# Hello\n\nBody.",
+    });
+
+    const iframe = document.querySelector('iframe[src="/print/file"]');
+    expect(iframe).not.toBeNull();
+    expect(iframe?.getAttribute("aria-hidden")).toBe("true");
+    // Top-level title becomes the suggested print filename (slashes → dashes,
+    // extension stripped). Deliberately not awaiting the iframe load — jsdom
+    // never navigates it.
+    expect(document.title).toBe("research-acme-notes");
+  });
+
+  it("prints docx files using the converted HTML as the payload", async () => {
+    const user = userEvent.setup();
+    const b64 = btoa(String.fromCharCode(1, 2, 3));
+    renderDialog({ path: "upload/resume.docx", content: b64 });
+    await screen.findByText("docx html");
+
+    await user.click(screen.getByRole("button", { name: "Print" }));
+
+    const payload = parsePayload(sessionStorage.getItem(PRINT_FILE_STORAGE_KEY));
+    expect(payload).toEqual({
+      path: "upload/resume.docx",
+      kind: "docx",
+      content: "<p>docx html</p>",
+    });
+  });
+
+  it("downloads text files through a temporary object URL", async () => {
+    const user = userEvent.setup();
+    // jsdom has no URL.createObjectURL; install a cheap stub and restore after.
+    const urlStatics = URL as unknown as Record<string, unknown>;
+    const originalCreate = urlStatics.createObjectURL;
+    const originalRevoke = urlStatics.revokeObjectURL;
+    const createObjectURL = vi.fn((_blob: Blob) => "blob:mock-url");
+    const revokeObjectURL = vi.fn();
+    urlStatics.createObjectURL = createObjectURL;
+    urlStatics.revokeObjectURL = revokeObjectURL;
+    let downloadName = "";
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(function (
+      this: HTMLAnchorElement
+    ) {
+      downloadName = this.download;
+    });
+
+    try {
+      renderDialog({ path: "research/notes.md", content: "# Hello" });
+      await user.click(screen.getByRole("button", { name: "Download" }));
+
+      expect(createObjectURL).toHaveBeenCalledTimes(1);
+      expect(createObjectURL.mock.calls[0][0]).toBeInstanceOf(Blob);
+      expect(clickSpy).toHaveBeenCalledTimes(1);
+      expect(downloadName).toBe("notes.md");
+      expect(revokeObjectURL).toHaveBeenCalledWith("blob:mock-url");
+    } finally {
+      clickSpy.mockRestore();
+      if (originalCreate === undefined) delete urlStatics.createObjectURL;
+      else urlStatics.createObjectURL = originalCreate;
+      if (originalRevoke === undefined) delete urlStatics.revokeObjectURL;
+      else urlStatics.revokeObjectURL = originalRevoke;
+    }
+  });
+
+  it("renders pdf files in an embedded data-URL iframe without a Print action", () => {
+    renderDialog({ path: "upload/cv.pdf", content: "JVBERi0=" });
+
+    const frame = screen.getByTitle("upload/cv.pdf");
+    expect(frame.tagName).toBe("IFRAME");
+    expect(frame.getAttribute("src")).toBe("data:application/pdf;base64,JVBERi0=");
+    expect(screen.queryByRole("button", { name: "Print" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Edit" })).toBeDisabled();
+  });
+
+  it("shows the empty-file placeholder", () => {
+    renderDialog({ path: "empty.md", content: "" });
+
+    expect(screen.getByText("File is empty")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/components/FileViewDialog.tsx
+++ b/frontend/src/app/components/FileViewDialog.tsx
@@ -11,7 +11,11 @@ import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { oneDark } from "react-syntax-highlighter/dist/esm/styles/prism";
 import { toast } from "sonner";
 import { MarkdownContent } from "@/app/components/MarkdownContent";
-import { PRINT_FILE_STORAGE_KEY, type PrintKind, type PrintPayload } from "@/app/print/file/page";
+import {
+  PRINT_FILE_STORAGE_KEY,
+  type PrintKind,
+  type PrintPayload,
+} from "@/app/print/file/printPayload";
 import type { FileItem } from "@/app/types/types";
 import useSWRMutation from "swr/mutation";
 

--- a/frontend/src/app/components/MarkdownContent.test.tsx
+++ b/frontend/src/app/components/MarkdownContent.test.tsx
@@ -1,0 +1,98 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MarkdownContent } from "@/app/components/MarkdownContent";
+
+// Real react-markdown / remark-gfm / remarkFilePaths run under vitest; only the
+// file-preview context is mocked so resolveFile/openFile are controllable.
+const { resolveFile, openFile } = vi.hoisted(() => ({
+  resolveFile: vi.fn<(candidate: string) => string | null>(),
+  openFile: vi.fn<(key: string) => void>(),
+}));
+
+vi.mock("@/providers/FilePreviewProvider", () => ({
+  useFilePreview: () => ({ resolveFile, openFile }),
+}));
+
+beforeEach(() => {
+  resolveFile.mockReset().mockReturnValue(null);
+  openFile.mockReset();
+});
+
+describe("MarkdownContent", () => {
+  it("renders GFM tables as real <table> markup", () => {
+    render(<MarkdownContent content={"| Col A | Col B |\n| --- | --- |\n| 1 | 2 |"} />);
+
+    expect(screen.getByRole("table")).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "Col A" })).toBeInTheDocument();
+    expect(screen.getByRole("cell", { name: "2" })).toBeInTheDocument();
+  });
+
+  it("turns a resolvable bare file path into a file-link button that opens the file", async () => {
+    const user = userEvent.setup();
+    resolveFile.mockImplementation((candidate) =>
+      candidate === "/processed/cv.md" ? "processed/cv.md" : null
+    );
+    const { container } = render(
+      <MarkdownContent content="See /processed/cv.md for the parsed resume." />
+    );
+
+    const fileLink = screen.getByRole("button", { name: "/processed/cv.md" });
+    expect(fileLink).toHaveAttribute("title", "Open file");
+    // The sentinel scheme never reaches the DOM as an anchor.
+    expect(container.querySelector("a")).toBeNull();
+
+    await user.click(fileLink);
+    expect(openFile).toHaveBeenCalledTimes(1);
+    expect(openFile).toHaveBeenCalledWith("processed/cv.md");
+  });
+
+  it("renders an unresolvable path as plain text with no anchor and no leaked scheme", () => {
+    const { container } = render(<MarkdownContent content="See /procesed/cv.md for details." />);
+
+    expect(container.textContent).toContain("See /procesed/cv.md for details.");
+    expect(container.querySelector("a")).toBeNull();
+    expect(container.querySelector('[href*="nextrole-file"]')).toBeNull();
+    expect(screen.queryByTitle("Open file")).not.toBeInTheDocument();
+    expect(openFile).not.toHaveBeenCalled();
+  });
+
+  it("renders regular https links as new-tab anchors with rel protection", () => {
+    render(<MarkdownContent content="[Example](https://example.com/jobs)" />);
+
+    const link = screen.getByRole("link", { name: "Example" });
+    expect(link).toHaveAttribute("href", "https://example.com/jobs");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("turns inline code naming a resolvable file into a file link", async () => {
+    const user = userEvent.setup();
+    resolveFile.mockImplementation((candidate) =>
+      candidate === "/processed/cv.md" ? "processed/cv.md" : null
+    );
+    render(<MarkdownContent content={"Open `/processed/cv.md` to review."} />);
+
+    const fileLink = screen.getByRole("button", { name: "/processed/cv.md" });
+    expect(fileLink).toHaveAttribute("title", "Open file");
+
+    await user.click(fileLink);
+    expect(openFile).toHaveBeenCalledWith("processed/cv.md");
+  });
+
+  it("renders inline code that does not resolve as a plain <code> element", () => {
+    const { container } = render(<MarkdownContent content={"Run `pnpm dev` locally."} />);
+
+    const code = container.querySelector("code");
+    expect(code).not.toBeNull();
+    expect(code).toHaveTextContent("pnpm dev");
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("renders fenced code blocks through the syntax highlighter", () => {
+    const { container } = render(<MarkdownContent content={"```js\nconst x = 1;\n```"} />);
+
+    const highlighted = container.querySelector("code.language-js");
+    expect(highlighted).not.toBeNull();
+    expect(highlighted!.textContent).toContain("const x = 1;");
+  });
+});

--- a/frontend/src/app/components/SubagentCard.test.tsx
+++ b/frontend/src/app/components/SubagentCard.test.tsx
@@ -1,0 +1,174 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { AIMessageChunk } from "@langchain/core/messages";
+import { useMessages, useToolCalls } from "@langchain/react";
+import type { AnyStream, AssembledToolCall, SubagentDiscoverySnapshot } from "@langchain/react";
+import { SubagentCard } from "@/app/components/SubagentCard";
+import type { ToolCall } from "@/app/types/types";
+
+// Keep everything real except the scoped selector hooks the card subscribes with.
+vi.mock("@langchain/react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@langchain/react")>();
+  return { ...actual, useToolCalls: vi.fn(), useMessages: vi.fn() };
+});
+
+const stream = {} as AnyStream;
+
+function makeSnapshot(overrides: Partial<SubagentDiscoverySnapshot> = {}) {
+  return {
+    id: "task-1",
+    name: "researcher",
+    namespace: ["task-1"],
+    parentId: null,
+    depth: 1,
+    status: "running",
+    taskInput: "Research Acme",
+    output: undefined,
+    error: undefined,
+    startedAt: new Date("2026-07-01T10:00:00Z"),
+    completedAt: null,
+    ...overrides,
+  } as SubagentDiscoverySnapshot;
+}
+
+const taskToolCall: ToolCall = {
+  id: "task-1",
+  name: "task",
+  args: { subagent_type: "researcher", description: "Research Acme Corp" },
+  status: "pending",
+};
+
+// The instantiation useToolCalls' mocked return type expects.
+type CardToolCall = AssembledToolCall<string, Record<string, any>, never>;
+
+function assembled(overrides: Partial<CardToolCall> = {}): CardToolCall {
+  return {
+    id: "nested-1",
+    callId: "nested-1",
+    name: "internet_search",
+    namespace: ["task-1"],
+    args: { query: "acme" },
+    input: { query: "acme" },
+    status: "finished",
+    output: { type: "tool", content: "10 results" },
+    error: undefined,
+    ...overrides,
+  } as CardToolCall;
+}
+
+function renderCard(snapshot = makeSnapshot()) {
+  return render(<SubagentCard stream={stream} snapshot={snapshot} taskToolCall={taskToolCall} />);
+}
+
+beforeEach(() => {
+  vi.mocked(useToolCalls).mockReturnValue([]);
+  vi.mocked(useMessages).mockReturnValue([]);
+});
+
+describe("SubagentCard", () => {
+  it.each([
+    ["running", "Running"],
+    ["complete", "Complete"],
+    ["error", "Failed"],
+  ] as const)("maps snapshot status %s to the %s indicator label", (status, label) => {
+    renderCard(makeSnapshot({ status }));
+
+    expect(screen.getByText(label)).toBeInTheDocument();
+  });
+
+  it("renders the subagent name and the task description as the input", () => {
+    renderCard();
+
+    expect(screen.getByText("researcher")).toBeInTheDocument();
+    // extractSubAgentContent prefers args.description for the Input panel.
+    expect(screen.getByText("Input")).toBeInTheDocument();
+    expect(screen.getByText("Research Acme Corp")).toBeInTheDocument();
+  });
+
+  it("renders the unwrapped tool payload in the output section", () => {
+    const { container } = renderCard(
+      makeSnapshot({
+        status: "complete",
+        output: { type: "tool", content: "Final research summary." },
+        completedAt: new Date("2026-07-01T10:05:00Z"),
+      })
+    );
+
+    expect(screen.getByText("Output")).toBeInTheDocument();
+    expect(screen.getByText("Final research summary.")).toBeInTheDocument();
+    // The ToolMessage envelope must not leak into the panel.
+    expect(container.textContent).not.toContain('"type"');
+  });
+
+  it("starts expanded and collapses/re-expands via the indicator", async () => {
+    const user = userEvent.setup();
+    renderCard();
+
+    expect(screen.getByText("Input")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /researcher/ }));
+    expect(screen.queryByText("Input")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /researcher/ }));
+    expect(screen.getByText("Input")).toBeInTheDocument();
+  });
+
+  it("renders nested tool calls from the tools channel, excluding nested task calls", () => {
+    vi.mocked(useToolCalls).mockReturnValue([
+      assembled(),
+      assembled({ id: "nested-2", callId: "nested-2", name: "task", status: "running" }),
+    ]);
+    renderCard();
+
+    expect(screen.getByText("Activity")).toBeInTheDocument();
+    expect(screen.getByText("internet_search")).toBeInTheDocument();
+    // The nested "task" call is filtered out of the activity list.
+    expect(screen.queryByText("task")).not.toBeInTheDocument();
+  });
+
+  it("shows still-streaming calls from message chunks without duplicating started ones", () => {
+    vi.mocked(useToolCalls).mockReturnValue([assembled()]);
+    vi.mocked(useMessages).mockReturnValue([
+      new AIMessageChunk({
+        content: "",
+        tool_call_chunks: [
+          // Already assembled on the tools channel — must not duplicate.
+          {
+            id: "nested-1",
+            name: "internet_search",
+            args: "{}",
+            index: 0,
+            type: "tool_call_chunk",
+          },
+          // Args still streaming — appears as a pending call.
+          {
+            id: "stream-1",
+            name: "read_file",
+            args: '{"path": "/pro',
+            index: 1,
+            type: "tool_call_chunk",
+          },
+        ],
+      }),
+    ]);
+    const { container } = renderCard();
+
+    expect(screen.getAllByText("internet_search")).toHaveLength(1);
+    expect(screen.getByText("read_file")).toBeInTheDocument();
+    // The streaming call renders in the pending state (spinner rail node).
+    expect(container.querySelector(".animate-spin")).not.toBeNull();
+  });
+
+  it("falls back to the task tool call result when the snapshot has no output", () => {
+    render(
+      <SubagentCard
+        stream={stream}
+        snapshot={makeSnapshot({ status: "complete" })}
+        taskToolCall={{ ...taskToolCall, status: "completed", result: "Task wrapped up." }}
+      />
+    );
+
+    expect(screen.getByText("Output")).toBeInTheDocument();
+    expect(screen.getByText("Task wrapped up.")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/components/TasksFilesSidebar.test.tsx
+++ b/frontend/src/app/components/TasksFilesSidebar.test.tsx
@@ -1,0 +1,279 @@
+import { act, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { TodoItem } from "@/app/types/types";
+import { TasksFilesSidebar } from "./TasksFilesSidebar";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const toast = vi.hoisted(() => ({
+  success: vi.fn(),
+  error: vi.fn(),
+  warning: vi.fn(),
+  info: vi.fn(),
+}));
+vi.mock("sonner", () => ({ toast, Toaster: () => null }));
+
+const removeFile = vi.fn(async (_path: string) => {});
+const removeFiles = vi.fn(async (paths: string[]) => ({
+  deleted: paths,
+  errors: [] as { path: string; reason: string }[],
+}));
+const chatCtx: {
+  isLoading: boolean;
+  interrupt: unknown;
+  removeFile: typeof removeFile;
+  removeFiles: typeof removeFiles;
+} = { isLoading: false, interrupt: undefined, removeFile, removeFiles };
+
+vi.mock("@/providers/ChatProvider", () => ({
+  useChatContext: () => chatCtx,
+}));
+
+// Stub the (heavy, Radix-dialog) file viewer; capture its props so open-file
+// and save wiring can be asserted.
+let dialogProps: {
+  file: { path: string; content: string } | null;
+  onSaveFile: (name: string, content: string) => Promise<void>;
+  onDelete?: (name: string) => void;
+  onClose: () => void;
+  editDisabled: boolean;
+} | null = null;
+vi.mock("@/app/components/FileViewDialog", () => ({
+  FileViewDialog: (props: NonNullable<typeof dialogProps>) => {
+    dialogProps = props;
+    return <div data-testid="file-view-dialog">{props.file?.path}</div>;
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const PATH_RESUME = "tailored_resume/acme/resume.md";
+const PATH_RESEARCH = "research/acme/company.md";
+const PATH_UPLOAD = "upload/cv.pdf";
+const PATH_LOOSE = "scratch/notes.txt"; // no matching FILE_CATEGORIES prefix
+
+const FILES: Record<string, string> = {
+  [PATH_RESUME]: "resume body",
+  [PATH_RESEARCH]: "research body",
+  [PATH_UPLOAD]: "JVBERi0=",
+  [PATH_LOOSE]: "loose note",
+};
+
+const setFiles = vi.fn(async () => {});
+
+function renderSidebar(overrides: { todos?: TodoItem[]; files?: Record<string, string> } = {}) {
+  return render(
+    <TasksFilesSidebar
+      todos={overrides.todos ?? []}
+      files={overrides.files ?? FILES}
+      setFiles={setFiles}
+    />
+  );
+}
+
+type User = ReturnType<typeof userEvent.setup>;
+
+async function openFilesPanel(user: User) {
+  await user.click(screen.getByRole("button", { name: "Toggle files panel" }));
+}
+
+async function selectTwoAndConfirmDelete(user: User) {
+  await openFilesPanel(user);
+  await user.click(screen.getByRole("checkbox", { name: `Select ${PATH_RESUME}` }));
+  await user.click(screen.getByRole("checkbox", { name: `Select ${PATH_RESEARCH}` }));
+  // Toolbar Delete (the per-card buttons are named "Delete <path>").
+  await user.click(screen.getByRole("button", { name: "Delete" }));
+  const dialog = await screen.findByRole("dialog");
+  expect(within(dialog).getByText("Delete 2 files?")).toBeInTheDocument();
+  await user.click(within(dialog).getByRole("button", { name: "Delete" }));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  chatCtx.isLoading = false;
+  chatCtx.interrupt = undefined;
+  dialogProps = null;
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("TasksFilesSidebar", () => {
+  // NOTE: files are NOT grouped under category headings — the grid is flat.
+  // getFileCategory only drives the per-card color; unknown top-level dirs
+  // fall back to the neutral text color.
+  it("renders every file as a card, color-bucketed by path category", async () => {
+    const user = userEvent.setup();
+    renderSidebar();
+
+    // Files panel starts collapsed when files exist at mount.
+    expect(screen.queryByTitle(PATH_RESUME)).not.toBeInTheDocument();
+    await openFilesPanel(user);
+
+    for (const path of Object.keys(FILES)) {
+      expect(screen.getByTitle(path)).toBeInTheDocument();
+    }
+
+    const resumeCard = screen.getByTitle(PATH_RESUME);
+    expect(within(resumeCard).getByText("resume")).toBeInTheDocument();
+    expect(within(resumeCard).getByText("tailored_resume/acme/")).toBeInTheDocument();
+    expect(within(resumeCard).getByText("MD")).toHaveStyle({ color: "var(--color-primary)" });
+
+    const researchCard = screen.getByTitle(PATH_RESEARCH);
+    expect(within(researchCard).getByText("MD")).toHaveStyle({
+      color: "var(--color-category-slate)",
+    });
+
+    const uploadCard = screen.getByTitle(PATH_UPLOAD);
+    expect(within(uploadCard).getByText("PDF")).toHaveStyle({
+      color: "var(--color-category-rose)",
+    });
+
+    const looseCard = screen.getByTitle(PATH_LOOSE);
+    expect(within(looseCard).getByText("TXT")).toHaveStyle({ color: "var(--text-secondary)" });
+  });
+
+  it("auto-expands the files panel when files first appear", () => {
+    const { rerender } = renderSidebar({ files: {} });
+    expect(screen.queryByTitle(PATH_UPLOAD)).not.toBeInTheDocument();
+
+    rerender(<TasksFilesSidebar todos={[]} files={FILES} setFiles={setFiles} />);
+
+    expect(screen.getByTitle(PATH_UPLOAD)).toBeInTheDocument();
+  });
+
+  it("shows the files empty state", async () => {
+    const user = userEvent.setup();
+    renderSidebar({ files: {} });
+    await openFilesPanel(user);
+
+    expect(screen.getByText("No files created yet")).toBeInTheDocument();
+  });
+
+  it("opens the FileViewDialog for a clicked file and wires saving back to setFiles", async () => {
+    const user = userEvent.setup();
+    renderSidebar();
+    await openFilesPanel(user);
+
+    await user.click(screen.getByTitle(PATH_RESEARCH));
+
+    expect(screen.getByTestId("file-view-dialog")).toHaveTextContent(PATH_RESEARCH);
+    expect(dialogProps?.file).toEqual({ path: PATH_RESEARCH, content: "research body" });
+    expect(dialogProps?.editDisabled).toBe(false);
+
+    await act(async () => {
+      await dialogProps?.onSaveFile(PATH_RESEARCH, "updated body");
+    });
+    expect(setFiles).toHaveBeenCalledWith({ ...FILES, [PATH_RESEARCH]: "updated body" });
+    expect(dialogProps?.file).toEqual({ path: PATH_RESEARCH, content: "updated body" });
+  });
+
+  it("deletes the selected files after confirmation and clears the selection", async () => {
+    const user = userEvent.setup();
+    renderSidebar();
+
+    await selectTwoAndConfirmDelete(user);
+
+    await waitFor(() => expect(removeFiles).toHaveBeenCalledWith([PATH_RESUME, PATH_RESEARCH]));
+    expect(removeFiles).toHaveBeenCalledTimes(1);
+    expect(removeFile).not.toHaveBeenCalled();
+    await waitFor(() => expect(toast.success).toHaveBeenCalledWith("Deleted 2 files"));
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+    // Selection toolbar gone once nothing is selected.
+    expect(screen.queryByRole("button", { name: "Clear" })).not.toBeInTheDocument();
+  });
+
+  it("shows an error toast and keeps failed paths selected when every delete fails", async () => {
+    const user = userEvent.setup();
+    removeFiles.mockResolvedValueOnce({
+      deleted: [],
+      errors: [
+        { path: PATH_RESUME, reason: "locked" },
+        { path: PATH_RESEARCH, reason: "locked" },
+      ],
+    });
+    renderSidebar();
+
+    await selectTwoAndConfirmDelete(user);
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith("Failed to delete 2 files"));
+    expect(toast.success).not.toHaveBeenCalled();
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+    // Failed paths stay selected so the user can see what's left.
+    expect(screen.getByRole("checkbox", { name: `Deselect ${PATH_RESUME}` })).toBeInTheDocument();
+    expect(screen.getByRole("checkbox", { name: `Deselect ${PATH_RESEARCH}` })).toBeInTheDocument();
+  });
+
+  it("shows a warning toast on partial failure and keeps only failed paths selected", async () => {
+    const user = userEvent.setup();
+    removeFiles.mockResolvedValueOnce({
+      deleted: [PATH_RESUME],
+      errors: [{ path: PATH_RESEARCH, reason: "in use" }],
+    });
+    renderSidebar();
+
+    await selectTwoAndConfirmDelete(user);
+
+    await waitFor(() => expect(toast.warning).toHaveBeenCalledWith("Deleted 1 of 2 (1 failed)"));
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+    expect(screen.getByRole("checkbox", { name: `Deselect ${PATH_RESEARCH}` })).toBeInTheDocument();
+    expect(screen.getByRole("checkbox", { name: `Select ${PATH_RESUME}` })).toBeInTheDocument();
+  });
+
+  it("deletes a single file from its card through removeFile", async () => {
+    const user = userEvent.setup();
+    renderSidebar();
+    await openFilesPanel(user);
+
+    await user.click(screen.getByRole("button", { name: `Delete ${PATH_UPLOAD}` }));
+    const dialog = await screen.findByRole("dialog");
+    expect(within(dialog).getByText("Delete file?")).toBeInTheDocument();
+    expect(within(dialog).getByText("cv.pdf")).toBeInTheDocument();
+
+    await user.click(within(dialog).getByRole("button", { name: "Delete" }));
+
+    await waitFor(() => expect(removeFile).toHaveBeenCalledWith(PATH_UPLOAD));
+    await waitFor(() => expect(toast.success).toHaveBeenCalledWith("Deleted cv.pdf"));
+    expect(removeFiles).not.toHaveBeenCalled();
+  });
+
+  it("disables destructive actions while the agent is streaming", async () => {
+    const user = userEvent.setup();
+    chatCtx.isLoading = true;
+    renderSidebar();
+    await openFilesPanel(user);
+
+    expect(screen.getByRole("button", { name: `Delete ${PATH_UPLOAD}` })).toBeDisabled();
+  });
+
+  it("groups tasks under status headings", async () => {
+    const user = userEvent.setup();
+    // The todo-group markup renders a keyless list; silence React's key
+    // warning for this test only.
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      renderSidebar({
+        todos: [
+          { id: "1", content: "Draft resume", status: "pending" },
+          { id: "2", content: "Research Acme", status: "in_progress" },
+          { id: "3", content: "Send follow-up", status: "completed" },
+        ],
+      });
+      await user.click(screen.getByRole("button", { name: "Toggle tasks panel" }));
+
+      expect(screen.getByRole("heading", { name: "Pending", level: 3 })).toBeInTheDocument();
+      expect(screen.getByRole("heading", { name: "In Progress", level: 3 })).toBeInTheDocument();
+      expect(screen.getByRole("heading", { name: "Completed", level: 3 })).toBeInTheDocument();
+      expect(screen.getByText("Draft resume")).toBeInTheDocument();
+      expect(screen.getByText("Research Acme")).toBeInTheDocument();
+      expect(screen.getByText("Send follow-up")).toBeInTheDocument();
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+});

--- a/frontend/src/app/components/ThreadList.test.tsx
+++ b/frontend/src/app/components/ThreadList.test.tsx
@@ -1,0 +1,177 @@
+import type { ComponentProps } from "react";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NuqsTestingAdapter } from "nuqs/adapters/testing";
+import { ThreadList, formatTime } from "@/app/components/ThreadList";
+import { useThreads } from "@/app/hooks/useThreads";
+import type { ThreadItem } from "@/app/hooks/useThreads";
+
+vi.mock("@/app/hooks/useThreads", () => ({ useThreads: vi.fn() }));
+
+const HOUR = 60 * 60 * 1000;
+const DAY = 24 * HOUR;
+
+function threadItem(id: string, overrides: Partial<ThreadItem> = {}): ThreadItem {
+  return {
+    id,
+    updatedAt: new Date(Date.now() - HOUR),
+    status: "idle",
+    title: `Thread ${id}`,
+    description: `About ${id}`,
+    ...overrides,
+  };
+}
+
+function swrState(overrides: Record<string, unknown> = {}) {
+  return {
+    data: undefined,
+    error: undefined,
+    isLoading: false,
+    isValidating: false,
+    size: 1,
+    setSize: vi.fn(),
+    mutate: vi.fn(),
+    ...overrides,
+  } as unknown as ReturnType<typeof useThreads>;
+}
+
+function renderList(
+  props: Partial<ComponentProps<typeof ThreadList>> = {},
+  searchParams: string = ""
+) {
+  const onThreadSelect = props.onThreadSelect ?? vi.fn();
+  const utils = render(
+    <NuqsTestingAdapter searchParams={searchParams}>
+      <ThreadList onThreadSelect={onThreadSelect} {...props} />
+    </NuqsTestingAdapter>
+  );
+  return { ...utils, onThreadSelect };
+}
+
+beforeEach(() => {
+  vi.mocked(useThreads).mockReturnValue(swrState());
+});
+
+describe("ThreadList", () => {
+  it("shows loading skeletons while the first page loads", () => {
+    vi.mocked(useThreads).mockReturnValue(swrState({ isLoading: true }));
+    const { container } = renderList();
+
+    expect(container.querySelectorAll(".animate-pulse")).toHaveLength(5);
+  });
+
+  it("shows the error state with the error message", () => {
+    vi.mocked(useThreads).mockReturnValue(swrState({ error: new Error("boom") }));
+    renderList();
+
+    expect(screen.getByText("Failed to load threads")).toBeInTheDocument();
+    expect(screen.getByText("boom")).toBeInTheDocument();
+  });
+
+  it("shows the empty state when the first page has no threads", () => {
+    vi.mocked(useThreads).mockReturnValue(swrState({ data: [[]] }));
+    renderList();
+
+    expect(screen.getByText("No threads found")).toBeInTheDocument();
+    expect(screen.getByText("New conversations will appear here.")).toBeInTheDocument();
+  });
+
+  it("groups threads and renders their titles and descriptions", () => {
+    vi.mocked(useThreads).mockReturnValue(
+      swrState({
+        data: [
+          [
+            threadItem("today", { title: "Fix resume", description: "Tighten the summary" }),
+            threadItem("stuck", { status: "interrupted", title: "Needs input" }),
+            threadItem("old", { updatedAt: new Date(Date.now() - 30 * DAY), title: "Old chat" }),
+          ],
+        ],
+      })
+    );
+    const onInterruptCountChange = vi.fn();
+    renderList({ onInterruptCountChange });
+
+    const groupFor = (label: string) =>
+      screen.getByRole("heading", { name: label }).parentElement as HTMLElement;
+    expect(within(groupFor("Today")).getByText("Fix resume")).toBeInTheDocument();
+    expect(within(groupFor("Today")).getByText("Tighten the summary")).toBeInTheDocument();
+    expect(within(groupFor("Requiring Attention")).getByText("Needs input")).toBeInTheDocument();
+    expect(within(groupFor("Older")).getByText("Old chat")).toBeInTheDocument();
+    expect(onInterruptCountChange).toHaveBeenCalledWith(1);
+  });
+
+  it("passes the selected status filter to useThreads (server-side filtering)", async () => {
+    const user = userEvent.setup();
+    vi.mocked(useThreads).mockReturnValue(swrState({ data: [[threadItem("t-1")]] }));
+    renderList();
+
+    expect(vi.mocked(useThreads)).toHaveBeenCalledWith({ status: undefined, limit: 20 });
+
+    await user.click(screen.getByRole("combobox"));
+    await user.click(await screen.findByRole("option", { name: "Error" }));
+
+    expect(vi.mocked(useThreads)).toHaveBeenLastCalledWith({ status: "error", limit: 20 });
+  });
+
+  it("invokes onThreadSelect with the thread id when a thread is clicked", async () => {
+    const user = userEvent.setup();
+    vi.mocked(useThreads).mockReturnValue(
+      swrState({ data: [[threadItem("t-1"), threadItem("t-2")]] })
+    );
+    const { onThreadSelect } = renderList();
+
+    await user.click(screen.getByRole("button", { name: /Thread t-2/ }));
+
+    expect(onThreadSelect).toHaveBeenCalledTimes(1);
+    expect(onThreadSelect).toHaveBeenCalledWith("t-2");
+  });
+
+  it("marks the thread from the threadId URL param as current", () => {
+    vi.mocked(useThreads).mockReturnValue(
+      swrState({ data: [[threadItem("t-1"), threadItem("t-2")]] })
+    );
+    renderList({}, "?threadId=t-1");
+
+    expect(screen.getByRole("button", { name: /Thread t-1/ })).toHaveAttribute(
+      "aria-current",
+      "true"
+    );
+    expect(screen.getByRole("button", { name: /Thread t-2/ })).toHaveAttribute(
+      "aria-current",
+      "false"
+    );
+  });
+
+  it("loads the next page when Load More is clicked", async () => {
+    const user = userEvent.setup();
+    const setSize = vi.fn();
+    const fullPage = Array.from({ length: 20 }, (_, i) => threadItem(`t-${i}`));
+    vi.mocked(useThreads).mockReturnValue(swrState({ data: [fullPage], size: 1, setSize }));
+    renderList();
+
+    await user.click(screen.getByRole("button", { name: "Load More" }));
+
+    expect(setSize).toHaveBeenCalledWith(2);
+  });
+});
+
+describe("formatTime", () => {
+  // Monday 2026-06-15, mid-day to stay clear of timezone/day edges.
+  const now = new Date(2026, 5, 15, 12, 0, 0);
+
+  it("formats same-day timestamps as HH:mm", () => {
+    expect(formatTime(new Date(2026, 5, 15, 9, 5), now)).toBe("09:05");
+  });
+
+  it('formats one-day-old timestamps as "Yesterday"', () => {
+    expect(formatTime(new Date(2026, 5, 14, 11, 0), now)).toBe("Yesterday");
+  });
+
+  it("formats timestamps within the week as the weekday name", () => {
+    expect(formatTime(new Date(2026, 5, 12, 12, 0), now)).toBe("Friday");
+  });
+
+  it("formats older timestamps as MM/dd", () => {
+    expect(formatTime(new Date(2026, 5, 1, 12, 0), now)).toBe("06/01");
+  });
+});

--- a/frontend/src/app/components/ThreadList.tsx
+++ b/frontend/src/app/components/ThreadList.tsx
@@ -42,7 +42,8 @@ function getThreadColor(status: ThreadItem["status"]): string {
   return STATUS_COLORS[status] ?? "bg-gray-400";
 }
 
-function formatTime(date: Date, now = new Date()): string {
+// eslint-disable-next-line react-refresh/only-export-components -- exported for tests
+export function formatTime(date: Date, now = new Date()): string {
   const diff = now.getTime() - date.getTime();
   const days = Math.floor(diff / (1000 * 60 * 60 * 24));
 

--- a/frontend/src/app/components/ToolApprovalInterrupt.test.tsx
+++ b/frontend/src/app/components/ToolApprovalInterrupt.test.tsx
@@ -1,0 +1,153 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ToolApprovalInterrupt } from "@/app/components/ToolApprovalInterrupt";
+import type { ActionRequest, ReviewConfig } from "@/app/types/types";
+
+const actionRequest: ActionRequest = {
+  name: "write_file",
+  args: { path: "/tmp/draft.md", content: "hello" },
+  description: "The agent wants to write the draft file.",
+};
+
+function renderInterrupt(
+  props: {
+    onResume?: (value: any) => void;
+    reviewConfig?: ReviewConfig;
+    isLoading?: boolean;
+    request?: ActionRequest;
+  } = {}
+) {
+  const onResume = props.onResume ?? vi.fn();
+  render(
+    <ToolApprovalInterrupt
+      actionRequest={props.request ?? actionRequest}
+      reviewConfig={props.reviewConfig}
+      onResume={onResume}
+      isLoading={props.isLoading}
+    />
+  );
+  return { onResume };
+}
+
+describe("ToolApprovalInterrupt", () => {
+  it("renders the header, description, tool name and current arguments", () => {
+    renderInterrupt();
+
+    expect(screen.getByText("Approval Required")).toBeInTheDocument();
+    expect(screen.getByText("The agent wants to write the draft file.")).toBeInTheDocument();
+    expect(screen.getByText("write_file")).toBeInTheDocument();
+    expect(screen.getByText(/"path": "\/tmp\/draft\.md"/)).toBeInTheDocument();
+  });
+
+  it("emits an approve decision when Approve is clicked", async () => {
+    const user = userEvent.setup();
+    const { onResume } = renderInterrupt();
+
+    await user.click(screen.getByRole("button", { name: "Approve" }));
+
+    expect(onResume).toHaveBeenCalledTimes(1);
+    expect(onResume).toHaveBeenCalledWith({ decisions: [{ type: "approve" }] });
+  });
+
+  it("reveals the rejection message input first, then confirms with the trimmed message", async () => {
+    const user = userEvent.setup();
+    const { onResume } = renderInterrupt();
+
+    await user.click(screen.getByRole("button", { name: "Reject" }));
+    // First click only reveals the input; nothing is resumed yet.
+    expect(onResume).not.toHaveBeenCalled();
+    expect(screen.getByText("Rejection Message (optional)")).toBeInTheDocument();
+
+    const textarea = screen.getByPlaceholderText("Explain why you're rejecting this action...");
+    await user.type(textarea, "  too risky  ");
+    await user.click(screen.getByRole("button", { name: "Confirm Reject" }));
+
+    expect(onResume).toHaveBeenCalledWith({
+      decisions: [{ type: "reject", message: "too risky" }],
+    });
+  });
+
+  it("cancels the rejection flow and returns to the decision buttons", async () => {
+    const user = userEvent.setup();
+    const { onResume } = renderInterrupt();
+
+    await user.click(screen.getByRole("button", { name: "Reject" }));
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(onResume).not.toHaveBeenCalled();
+    expect(screen.queryByText("Rejection Message (optional)")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Approve" })).toBeInTheDocument();
+  });
+
+  it("edits arguments and submits an edit decision with the edited_action", async () => {
+    const user = userEvent.setup();
+    const { onResume } = renderInterrupt();
+
+    await user.click(screen.getByRole("button", { name: "Edit" }));
+    expect(screen.getByText("Edit Arguments")).toBeInTheDocument();
+
+    const [pathField, contentField] = screen.getAllByRole("textbox") as HTMLTextAreaElement[];
+    expect(pathField).toHaveValue("/tmp/draft.md");
+    expect(contentField).toHaveValue("hello");
+
+    await user.clear(pathField);
+    await user.type(pathField, "notes/final.md");
+    await user.click(screen.getByRole("button", { name: "Save & Approve" }));
+
+    expect(onResume).toHaveBeenCalledWith({
+      decisions: [
+        {
+          type: "edit",
+          edited_action: {
+            name: "write_file",
+            args: { path: "notes/final.md", content: "hello" },
+          },
+        },
+      ],
+    });
+  });
+
+  it("parses JSON-looking edited values into objects", async () => {
+    const user = userEvent.setup();
+    const { onResume } = renderInterrupt();
+
+    await user.click(screen.getByRole("button", { name: "Edit" }));
+    const [, contentField] = screen.getAllByRole("textbox");
+
+    await user.clear(contentField);
+    await user.click(contentField);
+    await user.paste('{"tone": "formal"}');
+    await user.click(screen.getByRole("button", { name: "Save & Approve" }));
+
+    expect(onResume).toHaveBeenCalledWith({
+      decisions: [
+        {
+          type: "edit",
+          edited_action: {
+            name: "write_file",
+            args: { path: "/tmp/draft.md", content: { tone: "formal" } },
+          },
+        },
+      ],
+    });
+  });
+
+  it("hides reject and edit when the review config only allows approve", () => {
+    renderInterrupt({
+      reviewConfig: { actionName: "write_file", allowedDecisions: ["approve"] },
+    });
+
+    expect(screen.getByRole("button", { name: "Approve" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Reject" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Edit" })).not.toBeInTheDocument();
+  });
+
+  it("disables all controls while loading", () => {
+    renderInterrupt({ isLoading: true });
+
+    // The approve button swaps its label to "Approving..." while loading.
+    expect(screen.getByRole("button", { name: "Approving..." })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Reject" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Edit" })).toBeDisabled();
+  });
+});

--- a/frontend/src/app/components/ToolCallBox.test.tsx
+++ b/frontend/src/app/components/ToolCallBox.test.tsx
@@ -1,0 +1,135 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ToolCallBox } from "@/app/components/ToolCallBox";
+import type { ActionRequest, ToolCall } from "@/app/types/types";
+
+// Note: ToolCallBox no longer imports MarkdownContent (args/result render in
+// plain <pre> blocks since the toolErrors refactor), so no stub is needed.
+
+function call(overrides: Partial<ToolCall> = {}): ToolCall {
+  return {
+    id: "tc-1",
+    name: "internet_search",
+    args: { query: "acme corp" },
+    status: "completed",
+    ...overrides,
+  };
+}
+
+describe("ToolCallBox", () => {
+  it("renders a pending call with the running spinner and no status chip", () => {
+    const { container } = render(<ToolCallBox toolCall={call({ status: "pending" })} />);
+
+    expect(screen.getByText("internet_search")).toBeInTheDocument();
+    // getStatusMeta labels pending as "Running" but with showLabel: false, so
+    // the only running indicator is the spinning rail node — no chip text.
+    expect(container.querySelector(".animate-spin")).not.toBeNull();
+    expect(screen.queryByText("Running")).not.toBeInTheDocument();
+    expect(screen.queryByText(/^Error/)).not.toBeInTheDocument();
+    expect(screen.queryByText("Failed")).not.toBeInTheDocument();
+    expect(screen.queryByText("Needs review")).not.toBeInTheDocument();
+  });
+
+  it("shows a parsed error chip when a completed result carries an error payload", () => {
+    render(
+      <ToolCallBox
+        toolCall={call({
+          status: "completed",
+          result: "Error: {'error': {'code': 429, 'message': 'rate limited'}}",
+        })}
+      />
+    );
+
+    expect(screen.getByText("Error 429")).toBeInTheDocument();
+    expect(screen.getByTitle("Error 429")).toBeInTheDocument();
+  });
+
+  it("shows the needs-review chip for an interrupted call", () => {
+    render(<ToolCallBox toolCall={call({ status: "interrupted" })} />);
+
+    expect(screen.getByText("Needs review")).toBeInTheDocument();
+  });
+
+  it("shows the Failed chip for an error status without a parsable error payload", () => {
+    render(<ToolCallBox toolCall={call({ status: "error", result: "boom" })} />);
+
+    expect(screen.getByText("Failed")).toBeInTheDocument();
+  });
+
+  it("truncates long values in the collapsed preview and expands args on header click", async () => {
+    const user = userEvent.setup();
+    const args = { content: "A".repeat(150) };
+    const expectedPreview = `${JSON.stringify(args).slice(0, 96)}...`;
+    render(<ToolCallBox toolCall={call({ name: "write_file", args, result: undefined })} />);
+
+    // Collapsed: previewValue truncates the stringified args to 96 chars + "...".
+    expect(screen.getByText(expectedPreview)).toBeInTheDocument();
+    expect(screen.queryByText("Arguments")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /write_file/ }));
+
+    expect(screen.getByText("Arguments")).toBeInTheDocument();
+    expect(screen.queryByText(expectedPreview)).not.toBeInTheDocument();
+
+    // Individual args are collapsed behind their key; clicking reveals the full value.
+    await user.click(screen.getByRole("button", { name: "content" }));
+    expect(screen.getByText("A".repeat(150))).toBeInTheDocument();
+  });
+
+  it("renders the result section when expanded", async () => {
+    const user = userEvent.setup();
+    render(<ToolCallBox toolCall={call({ args: {}, result: "done ok" })} />);
+
+    // Completed without an error renders no chip at all.
+    expect(screen.queryByText("Completed")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /internet_search/ }));
+
+    expect(screen.getByText("Result")).toBeInTheDocument();
+    expect(screen.getByText("done ok")).toBeInTheDocument();
+  });
+
+  it("starts expanded with the approval UI when an actionRequest is present", async () => {
+    const user = userEvent.setup();
+    const onResume = vi.fn();
+    const actionRequest: ActionRequest = {
+      name: "write_file",
+      args: { path: "/tmp/draft.md" },
+      description: "Write the draft",
+    };
+    render(
+      <ToolCallBox
+        toolCall={call({ name: "write_file", status: "interrupted", args: { path: "/tmp/x" } })}
+        actionRequest={actionRequest}
+        onResume={onResume}
+      />
+    );
+
+    // Expanded immediately — no click needed — and the approval region renders.
+    expect(screen.getByText("Approval Required")).toBeInTheDocument();
+    expect(screen.getByText("Write the draft")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Approve" }));
+    expect(onResume).toHaveBeenCalledWith({ decisions: [{ type: "approve" }] });
+  });
+
+  it.each([
+    "read_file",
+    "write_todos",
+    "ls",
+    "execute",
+    "grep_search",
+    "generate_social_image",
+    "task",
+    "fetch_url",
+    "mcp_lookup",
+    "totally_unknown_tool",
+  ])("renders the %s tool header with an icon without crashing", (name) => {
+    const { container } = render(
+      <ToolCallBox toolCall={call({ name, args: { input: "x" }, result: "ok" })} />
+    );
+
+    expect(screen.getByText(name)).toBeInTheDocument();
+    expect(container.querySelector("svg")).not.toBeNull();
+  });
+});

--- a/frontend/src/app/components/ToolCallBox.tsx
+++ b/frontend/src/app/components/ToolCallBox.tsx
@@ -25,6 +25,7 @@ import { Button } from "@/components/ui/button";
 import { ToolCall, ActionRequest, ReviewConfig } from "@/app/types/types";
 import { cn } from "@/lib/utils";
 import { ToolApprovalInterrupt } from "@/app/components/ToolApprovalInterrupt";
+import { parseToolError, previewValue } from "@/app/utils/toolErrors";
 
 interface ToolCallBoxProps {
   toolCall: ToolCall;
@@ -48,53 +49,6 @@ const TOOL_ICON_MAP: Array<[RegExp, LucideIcon]> = [
 
 function getToolIcon(name: string): LucideIcon {
   return TOOL_ICON_MAP.find(([pattern]) => pattern.test(name))?.[1] ?? Terminal;
-}
-
-function parseToolError(result: unknown): { code?: string; message?: string } | null {
-  if (result == null) return null;
-
-  // Cap inspection at 256 chars — error markers always appear at the start, and
-  // a long streaming payload here would force a JSON.stringify of the full body.
-  const raw =
-    typeof result === "string"
-      ? result
-      : (() => {
-          try {
-            return JSON.stringify(result);
-          } catch {
-            return "";
-          }
-        })();
-  if (!raw) return null;
-  const text = raw.length > 256 ? raw.slice(0, 256) : raw;
-  const trimmed = text.trim();
-  const startsWithError = /^(error|exception|failed)\b\s*:?\s*/i.test(trimmed);
-  if (!startsWithError) return null;
-
-  const objectStart = trimmed.indexOf("{");
-  if (objectStart !== -1) {
-    try {
-      const parsed = JSON.parse(trimmed.slice(objectStart).replace(/'/g, '"'));
-      const error = parsed?.error ?? parsed;
-      if (error?.code || error?.status || error?.message) {
-        return {
-          code: error.code ? String(error.code) : error.status,
-          message: error.message ? String(error.message) : trimmed,
-        };
-      }
-    } catch {
-      // Fall through to regex detection for Python-style dicts or plain strings.
-    }
-  }
-
-  const codeMatch =
-    trimmed.match(/\bcode['"]?\s*:\s*(\d{3,})/i) ?? trimmed.match(/\b(\d{3})\s+[A-Z_]+\b/);
-  const statusMatch = trimmed.match(/\bstatus['"]?\s*:\s*['"]?([A-Z_]+)/i);
-
-  return {
-    code: codeMatch?.[1] ?? statusMatch?.[1],
-    message: trimmed,
-  };
 }
 
 function getStatusMeta(
@@ -140,23 +94,6 @@ function getStatusMeta(
         className: "border-border bg-muted text-muted-foreground",
         showLabel: true,
       };
-  }
-}
-
-function previewValue(value: unknown): string | null {
-  if (value == null) return null;
-  if (typeof value === "string") {
-    return value.length > 96 ? `${value.slice(0, 96)}...` : value;
-  }
-  // For objects/arrays we only need the first ~96 chars of the stringified form.
-  // JSON.stringify on a large streaming payload here is the dominant cost during
-  // streaming, so guard with try/catch and slice the result.
-  try {
-    const text = JSON.stringify(value);
-    if (!text) return null;
-    return text.length > 96 ? `${text.slice(0, 96)}...` : text;
-  } catch {
-    return null;
   }
 }
 

--- a/frontend/src/app/components/workspace/PlanSection.test.tsx
+++ b/frontend/src/app/components/workspace/PlanSection.test.tsx
@@ -1,0 +1,131 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { PlanSection } from "@/app/components/workspace/PlanSection";
+import type { TodoItem } from "@/app/types/types";
+
+function todo(id: string, status: TodoItem["status"], content = `Task ${id}`): TodoItem {
+  return { id, content, status };
+}
+
+function renderPlan(todos: TodoItem[], props: { open?: boolean; onToggle?: () => void } = {}) {
+  return render(
+    <PlanSection todos={todos} open={props.open ?? true} onToggle={props.onToggle ?? vi.fn()} />
+  );
+}
+
+describe("PlanSection", () => {
+  it("renders the empty state when there are no todos", () => {
+    renderPlan([]);
+
+    expect(screen.getByText("Plan")).toBeInTheDocument();
+    expect(screen.getByText("No tasks yet")).toBeInTheDocument();
+    expect(
+      screen.getByText("The agent's plan will appear here as soon as work starts.")
+    ).toBeInTheDocument();
+    // No progress block and no count badge for an empty plan.
+    expect(screen.queryByText("Progress")).not.toBeInTheDocument();
+    expect(screen.queryByText("0")).not.toBeInTheDocument();
+  });
+
+  it("shows the todo count badge in the header", () => {
+    renderPlan([
+      todo("1", "pending"),
+      todo("2", "in_progress"),
+      todo("3", "completed"),
+      todo("4", "completed"),
+    ]);
+
+    expect(screen.getByText("4")).toBeInTheDocument();
+  });
+
+  it("groups todos by status in the order in_progress, pending, completed", () => {
+    renderPlan([
+      todo("c1", "completed", "Ship the report"),
+      todo("p1", "pending", "Draft the summary"),
+      todo("a1", "in_progress", "Research the company"),
+    ]);
+
+    const headings = screen.getAllByRole("heading", { level: 3 });
+    expect(headings.map((h) => h.textContent)).toEqual(["In Progress", "Pending", "Completed"]);
+
+    // Each todo renders inside its own status group.
+    const groupFor = (label: string) =>
+      screen.getByRole("heading", { level: 3, name: label }).parentElement as HTMLElement;
+    expect(within(groupFor("In Progress")).getByText("Research the company")).toBeInTheDocument();
+    expect(within(groupFor("Pending")).getByText("Draft the summary")).toBeInTheDocument();
+    expect(within(groupFor("Completed")).getByText("Ship the report")).toBeInTheDocument();
+  });
+
+  it("omits status groups that have no todos", () => {
+    renderPlan([todo("1", "completed")]);
+
+    expect(
+      screen.queryByRole("heading", { level: 3, name: "In Progress" })
+    ).not.toBeInTheDocument();
+    expect(screen.queryByRole("heading", { level: 3, name: "Pending" })).not.toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 3, name: "Completed" })).toBeInTheDocument();
+  });
+
+  it("renders the completion percentage (2 of 4 completed renders as 50%)", () => {
+    renderPlan([
+      todo("1", "completed"),
+      todo("2", "completed"),
+      todo("3", "in_progress"),
+      todo("4", "pending"),
+    ]);
+
+    expect(screen.getByText("Progress")).toBeInTheDocument();
+    expect(screen.getByText("50%")).toBeInTheDocument();
+  });
+
+  it("shows the Active pulse badge only while a task is in progress", () => {
+    const { rerender } = renderPlan([todo("1", "in_progress"), todo("2", "completed")]);
+    expect(screen.getByText("Active")).toBeInTheDocument();
+
+    rerender(
+      <PlanSection
+        todos={[todo("1", "completed"), todo("2", "completed")]}
+        open
+        onToggle={vi.fn()}
+      />
+    );
+    expect(screen.queryByText("Active")).not.toBeInTheDocument();
+    expect(screen.getByText("100%")).toBeInTheDocument();
+  });
+
+  it("renders a status icon for every todo row", () => {
+    renderPlan([
+      todo("a", "in_progress"),
+      todo("b", "pending"),
+      todo("c", "completed"),
+      todo("d", "completed"),
+    ]);
+
+    for (const label of ["In Progress", "Pending", "Completed"]) {
+      const group = screen.getByRole("heading", { level: 3, name: label })
+        .parentElement as HTMLElement;
+      const rows = group.querySelectorAll(":scope > div > div");
+      const icons = group.querySelectorAll("svg");
+      expect(rows.length).toBeGreaterThan(0);
+      expect(icons).toHaveLength(rows.length);
+    }
+  });
+
+  it("hides the body when the card is collapsed", () => {
+    renderPlan([todo("1", "pending")], { open: false });
+
+    expect(screen.getByText("Plan")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Plan/ })).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByText("Progress")).not.toBeInTheDocument();
+    expect(screen.queryByText("Task 1")).not.toBeInTheDocument();
+  });
+
+  it("invokes onToggle when the header is clicked", async () => {
+    const onToggle = vi.fn();
+    const user = userEvent.setup();
+    renderPlan([todo("1", "pending")], { onToggle });
+
+    await user.click(screen.getByRole("button", { name: /Plan/ }));
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/app/components/workspace/SourcesSection.test.tsx
+++ b/frontend/src/app/components/workspace/SourcesSection.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { SourcesSection } from "@/app/components/workspace/SourcesSection";
+import type { Source } from "@/app/types/types";
+
+function source(id: string, title: string, url: string): Source {
+  return { id, title, url, toolCallId: `tool-${id}` };
+}
+
+function renderSources(sources: Source[], props: { open?: boolean; onToggle?: () => void } = {}) {
+  return render(
+    <SourcesSection
+      sources={sources}
+      open={props.open ?? true}
+      onToggle={props.onToggle ?? vi.fn()}
+    />
+  );
+}
+
+describe("SourcesSection", () => {
+  it("derives the host label from the URL and strips the www. prefix", () => {
+    renderSources([source("1", "Acme Careers", "https://www.example.com/careers/123")]);
+
+    expect(screen.getByText("Acme Careers")).toBeInTheDocument();
+    expect(screen.getByText("example.com")).toBeInTheDocument();
+    expect(screen.queryByText(/www\./)).not.toBeInTheDocument();
+  });
+
+  it('uses the special "in" avatar letter for linkedin hosts', () => {
+    renderSources([source("1", "Jane Doe", "https://www.linkedin.com/in/janedoe")]);
+
+    const item = screen.getByRole("listitem");
+    expect(within(item).getByText("in")).toBeInTheDocument();
+    expect(within(item).getByText("linkedin.com")).toBeInTheDocument();
+  });
+
+  it("falls back to the uppercased first alphanumeric character for other hosts", () => {
+    renderSources([source("1", "Acme", "https://example.com/jobs")]);
+
+    expect(screen.getByText("E")).toBeInTheDocument();
+  });
+
+  it("renders each source as a new-tab link with rel protection", () => {
+    renderSources([source("1", "Acme Careers", "https://www.example.com/careers")]);
+
+    const link = screen.getByRole("link", { name: /Acme Careers/ });
+    expect(link).toHaveAttribute("href", "https://www.example.com/careers");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("shows the source count badge in the header", () => {
+    renderSources([
+      source("1", "One", "https://a.com/x"),
+      source("2", "Two", "https://b.com/y"),
+      source("3", "Three", "https://c.com/z"),
+    ]);
+
+    expect(screen.getByText("Sources")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
+
+  it("renders an empty message (not null) when there are no sources", () => {
+    renderSources([]);
+
+    expect(screen.getByText("Sources")).toBeInTheDocument();
+    expect(screen.getByText("No sources yet")).toBeInTheDocument();
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+    // Count badge is hidden when the count is zero.
+    expect(screen.queryByText("0")).not.toBeInTheDocument();
+  });
+
+  it("falls back to the raw string as host label when the URL cannot be parsed", () => {
+    renderSources([source("1", "Mystery Doc", "not a url")]);
+
+    const item = screen.getByRole("listitem");
+    expect(within(item).getByText("not a url")).toBeInTheDocument();
+    // letterFor picks the first alphanumeric char of the fallback label.
+    expect(within(item).getByText("N")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Mystery Doc/ })).toHaveAttribute("href", "not a url");
+  });
+
+  it("hides the list when collapsed and toggles via the header", async () => {
+    const onToggle = vi.fn();
+    const user = userEvent.setup();
+    renderSources([source("1", "Acme", "https://example.com")], { open: false, onToggle });
+
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /Sources/ }));
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/app/hooks/useChat.test.tsx
+++ b/frontend/src/app/hooks/useChat.test.tsx
@@ -1,0 +1,476 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { HumanMessage } from "@langchain/core/messages";
+import { useStream } from "@langchain/react";
+import type { Assistant } from "@langchain/langgraph-sdk";
+import { useQueryState } from "nuqs";
+import { useClient } from "@/providers/ClientProvider";
+import {
+  fetchAgentFiles,
+  getAgentFileSources,
+  resolveStoreLocation,
+  writeAgentFile,
+  type AgentFile,
+} from "@/app/lib/agentFiles";
+import { deleteAgentFile } from "@/app/lib/uploadFiles";
+import { getConfig, type StandaloneConfig } from "@/lib/config";
+import type { AgentFileSources } from "@/app/config/agentFiles";
+import { useChat } from "@/app/hooks/useChat";
+
+vi.mock("@langchain/react", async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  useStream: vi.fn(),
+}));
+vi.mock("nuqs", () => ({ useQueryState: vi.fn() }));
+vi.mock("@/providers/ClientProvider", () => ({ useClient: vi.fn() }));
+vi.mock("@/app/lib/agentFiles", () => ({
+  fetchAgentFiles: vi.fn(),
+  getAgentFileSources: vi.fn(),
+  resolveStoreLocation: vi.fn(),
+  writeAgentFile: vi.fn(),
+}));
+vi.mock("@/app/lib/uploadFiles", () => ({ deleteAgentFile: vi.fn() }));
+vi.mock("@/lib/config", () => ({ getConfig: vi.fn() }));
+
+const useStreamMock = vi.mocked(useStream);
+const useQueryStateMock = vi.mocked(useQueryState);
+const useClientMock = vi.mocked(useClient);
+const fetchAgentFilesMock = vi.mocked(fetchAgentFiles);
+const getAgentFileSourcesMock = vi.mocked(getAgentFileSources);
+const resolveStoreLocationMock = vi.mocked(resolveStoreLocation);
+const writeAgentFileMock = vi.mocked(writeAgentFile);
+const deleteAgentFileMock = vi.mocked(deleteAgentFile);
+const getConfigMock = vi.mocked(getConfig);
+
+const assistant = {
+  assistant_id: "asst-123",
+  graph_id: "career_agent",
+  config: { configurable: { base_key: "base" }, tags: ["prod"] },
+} as unknown as Assistant;
+
+const careerSources: AgentFileSources = {
+  store: { namespacePrefix: ["career_agent"], pathPrefixes: ["/processed/"] },
+  disk: { root: "backend/agents/career_agent", includeDirs: ["upload", "tailored_resume"] },
+};
+
+const diskFile: AgentFile = {
+  path: "/upload/cv.md",
+  content: "old disk content",
+  encoding: "utf-8",
+  source: "disk",
+  sourceKey: "/backend/agents/career_agent/upload/cv.md",
+};
+
+const stateFile: AgentFile = {
+  path: "/notes.md",
+  content: "keep",
+  encoding: "utf-8",
+  source: "state",
+  sourceKey: "/notes.md",
+};
+
+function makeStream(overrides: Record<string, unknown> = {}) {
+  return {
+    submit: vi.fn().mockResolvedValue(undefined),
+    respond: vi.fn().mockResolvedValue(undefined),
+    stop: vi.fn().mockResolvedValue(undefined),
+    values: { files: {}, todos: [] } as Record<string, unknown>,
+    messages: [] as unknown[],
+    isLoading: false,
+    isThreadLoading: false,
+    interrupt: undefined as unknown,
+    subagents: new Map(),
+    ...overrides,
+  };
+}
+
+async function setup(
+  opts: {
+    stream?: ReturnType<typeof makeStream>;
+    threadId?: string | null;
+    agentFiles?: AgentFile[];
+    sources?: AgentFileSources;
+    config?: StandaloneConfig | null;
+    activeAssistant?: Assistant | null;
+  } = {}
+) {
+  const {
+    stream = makeStream(),
+    threadId = "thread-1",
+    agentFiles = [],
+    sources = undefined,
+    config = null,
+    activeAssistant = assistant,
+  } = opts;
+
+  const setThreadId = vi.fn();
+  const client = { threads: { updateState: vi.fn().mockResolvedValue(undefined) } };
+
+  useQueryStateMock.mockReturnValue([threadId, setThreadId] as never);
+  useClientMock.mockReturnValue(client as never);
+  useStreamMock.mockReturnValue(stream as never);
+  getConfigMock.mockReturnValue(config);
+  getAgentFileSourcesMock.mockReturnValue(sources);
+  resolveStoreLocationMock.mockReturnValue(null);
+  fetchAgentFilesMock.mockResolvedValue(agentFiles);
+  writeAgentFileMock.mockResolvedValue(undefined);
+  deleteAgentFileMock.mockResolvedValue(undefined);
+
+  const onHistoryRevalidate = vi.fn();
+  const utils = renderHook(() => useChat({ activeAssistant, onHistoryRevalidate }));
+  // Flush the mount-time refreshFiles() chain so extendedFiles settles inside act.
+  await act(async () => {});
+  return { ...utils, stream, client, setThreadId, onHistoryRevalidate };
+}
+
+const lastStreamArgs = () => useStreamMock.mock.calls.at(-1)?.[0] as any;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useStream wiring", () => {
+  it("passes assistant id, client, thread id, and history callbacks", async () => {
+    const { client, setThreadId, onHistoryRevalidate } = await setup();
+
+    const args = lastStreamArgs();
+    expect(args.assistantId).toBe("asst-123");
+    expect(args.client).toBe(client);
+    expect(args.threadId).toBe("thread-1");
+    expect(args.onThreadId).toBe(setThreadId);
+
+    args.onCreated();
+    args.onCompleted();
+    expect(onHistoryRevalidate).toHaveBeenCalledTimes(2);
+  });
+
+  it("holds the thread back until the assistant resolves", async () => {
+    await setup({ activeAssistant: null, threadId: "t-existing" });
+
+    const args = lastStreamArgs();
+    expect(args.assistantId).toBe("");
+    expect(args.threadId).toBeNull();
+  });
+});
+
+describe("sendMessage", () => {
+  it("submits a human message with the merged assistant + model-override config", async () => {
+    const { result, stream, onHistoryRevalidate } = await setup({
+      config: {
+        deploymentUrl: "http://x",
+        assistantId: "a",
+        mainAgentModel: "claude-big",
+        subagentModel: "claude-small",
+      },
+    });
+
+    act(() => {
+      result.current.sendMessage("hi");
+    });
+
+    expect(stream.submit).toHaveBeenCalledTimes(1);
+    const [payload, options] = stream.submit.mock.calls[0];
+    expect(payload.messages).toHaveLength(1);
+    expect(payload.messages[0]).toBeInstanceOf(HumanMessage);
+    expect(payload.messages[0].content).toBe("hi");
+    expect(options).toEqual({
+      config: {
+        tags: ["prod"],
+        recursion_limit: 100,
+        configurable: {
+          base_key: "base",
+          main_agent_model: "claude-big",
+          subagent_model: "claude-small",
+        },
+      },
+    });
+    expect(onHistoryRevalidate).toHaveBeenCalledTimes(1);
+  });
+
+  it("omits model overrides when no user config is stored", async () => {
+    const { result, stream } = await setup({ config: null });
+
+    act(() => {
+      result.current.sendMessage("hello");
+    });
+
+    const [, options] = stream.submit.mock.calls[0];
+    expect(options.config).toEqual({
+      tags: ["prod"],
+      recursion_limit: 100,
+      configurable: { base_key: "base" },
+    });
+  });
+});
+
+describe("resumeInterrupt / stopStream", () => {
+  it("responds to the interrupt with the value and merged config, then revalidates", async () => {
+    const { result, stream, onHistoryRevalidate } = await setup();
+
+    act(() => {
+      result.current.resumeInterrupt({ decision: "approve" });
+    });
+
+    expect(stream.respond).toHaveBeenCalledTimes(1);
+    expect(stream.respond).toHaveBeenCalledWith(
+      { decision: "approve" },
+      { config: { tags: ["prod"], configurable: { base_key: "base" } } }
+    );
+    expect(onHistoryRevalidate).toHaveBeenCalledTimes(1);
+  });
+
+  it("stopStream stops the stream", async () => {
+    const { result, stream } = await setup();
+
+    act(() => {
+      result.current.stopStream();
+    });
+
+    expect(stream.stop).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("stream state passthrough", () => {
+  it("exposes todos, files, email, messages, flags, interrupt, and subagents", async () => {
+    const todos = [{ id: "t1", content: "do it", status: "pending" }];
+    const email = { id: "e1", subject: "offer" };
+    const interrupt = { action_requests: [] };
+    const messages = [{ id: "m1" }];
+    const subagents = new Map([["call-1", { id: "sub-1" }]]);
+    const stream = makeStream({
+      values: { files: {}, todos, email },
+      isLoading: true,
+      isThreadLoading: true,
+      interrupt,
+      messages,
+      subagents,
+    });
+
+    const { result } = await setup({ stream, agentFiles: [stateFile] });
+
+    expect(result.current.todos).toBe(todos);
+    expect(result.current.email).toBe(email);
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.isThreadLoading).toBe(true);
+    expect(result.current.interrupt).toBe(interrupt);
+    expect(result.current.messages).toBe(messages);
+    expect(result.current.subagents).toBe(subagents);
+    await waitFor(() => expect(result.current.files).toEqual({ "/notes.md": "keep" }));
+  });
+
+  it("defaults todos to an empty array when the stream has none", async () => {
+    const { result } = await setup({ stream: makeStream({ values: {} }) });
+    expect(result.current.todos).toEqual([]);
+  });
+});
+
+describe("setFiles", () => {
+  it("writes the full state map through threads.updateState when no external sources", async () => {
+    const { result, client } = await setup({ sources: undefined });
+    fetchAgentFilesMock.mockClear();
+
+    await act(async () => {
+      await result.current.setFiles({ "/a.md": "hello" });
+    });
+
+    expect(client.threads.updateState).toHaveBeenCalledTimes(1);
+    expect(client.threads.updateState).toHaveBeenCalledWith("thread-1", {
+      values: { files: { "/a.md": "hello" } },
+    });
+    expect(writeAgentFileMock).not.toHaveBeenCalled();
+    expect(fetchAgentFilesMock).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op without a threadId when no external sources", async () => {
+    const { result, client } = await setup({ sources: undefined, threadId: null });
+
+    await act(async () => {
+      await result.current.setFiles({ "/a.md": "hello" });
+    });
+
+    expect(client.threads.updateState).not.toHaveBeenCalled();
+  });
+
+  it("routes a changed disk file to writeAgentFile with its existing sourceKey", async () => {
+    const { result, client } = await setup({ sources: careerSources, agentFiles: [diskFile] });
+    await waitFor(() => expect(result.current.files["/upload/cv.md"]).toBe("old disk content"));
+    fetchAgentFilesMock.mockClear();
+
+    await act(async () => {
+      await result.current.setFiles({ "/upload/cv.md": "new disk content" });
+    });
+
+    expect(writeAgentFileMock).toHaveBeenCalledTimes(1);
+    expect(writeAgentFileMock).toHaveBeenCalledWith({
+      client,
+      threadId: "thread-1",
+      graphId: "career_agent",
+      file: { ...diskFile, content: "new disk content" },
+    });
+    expect(client.threads.updateState).not.toHaveBeenCalled();
+    // Refetches to pick up new modified_at.
+    expect(fetchAgentFilesMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("routes a new path matching a store pathPrefix to a synthesized store write", async () => {
+    const { result, client } = await setup({ sources: careerSources });
+    resolveStoreLocationMock.mockImplementation((_cfg, path) =>
+      path.startsWith("/processed/")
+        ? { namespace: ["career_agent", "processed"], key: path.slice("/processed".length) }
+        : null
+    );
+
+    await act(async () => {
+      await result.current.setFiles({ "/processed/report.md": "store body" });
+    });
+
+    expect(resolveStoreLocationMock).toHaveBeenCalledWith(
+      careerSources.store,
+      "/processed/report.md"
+    );
+    expect(writeAgentFileMock).toHaveBeenCalledTimes(1);
+    expect(writeAgentFileMock).toHaveBeenCalledWith({
+      client,
+      threadId: "thread-1",
+      graphId: "career_agent",
+      file: {
+        path: "/processed/report.md",
+        content: "store body",
+        encoding: "utf-8",
+        source: "store",
+        sourceKey: "/processed/report.md",
+      },
+    });
+    expect(client.threads.updateState).not.toHaveBeenCalled();
+  });
+
+  it("routes a new path under a disk includeDir to a disk write with a synthesized sourceKey", async () => {
+    const { result, client } = await setup({ sources: careerSources });
+
+    await act(async () => {
+      await result.current.setFiles({ "/upload/new.pdf": "pdf bytes" });
+    });
+
+    expect(writeAgentFileMock).toHaveBeenCalledTimes(1);
+    expect(writeAgentFileMock).toHaveBeenCalledWith({
+      client,
+      threadId: "thread-1",
+      graphId: "career_agent",
+      file: {
+        path: "/upload/new.pdf",
+        content: "pdf bytes",
+        encoding: "utf-8",
+        source: "disk",
+        sourceKey: "/backend/agents/career_agent/upload/new.pdf",
+      },
+    });
+    expect(client.threads.updateState).not.toHaveBeenCalled();
+  });
+
+  it("falls back to a state update for unmatched new paths, carrying unchanged state files", async () => {
+    const { result, client } = await setup({
+      sources: careerSources,
+      agentFiles: [stateFile, diskFile],
+    });
+    await waitFor(() => expect(Object.keys(result.current.files)).toHaveLength(2));
+
+    await act(async () => {
+      await result.current.setFiles({
+        "/notes.md": "keep",
+        "/upload/cv.md": "old disk content",
+        "/random/new.md": "fresh",
+      });
+    });
+
+    expect(writeAgentFileMock).not.toHaveBeenCalled();
+    expect(client.threads.updateState).toHaveBeenCalledTimes(1);
+    expect(client.threads.updateState).toHaveBeenCalledWith("thread-1", {
+      values: { files: { "/notes.md": "keep", "/random/new.md": "fresh" } },
+    });
+  });
+
+  it("routes a changed state file through a single state update", async () => {
+    const { result, client } = await setup({ sources: careerSources, agentFiles: [stateFile] });
+    await waitFor(() => expect(result.current.files["/notes.md"]).toBe("keep"));
+
+    await act(async () => {
+      await result.current.setFiles({ "/notes.md": "edited note" });
+    });
+
+    expect(writeAgentFileMock).not.toHaveBeenCalled();
+    expect(client.threads.updateState).toHaveBeenCalledWith("thread-1", {
+      values: { files: { "/notes.md": "edited note" } },
+    });
+  });
+});
+
+describe("removeFiles", () => {
+  it("aggregates a mixed batch: deletes disk files, errors for state and unknown paths", async () => {
+    const pdfDiskFile: AgentFile = {
+      path: "/upload/cv.pdf",
+      content: "pdf",
+      encoding: "utf-8",
+      source: "disk",
+      sourceKey: "/backend/agents/career_agent/upload/cv.pdf",
+    };
+    const { result } = await setup({
+      sources: careerSources,
+      agentFiles: [pdfDiskFile, stateFile],
+    });
+    await waitFor(() => expect(Object.keys(result.current.files)).toHaveLength(2));
+    fetchAgentFilesMock.mockClear();
+
+    let outcome: Awaited<ReturnType<typeof result.current.removeFiles>> | undefined;
+    await act(async () => {
+      outcome = await result.current.removeFiles(["/upload/cv.pdf", "/notes.md", "/ghost.md"]);
+    });
+
+    expect(outcome).toEqual({
+      deleted: ["/upload/cv.pdf"],
+      errors: [
+        { path: "/notes.md", reason: "Only disk-backed files can be deleted from the UI" },
+        { path: "/ghost.md", reason: "File not found: /ghost.md" },
+      ],
+    });
+    expect(deleteAgentFileMock).toHaveBeenCalledTimes(1);
+    expect(deleteAgentFileMock).toHaveBeenCalledWith("/backend/agents/career_agent/upload/cv.pdf");
+    // Refreshes the file list after the batch.
+    expect(fetchAgentFilesMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("appendUploadNote", () => {
+  it("writes the formatted note into an empty composer and bumps the focus nonce", async () => {
+    const { result } = await setup();
+
+    act(() => {
+      result.current.appendUploadNote(["cv.pdf", "jd.md"]);
+    });
+
+    expect(result.current.input).toBe("Uploaded: cv.pdf, jd.md\n");
+    expect(result.current.focusComposerNonce).toBe(1);
+  });
+
+  it("appends below existing draft text, collapsing trailing newlines", async () => {
+    const { result } = await setup();
+
+    act(() => {
+      result.current.setInput("draft note\n\n");
+    });
+    act(() => {
+      result.current.appendUploadNote(["cv.pdf"]);
+    });
+
+    expect(result.current.input).toBe("draft note\n\nUploaded: cv.pdf\n");
+  });
+
+  it("is a no-op for an empty filename list", async () => {
+    const { result } = await setup();
+
+    act(() => {
+      result.current.appendUploadNote([]);
+    });
+
+    expect(result.current.input).toBe("");
+    expect(result.current.focusComposerNonce).toBe(0);
+  });
+});

--- a/frontend/src/app/hooks/useThreads.test.tsx
+++ b/frontend/src/app/hooks/useThreads.test.tsx
@@ -1,0 +1,204 @@
+import type { ReactNode } from "react";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { SWRConfig } from "swr";
+import { Client } from "@langchain/langgraph-sdk";
+import { getConfig } from "@/lib/config";
+import { useThreads } from "@/app/hooks/useThreads";
+
+const { searchMock } = vi.hoisted(() => ({ searchMock: vi.fn() }));
+
+vi.mock("@langchain/langgraph-sdk", () => ({
+  // Constructed with `new`, so the implementation must be a `function` (not an
+  // arrow) whose returned object becomes the instance.
+  Client: vi.fn(function () {
+    return { threads: { search: searchMock } };
+  }),
+}));
+vi.mock("@/lib/config", () => ({ getConfig: vi.fn() }));
+
+const ClientMock = vi.mocked(Client);
+const getConfigMock = vi.mocked(getConfig);
+
+const UUID_ASSISTANT = "0f1e2d3c-4b5a-6978-8899-aabbccddeeff";
+
+const baseConfig = {
+  deploymentUrl: "http://deploy:2024",
+  assistantId: "career_agent",
+};
+
+function makeWrapper() {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>{children}</SWRConfig>
+    );
+  };
+}
+
+function makeThread(overrides: Record<string, unknown> = {}) {
+  return {
+    thread_id: "00000000-0000-4000-8000-000000000000",
+    updated_at: "2026-07-01T10:00:00.000Z",
+    status: "idle",
+    values: { messages: [] },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // The key builder falls back to this env var when config has no key.
+  vi.stubEnv("NEXT_PUBLIC_LANGSMITH_API_KEY", "");
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("useThreads", () => {
+  it("returns no data and never constructs a client when config is null", async () => {
+    getConfigMock.mockReturnValue(null);
+
+    const { result } = renderHook(() => useThreads({}), { wrapper: makeWrapper() });
+    await act(async () => {});
+
+    expect(result.current.data).toBeUndefined();
+    expect(ClientMock).not.toHaveBeenCalled();
+    expect(searchMock).not.toHaveBeenCalled();
+  });
+
+  it("filters by assistant_id metadata for UUID assistant ids and sends the api key header", async () => {
+    getConfigMock.mockReturnValue({
+      ...baseConfig,
+      assistantId: UUID_ASSISTANT,
+      langsmithApiKey: "sk-ls",
+    });
+    searchMock.mockResolvedValue([]);
+
+    renderHook(() => useThreads({ status: "idle" }), { wrapper: makeWrapper() });
+    await waitFor(() => expect(searchMock).toHaveBeenCalled());
+
+    expect(ClientMock).toHaveBeenCalledWith({
+      apiUrl: "http://deploy:2024",
+      defaultHeaders: { "X-Api-Key": "sk-ls" },
+    });
+    expect(searchMock).toHaveBeenCalledWith({
+      limit: 20,
+      offset: 0,
+      sortBy: "updated_at",
+      sortOrder: "desc",
+      status: "idle",
+      metadata: { assistant_id: UUID_ASSISTANT },
+    });
+  });
+
+  it("omits the metadata filter for graph-name assistant ids and sends empty headers", async () => {
+    getConfigMock.mockReturnValue(baseConfig);
+    searchMock.mockResolvedValue([]);
+
+    renderHook(() => useThreads({}), { wrapper: makeWrapper() });
+    await waitFor(() => expect(searchMock).toHaveBeenCalled());
+
+    expect(ClientMock).toHaveBeenCalledWith({
+      apiUrl: "http://deploy:2024",
+      defaultHeaders: {},
+    });
+    const args = searchMock.mock.calls[0][0];
+    expect(args).not.toHaveProperty("metadata");
+    expect(args).toMatchObject({ limit: 20, offset: 0, sortBy: "updated_at", sortOrder: "desc" });
+  });
+
+  it("maps threads to titles and descriptions with truncation", async () => {
+    getConfigMock.mockReturnValue(baseConfig);
+    searchMock.mockResolvedValue([
+      makeThread({
+        thread_id: "11111111-1111-4111-8111-111111111111",
+        status: "idle",
+        values: {
+          messages: [
+            { type: "human", content: "a".repeat(60) },
+            { type: "ai", content: "b".repeat(120) },
+          ],
+        },
+      }),
+      makeThread({
+        thread_id: "22222222-2222-4222-8222-222222222222",
+        status: "busy",
+        updated_at: "2026-07-02T08:30:00.000Z",
+        values: {
+          messages: [
+            { type: "ai", content: [{ type: "text", text: "Block reply" }] },
+            { type: "human", content: [{ type: "text", text: "Block title" }] },
+          ],
+        },
+      }),
+    ]);
+
+    const { result } = renderHook(() => useThreads({}), { wrapper: makeWrapper() });
+    await waitFor(() => expect(result.current.data?.[0]).toHaveLength(2));
+
+    const [first, second] = result.current.data![0];
+    expect(first).toEqual({
+      id: "11111111-1111-4111-8111-111111111111",
+      updatedAt: new Date("2026-07-01T10:00:00.000Z"),
+      status: "idle",
+      title: "a".repeat(50) + "...",
+      description: "b".repeat(100),
+      assistantId: "career_agent",
+    });
+    // Array-of-blocks content resolves through the first block's text; short
+    // titles get no ellipsis and the ai description is never suffixed.
+    expect(second.title).toBe("Block title");
+    expect(second.description).toBe("Block reply");
+    expect(second.status).toBe("busy");
+    expect(second.updatedAt).toEqual(new Date("2026-07-02T08:30:00.000Z"));
+  });
+
+  it("falls back per-thread when values are malformed or missing", async () => {
+    getConfigMock.mockReturnValue(baseConfig);
+    searchMock.mockResolvedValue([
+      // values present but no messages array -> mapping throws -> id-based title.
+      makeThread({ thread_id: "deadbeef-0000-4000-8000-000000000000", values: {} }),
+      // values missing entirely -> guard short-circuits -> default title.
+      makeThread({ thread_id: "feedface-0000-4000-8000-000000000000", values: null }),
+    ]);
+
+    const { result } = renderHook(() => useThreads({}), { wrapper: makeWrapper() });
+    await waitFor(() => expect(result.current.data?.[0]).toHaveLength(2));
+
+    const [broken, missing] = result.current.data![0];
+    expect(broken.title).toBe("Thread deadbeef");
+    expect(broken.description).toBe("");
+    expect(missing.title).toBe("Untitled Thread");
+    expect(missing.description).toBe("");
+  });
+
+  it("advances the offset by page size and stops paginating after an empty page", async () => {
+    getConfigMock.mockReturnValue(baseConfig);
+    searchMock.mockImplementation(async (args: { offset: number }) =>
+      args.offset === 0
+        ? [
+            makeThread({ thread_id: "11111111-1111-4111-8111-111111111111" }),
+            makeThread({ thread_id: "22222222-2222-4222-8222-222222222222" }),
+          ]
+        : []
+    );
+
+    const { result } = renderHook(() => useThreads({ limit: 2 }), { wrapper: makeWrapper() });
+    await waitFor(() => expect(result.current.data?.[0]).toHaveLength(2));
+
+    await act(async () => {
+      await result.current.setSize(2);
+    });
+    await waitFor(() => expect(result.current.data).toHaveLength(2));
+    expect(searchMock).toHaveBeenCalledWith(expect.objectContaining({ limit: 2, offset: 2 }));
+
+    // Page 1 came back empty, so the page-2 key is null: no offset-4 request.
+    await act(async () => {
+      await result.current.setSize(3);
+    });
+    await act(async () => {});
+    const offsets = searchMock.mock.calls.map((c) => c[0].offset);
+    expect(offsets).not.toContain(4);
+    expect(result.current.data).toHaveLength(2);
+  });
+});

--- a/frontend/src/app/lib/agentFiles.test.ts
+++ b/frontend/src/app/lib/agentFiles.test.ts
@@ -1,0 +1,501 @@
+import type { Client } from "@langchain/langgraph-sdk";
+import { AGENT_FILE_SOURCES, type AgentFileSources } from "@/app/config/agentFiles";
+import {
+  type AgentFile,
+  fetchAgentFiles,
+  getAgentFileSources,
+  isBinaryPath,
+  isImagePath,
+  resolveStoreLocation,
+  writeAgentFile,
+} from "./agentFiles";
+
+const careerStoreCfg = AGENT_FILE_SOURCES.career_agent.store!;
+
+function makeClient() {
+  return {
+    store: {
+      searchItems: vi.fn(async (_ns: string[], _opts: { limit: number }) => ({
+        items: [] as unknown[],
+      })),
+      putItem: vi.fn(async () => undefined),
+    },
+    threads: {
+      updateState: vi.fn(async () => undefined),
+    },
+  };
+}
+type StubClient = ReturnType<typeof makeClient>;
+const asClient = (c: StubClient) => c as unknown as Client;
+
+function jsonResponse(
+  data: unknown,
+  init: { ok?: boolean; status?: number; text?: string } = {}
+): { ok: boolean; status: number; json: () => Promise<unknown>; text: () => Promise<string> } {
+  return {
+    ok: init.ok ?? true,
+    status: init.status ?? 200,
+    json: async () => data,
+    text: async () => init.text ?? "",
+  };
+}
+
+function file(over: Partial<AgentFile> & { sourceKey: string; source: AgentFile["source"] }) {
+  return {
+    path: over.sourceKey,
+    content: "content",
+    encoding: "utf-8" as const,
+    ...over,
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("isImagePath", () => {
+  it("recognizes image extensions", () => {
+    expect(isImagePath("/research/chart.png")).toBe(true);
+    expect(isImagePath("photo.webp")).toBe(true);
+  });
+
+  it("is case-insensitive", () => {
+    expect(isImagePath("/research/CHART.PNG")).toBe(true);
+    expect(isImagePath("pic.JpEg")).toBe(true);
+  });
+
+  it("rejects non-image and extension-less paths", () => {
+    expect(isImagePath("/processed/resume.pdf")).toBe(false);
+    expect(isImagePath("/processed/notes.md")).toBe(false);
+    expect(isImagePath("no-extension")).toBe(false);
+    expect(isImagePath("")).toBe(false);
+  });
+});
+
+describe("isBinaryPath", () => {
+  it("includes images plus documents and archives", () => {
+    expect(isBinaryPath("/upload/cv.pdf")).toBe(true);
+    expect(isBinaryPath("/upload/cv.DOCX")).toBe(true);
+    expect(isBinaryPath("/research/chart.png")).toBe(true);
+    expect(isBinaryPath("archive.tar.gz")).toBe(true);
+  });
+
+  it("rejects text and extension-less paths", () => {
+    expect(isBinaryPath("/processed/notes.md")).toBe(false);
+    expect(isBinaryPath("no-extension")).toBe(false);
+  });
+});
+
+describe("getAgentFileSources", () => {
+  it("returns the configured sources for a known graph id", () => {
+    expect(getAgentFileSources("career_agent")).toBe(AGENT_FILE_SOURCES.career_agent);
+  });
+
+  it("returns undefined for unknown, null, or undefined graph ids", () => {
+    expect(getAgentFileSources("mystery_agent")).toBeUndefined();
+    expect(getAgentFileSources(null)).toBeUndefined();
+    expect(getAgentFileSources(undefined)).toBeUndefined();
+  });
+});
+
+describe("resolveStoreLocation", () => {
+  it("maps a prefixed path to namespace segments plus a leading-slash key", () => {
+    expect(resolveStoreLocation(careerStoreCfg, "/processed/resume.md")).toEqual({
+      namespace: ["career_agent", "processed"],
+      key: "/resume.md",
+    });
+  });
+
+  it("keeps nested subdirectories in the key", () => {
+    expect(resolveStoreLocation(careerStoreCfg, "/interview_coach/acme/questions.md")).toEqual({
+      namespace: ["career_agent", "interview_coach"],
+      key: "/acme/questions.md",
+    });
+  });
+
+  it("resolves an exact prefix match (no remainder) to key '/'", () => {
+    expect(resolveStoreLocation(careerStoreCfg, "/processed")).toEqual({
+      namespace: ["career_agent", "processed"],
+      key: "/",
+    });
+  });
+
+  it("requires a segment boundary after the prefix", () => {
+    expect(resolveStoreLocation(careerStoreCfg, "/processedx/resume.md")).toBeNull();
+  });
+
+  it("returns null when no configured prefix matches", () => {
+    expect(resolveStoreLocation(careerStoreCfg, "/unknown/file.md")).toBeNull();
+  });
+
+  it("prefers the longest matching prefix regardless of config order", () => {
+    const cfg: NonNullable<AgentFileSources["store"]> = {
+      namespacePrefix: ["agent"],
+      pathPrefixes: ["/a/", "/a/b/"],
+    };
+    expect(resolveStoreLocation(cfg, "/a/b/c.md")).toEqual({
+      namespace: ["agent", "a", "b"],
+      key: "/c.md",
+    });
+    expect(resolveStoreLocation(cfg, "/a/x.md")).toEqual({
+      namespace: ["agent", "a"],
+      key: "/x.md",
+    });
+  });
+});
+
+describe("fetchAgentFiles", () => {
+  it("maps state files only when the graph has no configured sources", async () => {
+    const client = makeClient();
+    const result = await fetchAgentFiles({
+      client: asClient(client),
+      graphId: null,
+      stateFiles: {
+        "/notes/b.md": "raw string",
+        "/notes/a.md": { content: ["line 1", "line 2"] },
+        "/notes/c.md": { content: "inner" },
+        "/notes/d.md": 42,
+        "/notes/e.md": { content: null },
+      },
+    });
+
+    // No timestamps anywhere -> pure alphabetical order.
+    expect(result.map((f) => f.path)).toEqual([
+      "/notes/a.md",
+      "/notes/b.md",
+      "/notes/c.md",
+      "/notes/d.md",
+      "/notes/e.md",
+    ]);
+    expect(result.map((f) => f.content)).toEqual([
+      "line 1\nline 2",
+      "raw string",
+      "inner",
+      "42",
+      "",
+    ]);
+    for (const f of result) {
+      expect(f.source).toBe("state");
+      expect(f.encoding).toBe("utf-8");
+      expect(f.sourceKey).toBe(f.path);
+      expect(f.modifiedAt).toBeUndefined();
+    }
+    expect(client.store.searchItems).not.toHaveBeenCalled();
+  });
+
+  it("merges store, disk, and state files with state winning path collisions", async () => {
+    const client = makeClient();
+    client.store.searchItems.mockImplementation(async (namespace: string[]) => {
+      if (namespace.join("/") === "career_agent/processed") {
+        return {
+          items: [
+            {
+              key: "resume.md",
+              value: { content: "store resume" },
+              updatedAt: "2026-01-02T00:00:00.000Z",
+            },
+            {
+              key: "/notes.md",
+              value: { content: ["n1", "n2"] },
+              updated_at: "2026-01-01T00:00:00.000Z",
+            },
+          ],
+        };
+      }
+      if (namespace.join("/") === "career_agent/research") {
+        return { items: [{ key: "chart.png", value: { content: "AAAA", encoding: "base64" } }] };
+      }
+      return { items: [] };
+    });
+
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.startsWith("/api/files/list")) {
+        return jsonResponse({
+          files: [
+            {
+              path: "/backend/agents/career_agent/upload/cv.pdf",
+              isBinary: true,
+              modifiedAt: "2026-01-03T00:00:00.000Z",
+            },
+            { path: "/backend/agents/career_agent/upload/broken.md", isBinary: false },
+          ],
+        });
+      }
+      if (url.includes(encodeURIComponent("cv.pdf"))) {
+        return jsonResponse({ content: "JVBERi0=", encoding: "base64" });
+      }
+      // broken.md read fails -> that file is silently dropped.
+      return jsonResponse(null, { ok: false, status: 404 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await fetchAgentFiles({
+      client: asClient(client),
+      graphId: "career_agent",
+      stateFiles: {
+        "/processed/resume.md": "state resume",
+        "/state/todo.md": "todo",
+      },
+    });
+
+    // Newest first, then alphabetical among timestamp-less files.
+    expect(result.map((f) => f.path)).toEqual([
+      "/upload/cv.pdf",
+      "/processed/notes.md",
+      "/processed/resume.md",
+      "/research/chart.png",
+      "/state/todo.md",
+    ]);
+
+    const byPath = new Map(result.map((f) => [f.path, f]));
+
+    // State wins the collision on /processed/resume.md.
+    expect(byPath.get("/processed/resume.md")).toMatchObject({
+      source: "state",
+      content: "state resume",
+    });
+    // State files carry no timestamp (no modifiedAt key at all).
+    expect(byPath.get("/processed/resume.md")?.modifiedAt).toBeUndefined();
+
+    // Store item: array content joined, snake_case updated_at parsed.
+    expect(byPath.get("/processed/notes.md")).toMatchObject({
+      source: "store",
+      content: "n1\nn2",
+      encoding: "utf-8",
+      sourceKey: "/processed/notes.md",
+      modifiedAt: Date.parse("2026-01-01T00:00:00.000Z"),
+    });
+
+    // Store item without a timestamp keeps modifiedAt undefined; base64 kept.
+    expect(byPath.get("/research/chart.png")).toMatchObject({
+      source: "store",
+      content: "AAAA",
+      encoding: "base64",
+      modifiedAt: undefined,
+    });
+
+    // Disk file: root stripped from path, full repo path kept as sourceKey.
+    expect(byPath.get("/upload/cv.pdf")).toMatchObject({
+      source: "disk",
+      content: "JVBERi0=",
+      encoding: "base64",
+      sourceKey: "/backend/agents/career_agent/upload/cv.pdf",
+      modifiedAt: Date.parse("2026-01-03T00:00:00.000Z"),
+    });
+
+    // The failed disk read is dropped entirely.
+    expect(byPath.has("/upload/broken.md")).toBe(false);
+
+    // One store search per configured path prefix, with the page limit.
+    expect(client.store.searchItems).toHaveBeenCalledTimes(careerStoreCfg.pathPrefixes.length);
+    expect(client.store.searchItems).toHaveBeenCalledWith(["career_agent", "processed"], {
+      limit: 200,
+    });
+    expect(client.store.searchItems).toHaveBeenCalledWith(["career_agent", "memory"], {
+      limit: 200,
+    });
+
+    // Disk list call carries the configured root and dirs.
+    const listUrl = String(fetchMock.mock.calls[0][0]);
+    expect(listUrl).toContain("/api/files/list?");
+    expect(listUrl).toContain("root=backend%2Fagents%2Fcareer_agent");
+    expect(listUrl).toContain("dirs=upload%2Ctailored_resume%2Cinterview_battlecard");
+    expect(fetchMock).toHaveBeenCalledWith(
+      `/api/files/read?path=${encodeURIComponent("/backend/agents/career_agent/upload/cv.pdf")}`
+    );
+  });
+
+  it("still returns other sources when the disk fetch rejects", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const client = makeClient();
+    client.store.searchItems.mockImplementation(async (namespace: string[]) => {
+      if (namespace.join("/") === "career_agent/memory") {
+        return { items: [{ key: "profile.md", value: { content: "profile" } }] };
+      }
+      return { items: [] };
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Promise.reject(new Error("network down")))
+    );
+
+    const result = await fetchAgentFiles({
+      client: asClient(client),
+      graphId: "career_agent",
+      stateFiles: { "/state/todo.md": "todo" },
+    });
+
+    expect(result.map((f) => f.path)).toEqual(["/memory/profile.md", "/state/todo.md"]);
+    expect(warn).toHaveBeenCalledWith("disk fetch failed", expect.any(Error));
+  });
+
+  it("treats a non-ok disk list response as an empty disk source", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const client = makeClient();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse(null, { ok: false, status: 500, text: "boom" }))
+    );
+
+    const result = await fetchAgentFiles({
+      client: asClient(client),
+      graphId: "career_agent",
+      stateFiles: { "/state/todo.md": "todo" },
+    });
+
+    expect(result.map((f) => f.path)).toEqual(["/state/todo.md"]);
+    expect(warn).toHaveBeenCalledWith("disk list failed", 500, "boom");
+  });
+
+  it("still returns disk and state files when every store search rejects", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const client = makeClient();
+    client.store.searchItems.mockRejectedValue(new Error("store down"));
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        if (url.startsWith("/api/files/list")) {
+          return jsonResponse({
+            files: [{ path: "/backend/agents/career_agent/upload/cv.pdf", isBinary: true }],
+          });
+        }
+        return jsonResponse({ content: "disk content", encoding: "utf-8" });
+      })
+    );
+
+    const result = await fetchAgentFiles({
+      client: asClient(client),
+      graphId: "career_agent",
+      stateFiles: {},
+    });
+
+    expect(result.map((f) => f.path)).toEqual(["/upload/cv.pdf"]);
+    expect(warn).toHaveBeenCalled();
+  });
+});
+
+describe("writeAgentFile", () => {
+  it("routes store files to putItem with the resolved namespace and key", async () => {
+    const client = makeClient();
+    await writeAgentFile({
+      client: asClient(client),
+      threadId: null,
+      graphId: "career_agent",
+      file: file({ source: "store", sourceKey: "/processed/resume.md", content: "hello" }),
+    });
+    expect(client.store.putItem).toHaveBeenCalledExactlyOnceWith(
+      ["career_agent", "processed"],
+      "/resume.md",
+      { content: "hello", encoding: "utf-8" }
+    );
+  });
+
+  it("throws for a store file when the agent has no store config", async () => {
+    const client = makeClient();
+    await expect(
+      writeAgentFile({
+        client: asClient(client),
+        threadId: null,
+        graphId: "mystery_agent",
+        file: file({ source: "store", sourceKey: "/processed/resume.md" }),
+      })
+    ).rejects.toThrow("Store backend not configured for this agent");
+    expect(client.store.putItem).not.toHaveBeenCalled();
+  });
+
+  it("throws for a store file whose path matches no configured prefix", async () => {
+    const client = makeClient();
+    await expect(
+      writeAgentFile({
+        client: asClient(client),
+        threadId: null,
+        graphId: "career_agent",
+        file: file({ source: "store", sourceKey: "/elsewhere/resume.md" }),
+      })
+    ).rejects.toThrow(/No matching store pathPrefix for \/elsewhere\/resume\.md/);
+    expect(client.store.putItem).not.toHaveBeenCalled();
+  });
+
+  it("routes disk files to PUT /api/files/write with path, content, and encoding", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ ok: true }));
+    vi.stubGlobal("fetch", fetchMock);
+    const client = makeClient();
+
+    await writeAgentFile({
+      client: asClient(client),
+      threadId: null,
+      graphId: "career_agent",
+      file: file({
+        source: "disk",
+        sourceKey: "/backend/agents/career_agent/upload/cv.md",
+        content: "disk content",
+      }),
+    });
+
+    expect(fetchMock).toHaveBeenCalledExactlyOnceWith("/api/files/write", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        path: "/backend/agents/career_agent/upload/cv.md",
+        content: "disk content",
+        encoding: "utf-8",
+      }),
+    });
+  });
+
+  it("throws with status and body when the disk write fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse(null, { ok: false, status: 500, text: "boom" }))
+    );
+    await expect(
+      writeAgentFile({
+        client: asClient(makeClient()),
+        threadId: null,
+        graphId: "career_agent",
+        file: file({ source: "disk", sourceKey: "/backend/agents/career_agent/upload/cv.md" }),
+      })
+    ).rejects.toThrow("Disk write failed: 500 boom");
+  });
+
+  it("routes state files to threads.updateState, merging into the files map", async () => {
+    const client = makeClient();
+    await writeAgentFile({
+      client: asClient(client),
+      threadId: "thread-1",
+      graphId: "career_agent",
+      file: file({ source: "state", sourceKey: "/notes/todo.md", content: "new content" }),
+      stateFiles: { "/existing.md": "old" },
+    });
+    expect(client.threads.updateState).toHaveBeenCalledExactlyOnceWith("thread-1", {
+      values: { files: { "/existing.md": "old", "/notes/todo.md": "new content" } },
+    });
+  });
+
+  it("writes a state file even when no stateFiles map is provided", async () => {
+    const client = makeClient();
+    await writeAgentFile({
+      client: asClient(client),
+      threadId: "thread-1",
+      graphId: null,
+      file: file({ source: "state", sourceKey: "/only.md", content: "solo" }),
+    });
+    expect(client.threads.updateState).toHaveBeenCalledExactlyOnceWith("thread-1", {
+      values: { files: { "/only.md": "solo" } },
+    });
+  });
+
+  it("throws for a state file without a threadId", async () => {
+    const client = makeClient();
+    await expect(
+      writeAgentFile({
+        client: asClient(client),
+        threadId: null,
+        graphId: "career_agent",
+        file: file({ source: "state", sourceKey: "/notes/todo.md" }),
+      })
+    ).rejects.toThrow("No threadId for state write");
+    expect(client.threads.updateState).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/lib/fileCategories.test.ts
+++ b/frontend/src/app/lib/fileCategories.test.ts
@@ -1,0 +1,62 @@
+import { FILE_CATEGORIES, getFileCategory, splitBasename, splitFilePath } from "./fileCategories";
+
+describe("getFileCategory", () => {
+  it.each(FILE_CATEGORIES.map((c) => [c.prefix, c.label]))(
+    "maps %s/… to the %s category",
+    (prefix, label) => {
+      expect(getFileCategory(`${prefix}/anything.md`)?.label).toBe(label);
+    }
+  );
+
+  it("strips any number of leading slashes", () => {
+    expect(getFileCategory("/upload/cv.pdf")?.label).toBe("Upload");
+    expect(getFileCategory("///upload/cv.pdf")?.label).toBe("Upload");
+  });
+
+  it("matches a bare prefix with no trailing path", () => {
+    expect(getFileCategory("research")?.label).toBe("Research");
+  });
+
+  it("requires an exact first segment, not a prefix match", () => {
+    expect(getFileCategory("uploads/cv.pdf")).toBeNull();
+    expect(getFileCategory("upload_extra/cv.pdf")).toBeNull();
+  });
+
+  it("returns null for unknown categories and empty paths", () => {
+    expect(getFileCategory("unknown/file.txt")).toBeNull();
+    expect(getFileCategory("")).toBeNull();
+    expect(getFileCategory("///")).toBeNull();
+  });
+});
+
+describe("splitFilePath", () => {
+  it("splits directory prefix and basename", () => {
+    expect(splitFilePath("a/b/c.md")).toEqual({ prefix: "a/b/", basename: "c.md" });
+  });
+
+  it("returns an empty prefix when there is no slash", () => {
+    expect(splitFilePath("c.md")).toEqual({ prefix: "", basename: "c.md" });
+  });
+
+  it("returns an empty basename for a trailing slash", () => {
+    expect(splitFilePath("a/b/")).toEqual({ prefix: "a/b/", basename: "" });
+  });
+});
+
+describe("splitBasename", () => {
+  it("splits stem and extension at the last dot", () => {
+    expect(splitBasename("report.final.md")).toEqual({ stem: "report.final", ext: ".md" });
+  });
+
+  it("keeps dotfiles intact", () => {
+    expect(splitBasename(".env")).toEqual({ stem: ".env", ext: "" });
+  });
+
+  it("treats a trailing dot as part of the stem", () => {
+    expect(splitBasename("name.")).toEqual({ stem: "name.", ext: "" });
+  });
+
+  it("returns an empty extension when there is no dot", () => {
+    expect(splitBasename("README")).toEqual({ stem: "README", ext: "" });
+  });
+});

--- a/frontend/src/app/lib/uploadFiles.test.ts
+++ b/frontend/src/app/lib/uploadFiles.test.ts
@@ -1,0 +1,122 @@
+import {
+  CAREER_AGENT_UPLOAD_DIR,
+  deleteAgentFile,
+  uploadAgentFiles,
+  type UploadResponse,
+} from "./uploadFiles";
+
+function jsonResponse(data: unknown, init: { ok?: boolean; status?: number } = {}) {
+  return {
+    ok: init.ok ?? true,
+    status: init.status ?? 200,
+    json: async () => data,
+  };
+}
+
+function nonJsonResponse(status: number) {
+  return {
+    ok: false,
+    status,
+    json: async () => {
+      throw new SyntaxError("Unexpected token < in JSON");
+    },
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("uploadAgentFiles", () => {
+  const files = [
+    new File(["abc"], "cv.pdf", { type: "application/pdf" }),
+    new File(["defg"], "jd.txt", { type: "text/plain" }),
+  ];
+
+  it("POSTs FormData with the target dir and one entry per file, returning parsed JSON", async () => {
+    const response: UploadResponse = {
+      uploaded: [
+        { path: `${CAREER_AGENT_UPLOAD_DIR}/cv.pdf`, size: 3 },
+        { path: `${CAREER_AGENT_UPLOAD_DIR}/jd.txt`, size: 4 },
+      ],
+      errors: [],
+    };
+    const fetchMock = vi.fn(async () => jsonResponse(response));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await uploadAgentFiles({ files, targetDir: CAREER_AGENT_UPLOAD_DIR });
+
+    expect(result).toEqual(response);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe("/api/files/upload");
+    expect(init.method).toBe("POST");
+
+    const body = init.body as FormData;
+    expect(body).toBeInstanceOf(FormData);
+    expect(body.get("path")).toBe(CAREER_AGENT_UPLOAD_DIR);
+    const entries = body.getAll("file") as File[];
+    expect(entries).toHaveLength(2);
+    expect(entries.map((f) => f.name)).toEqual(["cv.pdf", "jd.txt"]);
+    expect(entries.every((f) => f instanceof File)).toBe(true);
+  });
+
+  it("throws the server-provided error reason on a non-ok JSON response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse({ error: "file too large" }, { ok: false, status: 413 }))
+    );
+    await expect(uploadAgentFiles({ files, targetDir: "some/dir" })).rejects.toThrow(
+      "file too large"
+    );
+  });
+
+  it("throws a generic message when the error response is not JSON", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => nonJsonResponse(500))
+    );
+    await expect(uploadAgentFiles({ files, targetDir: "some/dir" })).rejects.toThrow(
+      "Upload failed (500)"
+    );
+  });
+
+  it("throws the generic message when the error JSON has no error field", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse({}, { ok: false, status: 422 }))
+    );
+    await expect(uploadAgentFiles({ files, targetDir: "some/dir" })).rejects.toThrow(
+      "Upload failed (422)"
+    );
+  });
+});
+
+describe("deleteAgentFile", () => {
+  it("DELETEs with the URL-encoded path in the query string", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse(null));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(deleteAgentFile("upload/my cv.pdf")).resolves.toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledExactlyOnceWith(
+      "/api/files/delete?path=upload%2Fmy%20cv.pdf",
+      { method: "DELETE" }
+    );
+  });
+
+  it("propagates the server-provided error reason", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse({ error: "forbidden" }, { ok: false, status: 403 }))
+    );
+    await expect(deleteAgentFile("upload/cv.pdf")).rejects.toThrow("forbidden");
+  });
+
+  it("falls back to a generic message when the error body is not JSON", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => nonJsonResponse(404))
+    );
+    await expect(deleteAgentFile("upload/cv.pdf")).rejects.toThrow("Delete failed (404)");
+  });
+});

--- a/frontend/src/app/print/file/page.tsx
+++ b/frontend/src/app/print/file/page.tsx
@@ -4,39 +4,12 @@ import React, { useEffect, useState } from "react";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { oneLight } from "react-syntax-highlighter/dist/esm/styles/prism";
 import { MarkdownContent } from "@/app/components/MarkdownContent";
-
-export type PrintKind = "markdown" | "code" | "docx";
-
-export type PrintPayload = {
-  path: string;
-  content: string;
-  kind: PrintKind;
-  language?: string;
-};
-
-export const PRINT_FILE_STORAGE_KEY = "nextrole:print-file";
-
-function parsePayload(raw: string | null): PrintPayload | null {
-  if (!raw) return null;
-  try {
-    const parsed = JSON.parse(raw) as Partial<PrintPayload>;
-    if (
-      typeof parsed?.path === "string" &&
-      typeof parsed?.content === "string" &&
-      (parsed.kind === "markdown" || parsed.kind === "code" || parsed.kind === "docx")
-    ) {
-      return parsed as PrintPayload;
-    }
-    return null;
-  } catch {
-    return null;
-  }
-}
-
-function basenameWithoutExtension(path: string): string {
-  const base = path.split("/").pop() || path;
-  return base.replace(/\.[^.]+$/, "");
-}
+import {
+  PRINT_FILE_STORAGE_KEY,
+  type PrintPayload,
+  basenameWithoutExtension,
+  parsePayload,
+} from "./printPayload";
 
 const PRINT_STYLES = `
 @page { margin: 0.75in; size: letter; }

--- a/frontend/src/app/print/file/printPayload.test.ts
+++ b/frontend/src/app/print/file/printPayload.test.ts
@@ -1,0 +1,61 @@
+import { basenameWithoutExtension, parsePayload, type PrintPayload } from "./printPayload";
+
+describe("parsePayload", () => {
+  it("parses a valid markdown payload", () => {
+    const payload: PrintPayload = { path: "resume.md", content: "# Resume", kind: "markdown" };
+    expect(parsePayload(JSON.stringify(payload))).toEqual(payload);
+  });
+
+  it("parses a valid code payload with a language", () => {
+    const payload: PrintPayload = {
+      path: "scripts/build.ts",
+      content: "console.log(1);",
+      kind: "code",
+      language: "typescript",
+    };
+    expect(parsePayload(JSON.stringify(payload))).toEqual(payload);
+  });
+
+  it("parses a valid docx payload", () => {
+    const payload: PrintPayload = { path: "letter.docx", content: "<p>Hi</p>", kind: "docx" };
+    expect(parsePayload(JSON.stringify(payload))).toEqual(payload);
+  });
+
+  it("rejects an unknown kind", () => {
+    expect(parsePayload(JSON.stringify({ path: "a.pdf", content: "x", kind: "pdf" }))).toBeNull();
+  });
+
+  it("rejects payloads with a missing or non-string path or content", () => {
+    expect(parsePayload(JSON.stringify({ content: "x", kind: "markdown" }))).toBeNull();
+    expect(parsePayload(JSON.stringify({ path: "a.md", kind: "markdown" }))).toBeNull();
+    expect(parsePayload(JSON.stringify({ path: 42, content: "x", kind: "markdown" }))).toBeNull();
+  });
+
+  it("returns null for non-JSON input", () => {
+    expect(parsePayload("not json")).toBeNull();
+  });
+
+  it("returns null for null or empty input", () => {
+    expect(parsePayload(null)).toBeNull();
+    expect(parsePayload("")).toBeNull();
+  });
+});
+
+describe("basenameWithoutExtension", () => {
+  it("strips directories and the extension from a nested path", () => {
+    expect(basenameWithoutExtension("career/resume/final.md")).toBe("final");
+  });
+
+  it("leaves names without an extension unchanged", () => {
+    expect(basenameWithoutExtension("README")).toBe("README");
+    expect(basenameWithoutExtension("docs/README")).toBe("README");
+  });
+
+  it("strips only the last extension when the name has multiple dots", () => {
+    expect(basenameWithoutExtension("backup.tar.gz")).toBe("backup.tar");
+  });
+
+  it("falls back to the full path for a trailing slash", () => {
+    expect(basenameWithoutExtension("folder/sub/")).toBe("folder/sub/");
+  });
+});

--- a/frontend/src/app/print/file/printPayload.ts
+++ b/frontend/src/app/print/file/printPayload.ts
@@ -1,0 +1,32 @@
+export type PrintKind = "markdown" | "code" | "docx";
+
+export type PrintPayload = {
+  path: string;
+  content: string;
+  kind: PrintKind;
+  language?: string;
+};
+
+export const PRINT_FILE_STORAGE_KEY = "nextrole:print-file";
+
+export function parsePayload(raw: string | null): PrintPayload | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as Partial<PrintPayload>;
+    if (
+      typeof parsed?.path === "string" &&
+      typeof parsed?.content === "string" &&
+      (parsed.kind === "markdown" || parsed.kind === "code" || parsed.kind === "docx")
+    ) {
+      return parsed as PrintPayload;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function basenameWithoutExtension(path: string): string {
+  const base = path.split("/").pop() || path;
+  return base.replace(/\.[^.]+$/, "");
+}

--- a/frontend/src/app/utils/filePaths.test.ts
+++ b/frontend/src/app/utils/filePaths.test.ts
@@ -1,0 +1,165 @@
+import { FILE_PATH_URL_PREFIX, normalizeFilePath, remarkFilePaths } from "./filePaths";
+
+type MdNode = {
+  type: string;
+  value?: string;
+  url?: string;
+  children?: MdNode[];
+};
+
+const text = (value: string): MdNode => ({ type: "text", value });
+const paragraph = (...children: MdNode[]): MdNode => ({ type: "paragraph", children });
+const root = (...children: MdNode[]): MdNode => ({ type: "root", children });
+
+/** Expected shape of a link node produced by the plugin for `path`. */
+const fileLink = (path: string): MdNode => ({
+  type: "link",
+  url: `${FILE_PATH_URL_PREFIX}${path}`,
+  children: [text(path)],
+});
+
+function transform(tree: MdNode): MdNode {
+  remarkFilePaths()(tree);
+  return tree;
+}
+
+describe("normalizeFilePath", () => {
+  it("returns an already-clean path unchanged", () => {
+    expect(normalizeFilePath("/processed/resume.md")).toBe("/processed/resume.md");
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(normalizeFilePath("  /processed/resume.md\t")).toBe("/processed/resume.md");
+  });
+
+  it("strips wrapping quotes and backticks", () => {
+    expect(normalizeFilePath('"/processed/resume.md"')).toBe("/processed/resume.md");
+    expect(normalizeFilePath("'/processed/resume.md'")).toBe("/processed/resume.md");
+    expect(normalizeFilePath("`/processed/resume.md`")).toBe("/processed/resume.md");
+  });
+
+  it("strips wrapping parens, brackets, and angle brackets", () => {
+    expect(normalizeFilePath("(/processed/resume.md)")).toBe("/processed/resume.md");
+    expect(normalizeFilePath("[/processed/resume.md]")).toBe("/processed/resume.md");
+    expect(normalizeFilePath("</processed/resume.md>")).toBe("/processed/resume.md");
+  });
+
+  it("strips trailing punctuation runs", () => {
+    expect(normalizeFilePath("/processed/resume.md.")).toBe("/processed/resume.md");
+    expect(normalizeFilePath("/processed/resume.md,;")).toBe("/processed/resume.md");
+    expect(normalizeFilePath("/processed/resume.md!?")).toBe("/processed/resume.md");
+    expect(normalizeFilePath("/processed/resume.md:")).toBe("/processed/resume.md");
+  });
+
+  it("adds a leading slash to relative paths", () => {
+    expect(normalizeFilePath("processed/resume.md")).toBe("/processed/resume.md");
+  });
+
+  it("handles whitespace, wrappers, trailing punctuation, and missing slash together", () => {
+    expect(normalizeFilePath(' "processed/resume.md", ')).toBe("/processed/resume.md");
+  });
+
+  it("only strips leading wrappers, not leading path characters", () => {
+    // The leading strip class does not include `/`, so absolute paths survive.
+    expect(normalizeFilePath("(`/a/b.md`)")).toBe("/a/b.md");
+  });
+});
+
+describe("remarkFilePaths", () => {
+  it("splits a text node with a path in the middle into text + link + text", () => {
+    const tree = root(paragraph(text("See /processed/resume.md for details")));
+    transform(tree);
+    expect(tree.children![0].children).toEqual([
+      text("See "),
+      fileLink("/processed/resume.md"),
+      text(" for details"),
+    ]);
+  });
+
+  it("handles a path at the start of the text", () => {
+    const tree = root(paragraph(text("/processed/resume.md is ready")));
+    transform(tree);
+    expect(tree.children![0].children).toEqual([
+      fileLink("/processed/resume.md"),
+      text(" is ready"),
+    ]);
+  });
+
+  it("handles a path at the end of the text without an empty trailing node", () => {
+    const tree = root(paragraph(text("Saved to /processed/resume.md")));
+    transform(tree);
+    expect(tree.children![0].children).toEqual([
+      text("Saved to "),
+      fileLink("/processed/resume.md"),
+    ]);
+  });
+
+  it("links two paths in one text node, keeping the text between them", () => {
+    const tree = root(paragraph(text("Compare /a/b.md and /c/d.txt now")));
+    transform(tree);
+    expect(tree.children![0].children).toEqual([
+      text("Compare "),
+      fileLink("/a/b.md"),
+      text(" and "),
+      fileLink("/c/d.txt"),
+      text(" now"),
+    ]);
+  });
+
+  it("excludes trailing sentence punctuation from the linked path", () => {
+    const tree = root(paragraph(text("Saved to /a/b.md.")));
+    transform(tree);
+    expect(tree.children![0].children).toEqual([text("Saved to "), fileLink("/a/b.md"), text(".")]);
+  });
+
+  it("leaves text without any path unchanged", () => {
+    const tree = root(paragraph(text("no file paths here")));
+    transform(tree);
+    expect(tree.children![0].children).toEqual([text("no file paths here")]);
+  });
+
+  it("does not link a single-segment relative path (regex requires a leading slash)", () => {
+    const tree = root(paragraph(text("see processed/resume.md please")));
+    transform(tree);
+    expect(tree.children![0].children).toEqual([text("see processed/resume.md please")]);
+  });
+
+  it("does not link a path without a subfolder", () => {
+    const tree = root(paragraph(text("see /resume.md please")));
+    transform(tree);
+    expect(tree.children![0].children).toEqual([text("see /resume.md please")]);
+  });
+
+  it("does not descend into existing link nodes", () => {
+    const existing: MdNode = {
+      type: "link",
+      url: "https://example.com",
+      children: [text("/processed/resume.md")],
+    };
+    const tree = root(paragraph(existing));
+    transform(tree);
+    const child = tree.children![0].children![0];
+    expect(child).toBe(existing);
+    expect(child.url).toBe("https://example.com");
+    expect(child.children).toEqual([text("/processed/resume.md")]);
+  });
+
+  it("leaves inlineCode and code nodes untouched", () => {
+    const inline: MdNode = { type: "inlineCode", value: "/processed/resume.md" };
+    const block: MdNode = { type: "code", value: "/processed/resume.md" };
+    const tree = root(paragraph(inline), block);
+    transform(tree);
+    expect(tree.children![0].children).toEqual([
+      { type: "inlineCode", value: "/processed/resume.md" },
+    ]);
+    expect(tree.children![1]).toEqual({ type: "code", value: "/processed/resume.md" });
+  });
+
+  it("descends into non-excluded containers like emphasis", () => {
+    const tree = root(paragraph({ type: "emphasis", children: [text("read /a/b.md now")] }));
+    transform(tree);
+    const emphasis = tree.children![0].children![0];
+    expect(emphasis.type).toBe("emphasis");
+    expect(emphasis.children).toEqual([text("read "), fileLink("/a/b.md"), text(" now")]);
+  });
+});

--- a/frontend/src/app/utils/sources.test.ts
+++ b/frontend/src/app/utils/sources.test.ts
@@ -1,0 +1,200 @@
+import { AIMessage, type BaseMessage, HumanMessage, ToolMessage } from "@langchain/core/messages";
+import type { AssembledToolCall } from "@langchain/react";
+import { extractSources, extractSourcesFromToolCalls } from "./sources";
+
+/** AI message that issues a single tool call with the given id/name. */
+function aiToolCall(id: string, name = "tavily_search"): AIMessage {
+  return new AIMessage({ content: "", tool_calls: [{ id, name, args: {} }] });
+}
+
+function toolResult(id: string, content: string): ToolMessage {
+  return new ToolMessage({ content, tool_call_id: id });
+}
+
+describe("extractSources", () => {
+  it("returns [] when there are no messages", () => {
+    expect(extractSources([])).toEqual([]);
+  });
+
+  it("extracts sources from JSON tool output with a results array", () => {
+    const output = JSON.stringify({
+      results: [
+        { title: "One", url: "https://one.example" },
+        { title: "Two", url: "https://two.example" },
+      ],
+    });
+    const messages: BaseMessage[] = [
+      new HumanMessage("find stuff"),
+      aiToolCall("call1"),
+      toolResult("call1", output),
+    ];
+    expect(extractSources(messages)).toEqual([
+      { id: "call1:0", title: "One", url: "https://one.example", toolCallId: "call1" },
+      { id: "call1:1", title: "Two", url: "https://two.example", toolCallId: "call1" },
+    ]);
+  });
+
+  it("parses a Pythonish dict output via quote/True/False/None coercion", () => {
+    const output =
+      "{'results': [{'title': 'X', 'url': 'https://x.example'}], 'ok': True, " +
+      "'flag': False, 'none': None}";
+    const messages: BaseMessage[] = [
+      aiToolCall("call1", "web_search"),
+      toolResult("call1", output),
+    ];
+    expect(extractSources(messages)).toEqual([
+      { id: "call1:0", title: "X", url: "https://x.example", toolCallId: "call1" },
+    ]);
+  });
+
+  it("falls back to url as title when a JSON result has no title", () => {
+    const output = JSON.stringify({
+      results: [{ url: "https://untitled.example" }, { title: "no url here" }],
+    });
+    const messages: BaseMessage[] = [aiToolCall("c"), toolResult("c", output)];
+    expect(extractSources(messages)).toEqual([
+      {
+        id: "c:0",
+        title: "https://untitled.example",
+        url: "https://untitled.example",
+        toolCallId: "c",
+      },
+    ]);
+  });
+
+  it("parses markdown output with ## Title + **URL:** blocks", () => {
+    const output = [
+      "## First Result",
+      "**URL:** https://one.example",
+      "",
+      "Some summary text.",
+      "",
+      "## Second Result",
+      "**URL:** https://two.example",
+    ].join("\n");
+    const messages: BaseMessage[] = [aiToolCall("call1"), toolResult("call1", output)];
+    expect(extractSources(messages)).toEqual([
+      { id: "call1:0", title: "First Result", url: "https://one.example", toolCallId: "call1" },
+      { id: "call1:1", title: "Second Result", url: "https://two.example", toolCallId: "call1" },
+    ]);
+  });
+
+  it("uses the url as the title in the **URL:**-only fallback", () => {
+    const output = "Top hit below\n**URL:** https://only.example\nno headings anywhere";
+    const messages: BaseMessage[] = [aiToolCall("call1"), toolResult("call1", output)];
+    expect(extractSources(messages)).toEqual([
+      {
+        id: "call1:0",
+        title: "https://only.example",
+        url: "https://only.example",
+        toolCallId: "call1",
+      },
+    ]);
+  });
+
+  it("dedupes the same URL across multiple tool messages", () => {
+    const output = JSON.stringify({ results: [{ title: "Dup", url: "https://dup.example" }] });
+    const messages: BaseMessage[] = [
+      aiToolCall("c1"),
+      aiToolCall("c2"),
+      toolResult("c1", output),
+      toolResult("c2", output),
+    ];
+    const sources = extractSources(messages);
+    expect(sources).toHaveLength(1);
+    expect(sources[0]).toEqual({
+      id: "c1:0",
+      title: "Dup",
+      url: "https://dup.example",
+      toolCallId: "c1",
+    });
+  });
+
+  it("ignores tool results from non-search tools", () => {
+    const output = JSON.stringify({ results: [{ title: "T", url: "https://t.example" }] });
+    const messages: BaseMessage[] = [aiToolCall("c1", "write_file"), toolResult("c1", output)];
+    expect(extractSources(messages)).toEqual([]);
+  });
+
+  it("ignores a ToolMessage whose tool_call_id has no matching AI tool call", () => {
+    const output = JSON.stringify({ results: [{ title: "T", url: "https://t.example" }] });
+    const messages: BaseMessage[] = [aiToolCall("real"), toolResult("orphan", output)];
+    expect(extractSources(messages)).toEqual([]);
+  });
+
+  it("returns [] for unparseable search output", () => {
+    const messages: BaseMessage[] = [aiToolCall("c1"), toolResult("c1", "no links in here")];
+    expect(extractSources(messages)).toEqual([]);
+  });
+});
+
+describe("extractSourcesFromToolCalls", () => {
+  function assembled(over: {
+    id: string;
+    name: string;
+    status: "running" | "finished" | "error";
+    output: unknown;
+  }): AssembledToolCall {
+    return {
+      name: over.name,
+      callId: over.id,
+      id: over.id,
+      namespace: [],
+      input: {},
+      args: {},
+      output: over.output,
+      status: over.status,
+      error: undefined,
+    } as AssembledToolCall;
+  }
+
+  const resultsJson = { results: [{ title: "Hit", url: "https://hit.example" }] };
+
+  it("parses a JSON string output from a finished search call", () => {
+    const calls = [
+      assembled({
+        id: "tc1",
+        name: "tavily_search",
+        status: "finished",
+        output: JSON.stringify(resultsJson),
+      }),
+    ];
+    expect(extractSourcesFromToolCalls(calls)).toEqual([
+      { id: "tc1:0", title: "Hit", url: "https://hit.example", toolCallId: "tc1" },
+    ]);
+  });
+
+  it("reads an already-parsed object output directly", () => {
+    const calls = [
+      assembled({ id: "tc2", name: "web_search", status: "finished", output: resultsJson }),
+    ];
+    expect(extractSourcesFromToolCalls(calls)).toEqual([
+      { id: "tc2:0", title: "Hit", url: "https://hit.example", toolCallId: "tc2" },
+    ]);
+  });
+
+  it("skips calls that are not finished", () => {
+    const calls = [
+      assembled({ id: "run", name: "tavily_search", status: "running", output: resultsJson }),
+      assembled({ id: "err", name: "tavily_search", status: "error", output: resultsJson }),
+    ];
+    expect(extractSourcesFromToolCalls(calls)).toEqual([]);
+  });
+
+  it("skips finished calls from non-search tools", () => {
+    const calls = [
+      assembled({ id: "tc3", name: "read_file", status: "finished", output: resultsJson }),
+    ];
+    expect(extractSourcesFromToolCalls(calls)).toEqual([]);
+  });
+
+  it("dedupes URLs across calls, keeping the first occurrence", () => {
+    const calls = [
+      assembled({ id: "a", name: "tavily_search", status: "finished", output: resultsJson }),
+      assembled({ id: "b", name: "web_search", status: "finished", output: resultsJson }),
+    ];
+    const sources = extractSourcesFromToolCalls(calls);
+    expect(sources).toHaveLength(1);
+    expect(sources[0].toolCallId).toBe("a");
+  });
+});

--- a/frontend/src/app/utils/toolErrors.test.ts
+++ b/frontend/src/app/utils/toolErrors.test.ts
@@ -1,0 +1,117 @@
+import { parseToolError, previewValue } from "@/app/utils/toolErrors";
+
+describe("parseToolError", () => {
+  it("returns null for null and undefined", () => {
+    expect(parseToolError(null)).toBeNull();
+    expect(parseToolError(undefined)).toBeNull();
+  });
+
+  it("returns null for benign strings without an error marker", () => {
+    expect(parseToolError("All good")).toBeNull();
+    expect(parseToolError("Wrote 3 files to the workspace")).toBeNull();
+  });
+
+  it("detects an Error: prefix and returns the message without a code", () => {
+    const result = parseToolError("Error: something broke");
+    expect(result).not.toBeNull();
+    expect(result?.message).toBe("Error: something broke");
+    expect(result?.code).toBeUndefined();
+  });
+
+  it("detects Exception and Failed prefixes", () => {
+    expect(parseToolError("Exception: boom")?.message).toBe("Exception: boom");
+    expect(parseToolError("Failed to reach the server")?.message).toBe(
+      "Failed to reach the server"
+    );
+  });
+
+  it("extracts code and message from an embedded JSON error object", () => {
+    const result = parseToolError('Error: {"error": {"code": 429, "message": "Rate limited"}}');
+    expect(result).toEqual({ code: "429", message: "Rate limited" });
+  });
+
+  it("extracts the code from a single-quoted python-style dict", () => {
+    const raw = "Error: {'error': {'code': 429}}";
+    const result = parseToolError(raw);
+    expect(result?.code).toBe("429");
+    // No message field in the dict — falls back to the full trimmed text.
+    expect(result?.message).toBe(raw);
+  });
+
+  it("extracts a numeric code from free text", () => {
+    const result = parseToolError("Error: request rejected with code: 429");
+    expect(result?.code).toBe("429");
+    expect(result?.message).toBe("Error: request rejected with code: 429");
+  });
+
+  it("extracts the code from a '429 TOO_MANY_REQUESTS' pattern", () => {
+    expect(parseToolError("Error: 429 TOO_MANY_REQUESTS")?.code).toBe("429");
+  });
+
+  it("extracts an upper-case status token as the code", () => {
+    const result = parseToolError("Error: status: 'RESOURCE_EXHAUSTED' for the model");
+    expect(result?.code).toBe("RESOURCE_EXHAUSTED");
+  });
+
+  it("caps the inspected message at 256 characters", () => {
+    const input = `Error: ${"x".repeat(500)}`;
+    const result = parseToolError(input);
+    expect(result?.message).toBe(input.slice(0, 256));
+    expect(result?.message).toHaveLength(256);
+  });
+
+  it("stringifies non-string input before matching", () => {
+    // JSON.stringify of an object starts with "{", which never matches the
+    // Error/Exception/Failed start-of-text marker — so structured (non-string)
+    // results are never reported as errors.
+    expect(parseToolError({ error: { code: 429, message: "boom" } })).toBeNull();
+    expect(parseToolError(429)).toBeNull();
+  });
+
+  it("returns null when the input cannot be stringified", () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    expect(parseToolError(circular)).toBeNull();
+  });
+});
+
+describe("previewValue", () => {
+  it("returns null for null and undefined", () => {
+    expect(previewValue(null)).toBeNull();
+    expect(previewValue(undefined)).toBeNull();
+  });
+
+  it("passes short strings through unchanged", () => {
+    expect(previewValue("hello")).toBe("hello");
+    expect(previewValue("a".repeat(96))).toBe("a".repeat(96));
+  });
+
+  it("truncates strings longer than 96 chars to 96 chars plus '...'", () => {
+    const result = previewValue("a".repeat(97));
+    expect(result).toBe(`${"a".repeat(96)}...`);
+    expect(result).toHaveLength(99);
+  });
+
+  it("renders objects and arrays as compact JSON", () => {
+    expect(previewValue({ a: 1, b: "two" })).toBe('{"a":1,"b":"two"}');
+    expect(previewValue([1, 2, 3])).toBe("[1,2,3]");
+  });
+
+  it("truncates long stringified objects to 96 chars plus '...'", () => {
+    const value = { text: "y".repeat(200) };
+    expect(previewValue(value)).toBe(`${JSON.stringify(value).slice(0, 96)}...`);
+  });
+
+  it("returns null for circular objects", () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    expect(previewValue(circular)).toBeNull();
+  });
+
+  it("stringifies numbers and booleans", () => {
+    expect(previewValue(42)).toBe("42");
+    expect(previewValue(0)).toBe("0");
+    expect(previewValue(true)).toBe("true");
+    expect(previewValue(false)).toBe("false");
+  });
+});

--- a/frontend/src/app/utils/toolErrors.ts
+++ b/frontend/src/app/utils/toolErrors.ts
@@ -1,0 +1,63 @@
+export function parseToolError(result: unknown): { code?: string; message?: string } | null {
+  if (result == null) return null;
+
+  // Cap inspection at 256 chars — error markers always appear at the start, and
+  // a long streaming payload here would force a JSON.stringify of the full body.
+  const raw =
+    typeof result === "string"
+      ? result
+      : (() => {
+          try {
+            return JSON.stringify(result);
+          } catch {
+            return "";
+          }
+        })();
+  if (!raw) return null;
+  const text = raw.length > 256 ? raw.slice(0, 256) : raw;
+  const trimmed = text.trim();
+  const startsWithError = /^(error|exception|failed)\b\s*:?\s*/i.test(trimmed);
+  if (!startsWithError) return null;
+
+  const objectStart = trimmed.indexOf("{");
+  if (objectStart !== -1) {
+    try {
+      const parsed = JSON.parse(trimmed.slice(objectStart).replace(/'/g, '"'));
+      const error = parsed?.error ?? parsed;
+      if (error?.code || error?.status || error?.message) {
+        return {
+          code: error.code ? String(error.code) : error.status,
+          message: error.message ? String(error.message) : trimmed,
+        };
+      }
+    } catch {
+      // Fall through to regex detection for Python-style dicts or plain strings.
+    }
+  }
+
+  const codeMatch =
+    trimmed.match(/\bcode['"]?\s*:\s*(\d{3,})/i) ?? trimmed.match(/\b(\d{3})\s+[A-Z_]+\b/);
+  const statusMatch = trimmed.match(/\bstatus['"]?\s*:\s*['"]?([A-Z_]+)/i);
+
+  return {
+    code: codeMatch?.[1] ?? statusMatch?.[1],
+    message: trimmed,
+  };
+}
+
+export function previewValue(value: unknown): string | null {
+  if (value == null) return null;
+  if (typeof value === "string") {
+    return value.length > 96 ? `${value.slice(0, 96)}...` : value;
+  }
+  // For objects/arrays we only need the first ~96 chars of the stringified form.
+  // JSON.stringify on a large streaming payload here is the dominant cost during
+  // streaming, so guard with try/catch and slice the result.
+  try {
+    const text = JSON.stringify(value);
+    if (!text) return null;
+    return text.length > 96 ? `${text.slice(0, 96)}...` : text;
+  } catch {
+    return null;
+  }
+}

--- a/frontend/src/app/utils/utils.test.ts
+++ b/frontend/src/app/utils/utils.test.ts
@@ -1,0 +1,162 @@
+import { AIMessage } from "@langchain/core/messages";
+import {
+  cn,
+  extractStringFromMessageContent,
+  extractSubAgentContent,
+  parsePartialArgs,
+  toResultString,
+  unwrapToolPayload,
+} from "./utils";
+
+describe("cn", () => {
+  it("merges conflicting tailwind classes, last one wins", () => {
+    expect(cn("p-2", "p-4")).toBe("p-4");
+    expect(cn("p-2 p-4")).toBe("p-4");
+  });
+
+  it("handles clsx conditionals and drops falsy values", () => {
+    expect(cn("base", { active: true, hidden: false }, undefined, null, "extra")).toBe(
+      "base active extra"
+    );
+  });
+});
+
+describe("extractStringFromMessageContent", () => {
+  it("returns plain string content as-is", () => {
+    expect(extractStringFromMessageContent(new AIMessage("hello world"))).toBe("hello world");
+  });
+
+  it("joins text content blocks", () => {
+    const message = new AIMessage({
+      content: [
+        { type: "text", text: "Hello, " },
+        { type: "text", text: "world" },
+      ],
+    });
+    expect(extractStringFromMessageContent(message)).toBe("Hello, world");
+  });
+});
+
+describe("extractSubAgentContent", () => {
+  it("returns string input unchanged", () => {
+    expect(extractSubAgentContent("already a string")).toBe("already a string");
+  });
+
+  it("prefers description over prompt and result", () => {
+    expect(extractSubAgentContent({ description: "d", prompt: "p", result: "r" })).toBe("d");
+  });
+
+  it("falls back to prompt when description is missing or unusable", () => {
+    expect(extractSubAgentContent({ prompt: "p", result: "r" })).toBe("p");
+    // Empty-string and non-string descriptions are skipped.
+    expect(extractSubAgentContent({ description: "", prompt: "p" })).toBe("p");
+    expect(extractSubAgentContent({ description: 42, prompt: "p" })).toBe("p");
+  });
+
+  it("falls back to result when description and prompt are missing", () => {
+    expect(extractSubAgentContent({ result: "r" })).toBe("r");
+  });
+
+  it("stringifies objects without any known field", () => {
+    expect(extractSubAgentContent({ other: 1 })).toBe(JSON.stringify({ other: 1 }, null, 2));
+  });
+
+  it("stringifies non-string primitives", () => {
+    expect(extractSubAgentContent(42)).toBe("42");
+    expect(extractSubAgentContent(true)).toBe("true");
+    expect(extractSubAgentContent(null)).toBe("null");
+  });
+
+  it("returns undefined for undefined input (JSON.stringify(undefined) is undefined)", () => {
+    // Actual behavior: the declared `string` return type notwithstanding.
+    expect(extractSubAgentContent(undefined)).toBeUndefined();
+  });
+});
+
+describe("unwrapToolPayload", () => {
+  it("unwraps a tool envelope with string content", () => {
+    expect(unwrapToolPayload({ type: "tool", content: "hello" })).toBe("hello");
+  });
+
+  it("joins an array of text blocks (strings and {text} objects)", () => {
+    const payload = {
+      type: "tool",
+      content: [{ type: "text", text: "a" }, "b", { type: "text", text: "c" }],
+    };
+    expect(unwrapToolPayload(payload)).toBe("abc");
+  });
+
+  it("maps blocks without usable text to empty strings", () => {
+    const payload = { type: "tool", content: [{ foo: 1 }, { text: null }, 42] };
+    expect(unwrapToolPayload(payload)).toBe("");
+  });
+
+  it("returns non-string, non-array envelope content as-is", () => {
+    const content = { nested: true };
+    expect(unwrapToolPayload({ type: "tool", content })).toBe(content);
+  });
+
+  it("passes through objects that are not tool envelopes", () => {
+    const notEnvelope = { foo: 1 };
+    expect(unwrapToolPayload(notEnvelope)).toBe(notEnvelope);
+    const wrongType = { type: "other", content: "x" };
+    expect(unwrapToolPayload(wrongType)).toBe(wrongType);
+    const noContent = { type: "tool" };
+    expect(unwrapToolPayload(noContent)).toBe(noContent);
+  });
+
+  it("leaves arrays untouched", () => {
+    const arr = [{ type: "tool", content: "x" }];
+    expect(unwrapToolPayload(arr)).toBe(arr);
+  });
+
+  it("passes through primitives, null, and undefined", () => {
+    expect(unwrapToolPayload("plain")).toBe("plain");
+    expect(unwrapToolPayload(null)).toBeNull();
+    expect(unwrapToolPayload(undefined)).toBeUndefined();
+  });
+});
+
+describe("toResultString", () => {
+  it("returns undefined for null and undefined", () => {
+    expect(toResultString(undefined)).toBeUndefined();
+    expect(toResultString(null)).toBeUndefined();
+  });
+
+  it("returns strings unchanged, including the empty string", () => {
+    expect(toResultString("hello")).toBe("hello");
+    expect(toResultString("")).toBe("");
+  });
+
+  it("pretty-prints objects as JSON", () => {
+    expect(toResultString({ a: 1 })).toBe('{\n  "a": 1\n}');
+    expect(toResultString(42)).toBe("42");
+  });
+
+  it("falls back to String() for circular objects", () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    expect(toResultString(circular)).toBe("[object Object]");
+  });
+});
+
+describe("parsePartialArgs", () => {
+  it("parses complete JSON objects", () => {
+    expect(parsePartialArgs('{"a": 1, "b": "two"}')).toEqual({ a: 1, b: "two" });
+  });
+
+  it("best-effort parses a truncated streaming JSON prefix", () => {
+    expect(parsePartialArgs('{"query": "hel')).toEqual({ query: "hel" });
+  });
+
+  it("returns {} when the parse result is not a plain object", () => {
+    expect(parsePartialArgs('"just a string"')).toEqual({});
+    expect(parsePartialArgs("[1, 2")).toEqual({});
+    expect(parsePartialArgs("not json at all")).toEqual({});
+  });
+
+  it("returns {} for undefined or empty input", () => {
+    expect(parsePartialArgs(undefined)).toEqual({});
+    expect(parsePartialArgs("")).toEqual({});
+  });
+});

--- a/frontend/src/lib/config.browser.test.tsx
+++ b/frontend/src/lib/config.browser.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * DEFAULT_CONFIG is computed from process.env at module-evaluation time, so every
+ * test loads a fresh copy of the module (vi.resetModules + dynamic import) with the
+ * relevant NEXT_PUBLIC vars stubbed. Runs in jsdom (real localStorage); no JSX.
+ */
+const CONFIG_KEY = "deep-agent-config";
+
+type ConfigModule = typeof import("@/lib/config");
+
+async function loadConfigModule(
+  env: { deploymentUrl?: string; assistantId?: string; langsmithApiKey?: string } = {}
+): Promise<ConfigModule> {
+  vi.resetModules();
+  vi.stubEnv("NEXT_PUBLIC_LANGGRAPH_DEPLOYMENT_URL", env.deploymentUrl);
+  vi.stubEnv("NEXT_PUBLIC_LANGGRAPH_ASSISTANT_ID", env.assistantId);
+  vi.stubEnv("NEXT_PUBLIC_LANGSMITH_API_KEY", env.langsmithApiKey);
+  return import("@/lib/config");
+}
+
+const ENV_DEFAULTS = { deploymentUrl: "http://env-host:2024", assistantId: "env-assistant" };
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("DEFAULT_CONFIG", () => {
+  it("is null when the NEXT_PUBLIC deployment env vars are unset", async () => {
+    const mod = await loadConfigModule();
+    expect(mod.DEFAULT_CONFIG).toBeNull();
+  });
+
+  it("is null when only one of the two required env vars is set", async () => {
+    const mod = await loadConfigModule({ deploymentUrl: "http://env-host:2024" });
+    expect(mod.DEFAULT_CONFIG).toBeNull();
+  });
+
+  it("derives from env when both deployment url and assistant id are set", async () => {
+    const mod = await loadConfigModule({ ...ENV_DEFAULTS, langsmithApiKey: "sk-env" });
+    expect(mod.DEFAULT_CONFIG).toEqual({
+      deploymentUrl: "http://env-host:2024",
+      assistantId: "env-assistant",
+      langsmithApiKey: "sk-env",
+    });
+  });
+
+  it("normalizes an empty langsmith key to undefined", async () => {
+    const mod = await loadConfigModule({ ...ENV_DEFAULTS, langsmithApiKey: "" });
+    expect(mod.DEFAULT_CONFIG).toEqual({
+      deploymentUrl: "http://env-host:2024",
+      assistantId: "env-assistant",
+      langsmithApiKey: undefined,
+    });
+  });
+});
+
+describe("getConfig", () => {
+  it("returns null with nothing stored and no env defaults", async () => {
+    const mod = await loadConfigModule();
+    expect(mod.getConfig()).toBeNull();
+  });
+
+  it("returns DEFAULT_CONFIG (same object) with nothing stored", async () => {
+    const mod = await loadConfigModule(ENV_DEFAULTS);
+    expect(mod.getConfig()).toBe(mod.DEFAULT_CONFIG);
+  });
+
+  it("returns valid stored JSON, which wins over the env default", async () => {
+    const stored = {
+      deploymentUrl: "http://stored-host:8123",
+      assistantId: "stored-assistant",
+      mainAgentModel: "model-big",
+    };
+    window.localStorage.setItem(CONFIG_KEY, JSON.stringify(stored));
+    const mod = await loadConfigModule(ENV_DEFAULTS);
+    expect(mod.getConfig()).toEqual(stored);
+  });
+
+  it("falls back to DEFAULT_CONFIG when the stored JSON is corrupted", async () => {
+    window.localStorage.setItem(CONFIG_KEY, "{definitely not json!!");
+    const mod = await loadConfigModule(ENV_DEFAULTS);
+    expect(mod.getConfig()).toBe(mod.DEFAULT_CONFIG);
+    expect(mod.getConfig()).toEqual({
+      deploymentUrl: "http://env-host:2024",
+      assistantId: "env-assistant",
+      langsmithApiKey: undefined,
+    });
+  });
+});
+
+describe("saveConfig", () => {
+  it("writes JSON under the storage key and round-trips through getConfig", async () => {
+    const mod = await loadConfigModule();
+    const config = {
+      deploymentUrl: "http://saved-host:9000",
+      assistantId: "saved-assistant",
+      langsmithApiKey: "sk-saved",
+      mainAgentModel: "model-big",
+      subagentModel: "model-small",
+    };
+
+    mod.saveConfig(config);
+
+    expect(window.localStorage.getItem(CONFIG_KEY)).toBe(JSON.stringify(config));
+    expect(mod.getConfig()).toEqual(config);
+  });
+});

--- a/frontend/src/lib/config.test.ts
+++ b/frontend/src/lib/config.test.ts
@@ -1,0 +1,98 @@
+const DEPLOYMENT_URL = "http://localhost:2024";
+const ASSISTANT_ID = "career_agent";
+
+/**
+ * DEFAULT_CONFIG is computed from process.env at import time, so every test
+ * stubs the env first, then dynamically imports a fresh copy of the module.
+ */
+async function loadConfig() {
+  return await import("@/lib/config");
+}
+
+function stubRequiredEnv() {
+  vi.stubEnv("NEXT_PUBLIC_LANGGRAPH_DEPLOYMENT_URL", DEPLOYMENT_URL);
+  vi.stubEnv("NEXT_PUBLIC_LANGGRAPH_ASSISTANT_ID", ASSISTANT_ID);
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  // Start from a known-clean slate regardless of the host shell's env.
+  vi.stubEnv("NEXT_PUBLIC_LANGGRAPH_DEPLOYMENT_URL", undefined);
+  vi.stubEnv("NEXT_PUBLIC_LANGGRAPH_ASSISTANT_ID", undefined);
+  vi.stubEnv("NEXT_PUBLIC_LANGSMITH_API_KEY", undefined);
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("DEFAULT_CONFIG", () => {
+  it("is built from env when both required vars are set", async () => {
+    stubRequiredEnv();
+    vi.stubEnv("NEXT_PUBLIC_LANGSMITH_API_KEY", "");
+    const { DEFAULT_CONFIG } = await loadConfig();
+    expect(DEFAULT_CONFIG).toEqual({
+      deploymentUrl: DEPLOYMENT_URL,
+      assistantId: ASSISTANT_ID,
+      langsmithApiKey: undefined,
+    });
+  });
+
+  it("coerces an empty NEXT_PUBLIC_LANGSMITH_API_KEY to undefined", async () => {
+    stubRequiredEnv();
+    vi.stubEnv("NEXT_PUBLIC_LANGSMITH_API_KEY", "");
+    const { DEFAULT_CONFIG } = await loadConfig();
+    expect(DEFAULT_CONFIG?.langsmithApiKey).toBeUndefined();
+  });
+
+  it("includes the langsmith key when it is set", async () => {
+    stubRequiredEnv();
+    vi.stubEnv("NEXT_PUBLIC_LANGSMITH_API_KEY", "ls-secret");
+    const { DEFAULT_CONFIG } = await loadConfig();
+    expect(DEFAULT_CONFIG?.langsmithApiKey).toBe("ls-secret");
+  });
+
+  it("is null when only the deployment URL is set", async () => {
+    vi.stubEnv("NEXT_PUBLIC_LANGGRAPH_DEPLOYMENT_URL", DEPLOYMENT_URL);
+    const { DEFAULT_CONFIG } = await loadConfig();
+    expect(DEFAULT_CONFIG).toBeNull();
+  });
+
+  it("is null when only the assistant id is set", async () => {
+    vi.stubEnv("NEXT_PUBLIC_LANGGRAPH_ASSISTANT_ID", ASSISTANT_ID);
+    const { DEFAULT_CONFIG } = await loadConfig();
+    expect(DEFAULT_CONFIG).toBeNull();
+  });
+
+  it("is null when neither required var is set", async () => {
+    const { DEFAULT_CONFIG } = await loadConfig();
+    expect(DEFAULT_CONFIG).toBeNull();
+  });
+});
+
+describe("getConfig (SSR / node, no window)", () => {
+  it("returns DEFAULT_CONFIG when it is populated", async () => {
+    stubRequiredEnv();
+    const mod = await loadConfig();
+    expect(mod.getConfig()).toBe(mod.DEFAULT_CONFIG);
+    expect(mod.getConfig()).toEqual({
+      deploymentUrl: DEPLOYMENT_URL,
+      assistantId: ASSISTANT_ID,
+      langsmithApiKey: undefined,
+    });
+  });
+
+  it("returns null when DEFAULT_CONFIG is null", async () => {
+    const mod = await loadConfig();
+    expect(mod.getConfig()).toBeNull();
+  });
+});
+
+describe("saveConfig (SSR / node, no window)", () => {
+  it("is a no-op that does not throw", async () => {
+    const { saveConfig } = await loadConfig();
+    expect(() =>
+      saveConfig({ deploymentUrl: "http://example.com", assistantId: "agent" })
+    ).not.toThrow();
+  });
+});

--- a/frontend/src/providers/AccentProvider.test.tsx
+++ b/frontend/src/providers/AccentProvider.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ACCENT_STORAGE_KEY, AccentProvider, DEFAULT_ACCENT, useAccent } from "./AccentProvider";
+
+function Probe() {
+  const { accent, setAccent } = useAccent();
+  return (
+    <div>
+      <span data-testid="accent">{accent}</span>
+      <button onClick={() => setAccent("blue")}>set blue</button>
+    </div>
+  );
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+  document.documentElement.removeAttribute("data-accent");
+});
+
+describe("AccentProvider", () => {
+  it("defaults to the default accent when nothing is stored", () => {
+    render(
+      <AccentProvider>
+        <Probe />
+      </AccentProvider>
+    );
+    expect(screen.getByTestId("accent")).toHaveTextContent(DEFAULT_ACCENT);
+  });
+
+  it("hydrates a valid stored accent on mount", () => {
+    window.localStorage.setItem(ACCENT_STORAGE_KEY, "coral");
+    render(
+      <AccentProvider>
+        <Probe />
+      </AccentProvider>
+    );
+    expect(screen.getByTestId("accent")).toHaveTextContent("coral");
+  });
+
+  it("ignores an invalid stored value", () => {
+    window.localStorage.setItem(ACCENT_STORAGE_KEY, "neon");
+    render(
+      <AccentProvider>
+        <Probe />
+      </AccentProvider>
+    );
+    expect(screen.getByTestId("accent")).toHaveTextContent(DEFAULT_ACCENT);
+  });
+
+  it("setAccent updates state, the <html> attribute, and storage", async () => {
+    const user = userEvent.setup();
+    render(
+      <AccentProvider>
+        <Probe />
+      </AccentProvider>
+    );
+
+    await user.click(screen.getByRole("button", { name: "set blue" }));
+
+    expect(screen.getByTestId("accent")).toHaveTextContent("blue");
+    expect(document.documentElement.getAttribute("data-accent")).toBe("blue");
+    expect(window.localStorage.getItem(ACCENT_STORAGE_KEY)).toBe("blue");
+  });
+});
+
+describe("useAccent", () => {
+  it("throws when used outside AccentProvider", () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(() => render(<Probe />)).toThrow("useAccent must be used within AccentProvider");
+    vi.restoreAllMocks();
+  });
+});

--- a/frontend/src/providers/ChatProvider.test.tsx
+++ b/frontend/src/providers/ChatProvider.test.tsx
@@ -1,0 +1,61 @@
+import { render, renderHook } from "@testing-library/react";
+import type { Assistant } from "@langchain/langgraph-sdk";
+import { useChat } from "@/app/hooks/useChat";
+import { ChatProvider, useChatContext } from "@/providers/ChatProvider";
+
+vi.mock("@/app/hooks/useChat", () => ({ useChat: vi.fn() }));
+
+const useChatMock = vi.mocked(useChat);
+
+const assistant = {
+  assistant_id: "asst-1",
+  graph_id: "career_agent",
+} as unknown as Assistant;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("ChatProvider", () => {
+  it("exposes the useChat return value through useChatContext", () => {
+    const sentinel = { sendMessage: vi.fn(), files: {} } as unknown as ReturnType<typeof useChat>;
+    useChatMock.mockReturnValue(sentinel);
+
+    let captured: unknown;
+    function Probe() {
+      captured = useChatContext();
+      return null;
+    }
+
+    render(
+      <ChatProvider activeAssistant={assistant}>
+        <Probe />
+      </ChatProvider>
+    );
+
+    expect(captured).toBe(sentinel);
+  });
+
+  it("forwards its props to useChat", () => {
+    useChatMock.mockReturnValue({} as ReturnType<typeof useChat>);
+    const onHistoryRevalidate = vi.fn();
+
+    render(
+      <ChatProvider activeAssistant={assistant} onHistoryRevalidate={onHistoryRevalidate}>
+        <span>child</span>
+      </ChatProvider>
+    );
+
+    expect(useChatMock).toHaveBeenCalledWith({ activeAssistant: assistant, onHistoryRevalidate });
+  });
+});
+
+describe("useChatContext", () => {
+  it("throws its exact error when used outside a ChatProvider", () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(() => renderHook(() => useChatContext())).toThrow(
+      "useChatContext must be used within a ChatProvider"
+    );
+    errSpy.mockRestore();
+  });
+});

--- a/frontend/src/providers/ClientProvider.test.tsx
+++ b/frontend/src/providers/ClientProvider.test.tsx
@@ -1,0 +1,89 @@
+import { render, renderHook } from "@testing-library/react";
+import { Client } from "@langchain/langgraph-sdk";
+import { ClientProvider, useClient } from "@/providers/ClientProvider";
+
+vi.mock("@langchain/langgraph-sdk", () => ({ Client: vi.fn() }));
+
+const ClientMock = vi.mocked(Client);
+
+let seenClients: unknown[] = [];
+
+function Probe() {
+  seenClients.push(useClient());
+  return null;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  seenClients = [];
+});
+
+describe("ClientProvider", () => {
+  it("constructs the SDK client with the deployment url and api-key headers", () => {
+    render(
+      <ClientProvider deploymentUrl="http://backend:2024" apiKey="sk-test">
+        <Probe />
+      </ClientProvider>
+    );
+
+    expect(ClientMock).toHaveBeenCalledTimes(1);
+    expect(ClientMock).toHaveBeenCalledWith({
+      apiUrl: "http://backend:2024",
+      defaultHeaders: {
+        "Content-Type": "application/json",
+        "X-Api-Key": "sk-test",
+      },
+    });
+    expect(seenClients[0]).toBe(ClientMock.mock.instances[0]);
+  });
+
+  it("keeps one identity-stable client across rerenders with unchanged props", () => {
+    const { rerender } = render(
+      <ClientProvider deploymentUrl="http://backend:2024" apiKey="sk-test">
+        <Probe />
+      </ClientProvider>
+    );
+    rerender(
+      <ClientProvider deploymentUrl="http://backend:2024" apiKey="sk-test">
+        <Probe />
+      </ClientProvider>
+    );
+
+    expect(ClientMock).toHaveBeenCalledTimes(1);
+    expect(seenClients.length).toBeGreaterThanOrEqual(2);
+    expect(seenClients.at(-1)).toBe(seenClients[0]);
+  });
+
+  it("constructs a new client when apiKey changes", () => {
+    const { rerender } = render(
+      <ClientProvider deploymentUrl="http://backend:2024" apiKey="sk-test">
+        <Probe />
+      </ClientProvider>
+    );
+    rerender(
+      <ClientProvider deploymentUrl="http://backend:2024" apiKey="sk-other">
+        <Probe />
+      </ClientProvider>
+    );
+
+    expect(ClientMock).toHaveBeenCalledTimes(2);
+    expect(ClientMock).toHaveBeenLastCalledWith({
+      apiUrl: "http://backend:2024",
+      defaultHeaders: {
+        "Content-Type": "application/json",
+        "X-Api-Key": "sk-other",
+      },
+    });
+    expect(seenClients.at(-1)).not.toBe(seenClients[0]);
+  });
+});
+
+describe("useClient", () => {
+  it("throws its exact error when used outside a ClientProvider", () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(() => renderHook(() => useClient())).toThrow(
+      "useClient must be used within a ClientProvider"
+    );
+    errSpy.mockRestore();
+  });
+});

--- a/frontend/src/providers/FilePreviewProvider.test.tsx
+++ b/frontend/src/providers/FilePreviewProvider.test.tsx
@@ -1,0 +1,190 @@
+import { act, render, renderHook, screen } from "@testing-library/react";
+import { FileViewDialog } from "@/app/components/FileViewDialog";
+import { useChatContext } from "@/providers/ChatProvider";
+import { FilePreviewProvider, useFilePreview } from "@/providers/FilePreviewProvider";
+
+vi.mock("@/providers/ChatProvider", () => ({ useChatContext: vi.fn() }));
+vi.mock("@/app/components/FileViewDialog", () => ({
+  FileViewDialog: vi.fn(() => <div data-testid="file-view-dialog" />),
+}));
+
+const useChatContextMock = vi.mocked(useChatContext);
+const dialogMock = vi.mocked(FileViewDialog);
+
+type PreviewApi = NonNullable<ReturnType<typeof useFilePreview>>;
+type ChatCtx = ReturnType<typeof useChatContext>;
+
+function makeChatCtx(overrides: Record<string, unknown> = {}) {
+  return {
+    files: {
+      "/processed/cv.md": "# CV body",
+      "notes/summary.md": "summary text",
+      "/raw/blocks.md": { content: ["line1", "line2"] },
+    },
+    setFiles: vi.fn().mockResolvedValue(undefined),
+    isLoading: false,
+    interrupt: undefined,
+    ...overrides,
+  } as unknown as ChatCtx;
+}
+
+function renderPreview(ctx: ChatCtx = makeChatCtx()) {
+  useChatContextMock.mockReturnValue(ctx);
+  let api: PreviewApi | null = null;
+  function Capture() {
+    api = useFilePreview();
+    return null;
+  }
+  render(
+    <FilePreviewProvider>
+      <Capture />
+    </FilePreviewProvider>
+  );
+  if (!api) throw new Error("preview context not captured");
+  return { ctx, api: api as PreviewApi };
+}
+
+/** openFile defers via setTimeout(0); run it under fake timers wrapped in act. */
+function openFileAndFlush(api: PreviewApi, candidate: string) {
+  act(() => {
+    api.openFile(candidate);
+  });
+  act(() => {
+    vi.runAllTimers();
+  });
+}
+
+function lastDialogProps() {
+  const call = dialogMock.mock.calls.at(-1);
+  if (!call) throw new Error("FileViewDialog was never rendered");
+  return call[0];
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("resolveFile", () => {
+  it("normalizes messy candidate paths to the canonical file key", () => {
+    const { api } = renderPreview();
+    expect(api.resolveFile("`/processed/cv.md`,")).toBe("/processed/cv.md");
+    expect(api.resolveFile("(/processed/cv.md)")).toBe("/processed/cv.md");
+    expect(api.resolveFile("processed/cv.md")).toBe("/processed/cv.md");
+    expect(api.resolveFile("  /processed/cv.md  ")).toBe("/processed/cv.md");
+  });
+
+  it("returns the stored key when it lacks a leading slash", () => {
+    const { api } = renderPreview();
+    expect(api.resolveFile("/notes/summary.md")).toBe("notes/summary.md");
+  });
+
+  it("returns null for paths that resolve to no known file", () => {
+    const { api } = renderPreview();
+    expect(api.resolveFile("/procesed/cv.md")).toBeNull();
+    expect(api.resolveFile("/missing/nope.md")).toBeNull();
+  });
+});
+
+describe("openFile", () => {
+  it("defers opening to the next tick, then shows the dialog with the resolved file", () => {
+    vi.useFakeTimers();
+    const { api } = renderPreview();
+
+    act(() => {
+      api.openFile("`/processed/cv.md`,");
+    });
+    // Not yet open: the setTimeout(0) hasn't fired.
+    expect(screen.queryByTestId("file-view-dialog")).not.toBeInTheDocument();
+    expect(dialogMock).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    expect(screen.getByTestId("file-view-dialog")).toBeInTheDocument();
+    const props = lastDialogProps();
+    expect(props.file).toEqual({ path: "/processed/cv.md", content: "# CV body" });
+    expect(props.editDisabled).toBe(false);
+  });
+
+  it("joins array content when the file value is an object with content blocks", () => {
+    vi.useFakeTimers();
+    const { api } = renderPreview();
+
+    openFileAndFlush(api, "/raw/blocks.md");
+
+    expect(lastDialogProps().file).toEqual({ path: "/raw/blocks.md", content: "line1\nline2" });
+  });
+
+  it("does not open a dialog for an unresolvable path", () => {
+    vi.useFakeTimers();
+    const { api } = renderPreview();
+
+    openFileAndFlush(api, "/ghost.md");
+
+    expect(dialogMock).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("file-view-dialog")).not.toBeInTheDocument();
+  });
+});
+
+describe("dialog wiring", () => {
+  it("disables editing while the stream is loading", () => {
+    vi.useFakeTimers();
+    const { api } = renderPreview(makeChatCtx({ isLoading: true }));
+
+    openFileAndFlush(api, "/processed/cv.md");
+
+    expect(lastDialogProps().editDisabled).toBe(true);
+  });
+
+  it("disables editing while an interrupt is pending", () => {
+    vi.useFakeTimers();
+    const { api } = renderPreview(makeChatCtx({ interrupt: { action_requests: [] } }));
+
+    openFileAndFlush(api, "/processed/cv.md");
+
+    expect(lastDialogProps().editDisabled).toBe(true);
+  });
+
+  it("saves through the chat context setFiles with the full merged files map", async () => {
+    vi.useFakeTimers();
+    const { api, ctx } = renderPreview();
+
+    openFileAndFlush(api, "/processed/cv.md");
+    const props = lastDialogProps();
+    await act(async () => {
+      await props.onSaveFile("/processed/cv.md", "updated body");
+    });
+
+    expect(ctx.setFiles).toHaveBeenCalledWith({
+      "/processed/cv.md": "updated body",
+      "notes/summary.md": "summary text",
+      "/raw/blocks.md": { content: ["line1", "line2"] },
+    });
+  });
+
+  it("closes the dialog via onClose", () => {
+    vi.useFakeTimers();
+    const { api } = renderPreview();
+
+    openFileAndFlush(api, "/processed/cv.md");
+    expect(screen.getByTestId("file-view-dialog")).toBeInTheDocument();
+
+    act(() => {
+      lastDialogProps().onClose();
+    });
+
+    expect(screen.queryByTestId("file-view-dialog")).not.toBeInTheDocument();
+  });
+});
+
+describe("useFilePreview", () => {
+  it("returns null outside the provider instead of throwing", () => {
+    const { result } = renderHook(() => useFilePreview());
+    expect(result.current).toBeNull();
+  });
+});

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -5,7 +5,7 @@
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
-    "types": ["node"],
+    "types": ["node", "vitest/globals"],
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,36 @@
+import { fileURLToPath } from "node:url";
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vitest/config";
+
+// Environment convention: `.test.ts` files run in node (pure modules, route
+// handlers, fetch wrappers); `.test.tsx` files run in jsdom (anything that
+// renders or touches window/localStorage). The extension is the switch — a
+// `.tsx` test without JSX (e.g. config.browser.test.tsx) is fine.
+export default defineConfig({
+  plugins: [react()],
+  resolve: { alias: { "@": fileURLToPath(new URL("./src", import.meta.url)) } },
+  test: {
+    globals: true,
+    projects: [
+      {
+        extends: true,
+        test: { name: "node", environment: "node", include: ["src/**/*.test.ts"] },
+      },
+      {
+        extends: true,
+        test: {
+          name: "jsdom",
+          environment: "jsdom",
+          include: ["src/**/*.test.tsx"],
+          setupFiles: ["./vitest.setup.ts"],
+        },
+      },
+    ],
+    coverage: {
+      provider: "v8",
+      include: ["src/**/*.{ts,tsx}"],
+      exclude: ["src/**/*.test.*", "src/components/ui/**", "src/app/types/**", "src/types/**"],
+      reporter: ["text", "html"],
+    },
+  },
+});

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -1,0 +1,32 @@
+import "@testing-library/jest-dom/vitest";
+
+// jsdom lacks several browser APIs that Radix primitives, use-stick-to-bottom,
+// and next-themes touch at render time. Stub only what's missing (`??=`) so a
+// future jsdom release that implements one of these wins automatically.
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+window.ResizeObserver ??= ResizeObserverStub as unknown as typeof ResizeObserver;
+
+window.matchMedia ??= ((query: string) => ({
+  matches: false,
+  media: query,
+  onchange: null,
+  addEventListener() {},
+  removeEventListener() {},
+  addListener() {},
+  removeListener() {},
+  dispatchEvent: () => false,
+})) as unknown as typeof window.matchMedia;
+
+Element.prototype.scrollIntoView ??= () => {};
+Element.prototype.hasPointerCapture ??= () => false;
+Element.prototype.setPointerCapture ??= () => {};
+Element.prototype.releasePointerCapture ??= () => {};
+window.HTMLElement.prototype.scrollTo ??= () => {};
+
+if (!window.PointerEvent) {
+  window.PointerEvent = MouseEvent as unknown as typeof PointerEvent;
+}


### PR DESCRIPTION
<!--
Thanks for contributing to NextRole! Please fill this in so reviewers have context.
See CONTRIBUTING.md for the full workflow.
-->

## What & why

The frontend had zero test infrastructure while the backend has pytest plus a required `backend-tests` check. This PR brings the frontend to parity:

- **Vitest 4 + React Testing Library + jsdom**, split into two projects by extension: `.test.ts` → node (pure modules, API route handlers), `.test.tsx` → jsdom (rendering / browser APIs). Vitest over Jest because the app depends on ESM-only packages (react-markdown 10, remark-gfm 4, deep-ESM react-syntax-highlighter) and the repo already ships Vitest 4 in `backend/server/api/js`.
- **367 tests in 33 colocated files**: utils/parsers (filePaths remark plugin, sources extraction incl. pythonish-dict coercion, tool error parsing), the security-critical `resolveSafe`/`resolveDir` path-traversal guards and all five `/api/files/*` handlers against a real temp-dir sandbox, config env-at-import branches, providers, `useChat` (submit config, interrupt resume, the full file CRUD routing matrix) and `useThreads` over real SWR, plus eleven components (ToolCallBox, MarkdownContent file-linkification, HITL approval, ThreadList, FileViewDialog incl. docx-via-mammoth and print payload, TasksFilesSidebar, ChatInterface, …).
- **New required `frontend-tests` CI check** (`.github/workflows/frontend-tests.yml`) mirroring `backend-tests.yml`'s detect-job + job-level `if:` pattern, so backend-only/docs-only PRs report success via skip instead of blocking on "Expected". Node comes from `frontend/.nvmrc` (24) to match the runtime.
- **Small testability refactor (zero behavior change)**: print payload parsing moved out of the print route module (also fixes `FileViewDialog` importing from a route file), tool error parsing moved out of `ToolCallBox`, `formatTime` exported.
- **Docs/skill**: Testing sections in `CONTRIBUTING.md` + `frontend/CLAUDE.md`, PR template checklist, and the `upgrade-frontend-deps` skill's Gate G now runs `pnpm test` (plus a `vitest`↔`@vitest/coverage-v8` lockstep ground rule — coverage is an exact-version peer of the runner).

Deliberate coverage skips: vendored `components/ui/*` shadcn primitives, thin presentational components, `page.tsx`/`layout.tsx` (whole-app integration is agent-browser territory), and dead code paths (composer attach is behind a hardcoded off flag).

Notable findings from writing the tests (not fixed here, tested as-is): an unreachable branch in `useChat.setFiles`' state routing, `useThreads` has two distinct fallback titles, and delete's EISDIR branch is only reachable on Linux (darwin throws EPERM) — covered via a mocked `unlink`.

Follow-up candidates: CI still never runs `next build` (a separate non-required `frontend-build` job would catch build-only breakage); `ci.yml` pins Node 22 while the runtime is 24 (`node-version-file` would end the drift).

**Post-merge step**: add `frontend-tests` to the branch-protection required checks.

## Type of change

- [ ] 🐛 `fix` — bug fix
- [ ] ✨ `feat` — new feature
- [ ] 📝 `docs` — documentation only
- [ ] ♻️ `refactor` — no behavior change
- [x] 🧹 `chore` / `test` — tooling, deps, tests

## How was it tested?

- `pnpm test` — 367/367 across both projects (node + jsdom), ~2s.
- `pnpm exec tsc --noEmit`, `pnpm lint` (0 errors; warning count unchanged at the pre-existing 18), `pnpm build` (colocated tests don't become routes), `check:sdk-sync` single copy.
- Every commit passed the pre-commit gate (prettier, eslint, tsc, gitleaks, hygiene).
- Route-handler tests exercise real filesystem traversal in a `mkdtemp` sandbox — no fs mocks for the security cases.

## Checklist

- [x] PR is focused on a single logical change
- [x] Added/updated tests for changed behavior (backend: `cd backend && uv run pytest`; frontend: `cd frontend && pnpm test`)
- [x] Ran the quality gate locally (`pre-commit run --all-files`)
- [x] Updated docs (README / `CLAUDE.md` / `docs/prd/`) if behavior changed
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] No secrets or user uploads (CVs/JDs) committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)