### PR TITLE
feat: enforce per-user authn + authz in the agent server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,15 @@ GOOGLE_AUTH_CLIENT_SECRET=
 #   AUTH_DATABASE_URL="postgresql://<POSTGRES_USER>:<POSTGRES_PASSWORD>@localhost:<POSTGRES_LOCAL_PORT>/<POSTGRES_DB>" \
 #   BETTER_AUTH_SECRET=<same secret> \
 #     pnpm --dir frontend dlx @better-auth/cli@latest migrate --config src/lib/auth/server.ts
+#
+# Backend enforcement — set BOTH of these together with AUTH_ENABLED=true
+# (frontend login without backend enforcement is fine for trying the UI, but
+# provides no isolation; backend enforcement without frontend tokens 401s
+# every request):
+#   LANGGRAPH_AUTH={"path": "/deps/next-role/backend/agents/auth.py:auth", "disable_studio_auth": true}
+# In cloud deployments additionally set REQUIRE_AUTH=true — the backend then
+# refuses to boot if LANGGRAPH_AUTH is missing:
+#   REQUIRE_AUTH=true
 
 # --- Object storage (binary artifacts: uploads + rendered PDFs) ---
 # Local dev runs SeaweedFS (S3-compatible) via docker compose; in the cloud,

--- a/backend/agents/auth.py
+++ b/backend/agents/auth.py
@@ -1,0 +1,167 @@
+"""Custom authentication + authorization for multi-user mode.
+
+Loaded by the agent server when ``LANGGRAPH_AUTH`` points here
+(``{"path": "/deps/next-role/backend/agents/auth.py:auth", "disable_studio_auth": true}``).
+With ``LANGGRAPH_AUTH`` unset this module is never imported and the server
+runs in its zero-login single-user mode.
+
+Authentication: every request must carry ``Authorization: Bearer <JWT>``
+minted by the frontend's Better Auth JWT plugin (``/api/auth/token``). The
+token is verified against the frontend's JWKS (``AUTH_JWKS_URL``) with the
+algorithm pinned to EdDSA — never trusted from the token header — plus
+issuer/audience checks when configured. The JWT ``sub`` claim (the Better
+Auth user id) becomes the identity that owns threads, files, and memory.
+
+Authorization ("single-owner resources"): the most specific ``@auth.on``
+handler runs per request. Threads (which also cover runs — run events
+dispatch under the ``threads`` resource) and crons stamp
+``metadata.owner = identity`` on create and return an ``{"owner": identity}``
+filter that the core-server servicers enforce in SQL. Assistants are shared:
+readable by every authenticated user, mutable by none. Store namespaces are
+rewritten so their first segment is always the caller's identity. Anything
+without a specific handler falls into the global default-deny.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import Any
+
+import jwt
+from jwt import PyJWKClient
+from langgraph_sdk import Auth
+
+# Required when this module is active; fail fast at import with a clear name.
+_JWKS_URL = os.environ["AUTH_JWKS_URL"]
+_ISSUER = os.environ.get("AUTH_JWT_ISSUER") or None
+_AUDIENCE = os.environ.get("AUTH_JWT_AUDIENCE") or None
+
+# Better Auth's JWT plugin signs with EdDSA (Ed25519) by default. Pin it —
+# accepting the token header's alg would let a caller downgrade verification.
+_ALGORITHMS = ["EdDSA"]
+
+# PyJWKClient caches fetched keys (lifespan below) so the thread hop for its
+# blocking HTTP fetch is rare after startup.
+_jwk_client = PyJWKClient(_JWKS_URL, cache_keys=True, lifespan=300)
+
+auth = Auth()
+
+
+@auth.authenticate
+async def authenticate(authorization: str | None) -> Auth.types.MinimalUserDict:
+    """Verify the Better Auth bearer JWT and resolve the caller's identity.
+
+    Uses the ``authorization`` parameter (not ``request``) so the same
+    handler serves HTTP and WebSocket scopes.
+    """
+    scheme, _, token = (authorization or "").partition(" ")
+    if scheme.lower() != "bearer" or not token:
+        raise Auth.exceptions.HTTPException(
+            status_code=401,
+            detail="Missing bearer token",
+        )
+    try:
+        signing_key = await asyncio.to_thread(_jwk_client.get_signing_key_from_jwt, token)
+        claims = jwt.decode(
+            token,
+            signing_key.key,
+            algorithms=_ALGORITHMS,
+            issuer=_ISSUER,
+            audience=_AUDIENCE,
+            options={
+                "require": ["exp", "sub"],
+                "verify_iss": _ISSUER is not None,
+                "verify_aud": _AUDIENCE is not None,
+            },
+        )
+    except jwt.PyJWTError as e:
+        raise Auth.exceptions.HTTPException(
+            status_code=401,
+            detail=f"Invalid token: {e}",
+        ) from None
+    # Only `identity` drives authorization/scoping; carry a display name when
+    # the token provides one (MinimalUserDict has no email field).
+    user: Auth.types.MinimalUserDict = {"identity": claims["sub"]}
+    if isinstance(name := claims.get("name"), str):
+        user["display_name"] = name
+    return user
+
+
+def _stamp_owner(value: dict[str, Any], identity: str) -> None:
+    """Write ``owner`` into the resource's metadata (persisted on create).
+
+    Mutating ``value["metadata"]`` is the contract: for run creation the ops
+    layer serializes this same dict into the run row and into the metadata of
+    an implicitly-created thread, which is what the SQL filters match on.
+    """
+    if isinstance(value, dict):
+        metadata = value.setdefault("metadata", None)
+        if metadata is None:
+            value["metadata"] = {"owner": identity}
+        elif isinstance(metadata, dict):
+            metadata["owner"] = identity
+
+
+@auth.on.threads
+async def authorize_threads(
+    ctx: Auth.types.AuthContext,
+    value: dict[str, Any],
+) -> dict[str, Any]:
+    """Threads (and runs — same resource) are private to their owner."""
+    _stamp_owner(value, ctx.user.identity)
+    return {"owner": ctx.user.identity}
+
+
+@auth.on.crons
+async def authorize_crons(
+    ctx: Auth.types.AuthContext,
+    value: dict[str, Any],
+) -> dict[str, Any]:
+    """Crons are private to their owner (same metadata convention)."""
+    _stamp_owner(value, ctx.user.identity)
+    return {"owner": ctx.user.identity}
+
+
+@auth.on.assistants
+async def authorize_assistants(
+    ctx: Auth.types.AuthContext,
+    value: dict[str, Any],  # noqa: ARG001  (required by the @auth.on keyword-call contract)
+) -> bool | None:
+    """Assistants are shared system config: read for everyone, write for no one.
+
+    The career_agent assistant is registered by the deployment itself
+    (LANGSERVE_GRAPHS), not created by users.
+    """
+    if ctx.action in ("create", "update", "delete"):
+        return False
+    return None
+
+
+@auth.on.store
+async def authorize_store(
+    ctx: Auth.types.AuthContext,
+    value: dict[str, Any],
+) -> None:
+    """Scope every store namespace to the caller.
+
+    Rewrite pattern: the caller keeps using logical namespaces (e.g.
+    ``("career_agent", "memory")``) and the identity is prepended server-side,
+    landing on the same physical rows the agent's per-user StoreBackend
+    namespaces address. A namespace already starting with the identity is
+    left as-is. A foreign prefix simply becomes a scoped (empty) subtree —
+    cross-user reads are impossible by construction.
+    """
+    identity = ctx.user.identity
+    namespace = tuple(value.get("namespace") or ())
+    if not namespace or namespace[0] != identity:
+        value["namespace"] = (identity, *namespace)
+
+
+@auth.on
+async def deny_unhandled(
+    ctx: Auth.types.AuthContext,  # noqa: ARG001  (required by the @auth.on keyword-call contract)
+    value: dict[str, Any],  # noqa: ARG001
+) -> bool:
+    """Fail closed: any resource/action without a specific handler is denied."""
+    return False

--- a/backend/agents/files_api.py
+++ b/backend/agents/files_api.py
@@ -27,6 +27,8 @@ from __future__ import annotations
 import asyncio
 import base64
 import binascii
+import functools
+import os
 from typing import TYPE_CHECKING, Any
 
 from backend.agents.career_agent.object_storage import (
@@ -50,6 +52,27 @@ if TYPE_CHECKING:
 
 _ALLOWED_UPLOAD_EXTS = {"pdf", "doc", "docx", "txt", "md"}
 _MAX_UPLOAD_BYTES = 10 * 1024 * 1024
+
+# Multi-user mode marker: when the server runs with custom auth, its
+# middleware wraps this app too (`enable_custom_route_auth` in LANGGRAPH_HTTP)
+# and populates request.scope["user"]. The guard below is belt-and-braces for
+# the misconfigured case (auth set but the custom-route flag missing).
+_AUTH_ENABLED = bool(os.environ.get("LANGGRAPH_AUTH"))
+
+
+def _authenticated(handler):  # noqa: ANN001, ANN202
+    """Reject unauthenticated requests with 401 in multi-user mode."""
+
+    @functools.wraps(handler)
+    async def wrapped(request: Request) -> JSONResponse:
+        if _AUTH_ENABLED:
+            user = request.scope.get("user")
+            if user is None or not getattr(user, "is_authenticated", False):
+                return JSONResponse({"error": "Unauthorized"}, status_code=401)
+        return await handler(request)
+
+    return wrapped
+
 
 # Extensions served as base64 (mirrors the frontend's former BINARY_EXTS).
 _BINARY_EXTS = {
@@ -254,10 +277,10 @@ async def delete_file(request: Request) -> JSONResponse:
 
 app = Starlette(
     routes=[
-        Route("/files/list", list_files, methods=["GET"]),
-        Route("/files/read", read_file, methods=["GET"]),
-        Route("/files/upload", upload_files, methods=["POST"]),
-        Route("/files/write", write_file, methods=["PUT"]),
-        Route("/files/delete", delete_file, methods=["DELETE"]),
+        Route("/files/list", _authenticated(list_files), methods=["GET"]),
+        Route("/files/read", _authenticated(read_file), methods=["GET"]),
+        Route("/files/upload", _authenticated(upload_files), methods=["POST"]),
+        Route("/files/write", _authenticated(write_file), methods=["PUT"]),
+        Route("/files/delete", _authenticated(delete_file), methods=["DELETE"]),
     ],
 )

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -85,7 +85,9 @@ dependencies = [
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-pythonpath = [".."]
+# Repo root for `backend.agents.*` namespace imports; "." for the server
+# top-level packages (server.core_server, ...) — mirrors [tool.ty.environment].
+pythonpath = ["..", "."]
 asyncio_mode = "auto"
 addopts = "--import-mode=importlib -m 'not integration and not eval'"
 markers = [

--- a/backend/server/api/config/__init__.py
+++ b/backend/server/api/config/__init__.py
@@ -452,6 +452,19 @@ LANGGRAPH_AUTH = env(
     cast=_parse.parse_schema(AuthConfig),
     default=None,
 )
+# Deployment guard for multi-user mode: a cloud deployment sets
+# REQUIRE_AUTH=true so a misconfigured (auth-less) boot fails loudly instead
+# of serving every user's data to everyone. Local zero-login mode leaves both
+# unset.
+REQUIRE_AUTH = env("REQUIRE_AUTH", cast=bool, default=False)
+if REQUIRE_AUTH and not LANGGRAPH_AUTH:
+    raise RuntimeError(
+        "REQUIRE_AUTH is set but LANGGRAPH_AUTH is not configured — refusing "
+        "to start an unauthenticated multi-user deployment. Set LANGGRAPH_AUTH "
+        '(e.g. {"path": "/deps/next-role/backend/agents/auth.py:auth", '
+        '"disable_studio_auth": true}) or unset REQUIRE_AUTH for single-user use.',
+    )
+
 # Not in public docs: populated by langgraph.json config, not set as env var directly
 LANGGRAPH_ENCRYPTION = env(
     "LANGGRAPH_ENCRYPTION",

--- a/backend/server/core_server/_filters.py
+++ b/backend/server/core_server/_filters.py
@@ -1,0 +1,138 @@
+"""Translate custom-auth ``AuthFilter`` protos into parameterized SQL predicates.
+
+The HTTP ops layer (server/api/grpc/ops) runs the deployment's custom-auth
+handlers and ships the resulting ownership filters on request protos
+(``request.filters``, ``request.thread_filters``, ``request.assistant_filters``).
+The native servicers translate them here into WHERE predicates so that
+authorization is enforced at the data plane — an unowned row is
+indistinguishable from a missing one (NOT_FOUND, never a 403 existence
+oracle).
+
+With no filters (single-user / noop auth) every helper returns ``""`` and
+queries stay byte-for-byte what they were before multi-user support.
+
+Safety: filter values are always bound as psycopg named parameters (wrapped
+in ``Jsonb``) — never interpolated into SQL. Metadata matching uses JSONB
+containment (``@>``), which the existing GIN ``jsonb_path_ops`` indexes on
+``thread.metadata`` / ``assistant.metadata`` satisfy. ``column`` /
+``thread_id_expr`` arguments are trusted literals supplied by servicer code,
+never request data.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import orjson
+from psycopg.types.json import Jsonb
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from server.grpc_common.proto import core_api_pb2 as pb
+
+
+def filters_clause(
+    filters: Iterable[pb.AuthFilter],
+    params: dict[str, Any],
+    *,
+    column: str = "metadata",
+    param_prefix: str = "_af",
+) -> str:
+    """Build one SQL predicate for a request's AuthFilter list.
+
+    Args:
+        filters: repeated ``pb.AuthFilter`` field from a request proto.
+        params: the query's named-parameter dict; bindings are added in place
+            under collision-free ``{param_prefix}N`` names.
+        column: trusted SQL text for the JSONB column the filters target
+            (optionally alias-qualified, e.g. ``"thread.metadata"``).
+        param_prefix: prefix for generated parameter names.
+
+    Returns:
+        ``""`` when there is nothing to enforce, else a parenthesized
+        predicate ANDing all top-level filters (upstream semantics: the
+        filter list is a conjunction).
+    """
+    if not filters:
+        return ""
+    state = _BindState(params, param_prefix)
+    preds = [p for f in filters if (p := _predicate(f, state, column))]
+    if not preds:
+        return ""
+    return "(" + " AND ".join(preds) + ")"
+
+
+def thread_owner_clause(
+    filters: Iterable[pb.AuthFilter],
+    params: dict[str, Any],
+    *,
+    thread_id_expr: str,
+    param_prefix: str = "_af",
+) -> str:
+    """Ownership predicate for run rows via their parent thread.
+
+    Runs carry no owner column of their own — ownership is the parent
+    thread's metadata — so run RPCs wrap the thread filter in an EXISTS
+    subquery. ``thread_id_expr`` is trusted SQL text (e.g. ``"run.thread_id"``).
+    """
+    inner = filters_clause(
+        filters,
+        params,
+        column="_af_thread.metadata",
+        param_prefix=param_prefix,
+    )
+    if not inner:
+        return ""
+    return (
+        "EXISTS (SELECT 1 FROM thread AS _af_thread "
+        f"WHERE _af_thread.thread_id = {thread_id_expr} AND {inner})"
+    )
+
+
+class _BindState:
+    """Allocates collision-free named parameters into an existing dict."""
+
+    def __init__(self, params: dict[str, Any], prefix: str) -> None:
+        self.params = params
+        self.prefix = prefix
+        self.n = 0
+
+    def bind(self, value: Any) -> str:
+        while (name := f"{self.prefix}{self.n}") in self.params:
+            self.n += 1
+        self.params[name] = value
+        self.n += 1
+        return name
+
+
+def _predicate(f: pb.AuthFilter, state: _BindState, column: str) -> str:
+    kind = f.WhichOneof("filter")
+    if kind == "eq":
+        # match is JSON text (see ops._serialize_filter_value); containment on
+        # a single key-value pair is equality for scalar values.
+        value = orjson.loads(f.eq.match)
+        name = state.bind(Jsonb({f.eq.key: value}))
+        return f"{column} @> %({name})s"
+    if kind == "contains":
+        preds = []
+        for match in f.contains.matches:
+            value = orjson.loads(match)
+            name = state.bind(Jsonb({f.contains.key: [value]}))
+            preds.append(f"{column} @> %({name})s")
+        return _join(preds, " OR ")
+    if kind == "and_filter":
+        preds = [p for sub in f.and_filter.filters if (p := _predicate(sub, state, column))]
+        return _join(preds, " AND ")
+    if kind == "or_filter":
+        preds = [p for sub in f.or_filter.filters if (p := _predicate(sub, state, column))]
+        return _join(preds, " OR ")
+    return ""
+
+
+def _join(preds: list[str], sep: str) -> str:
+    if not preds:
+        return ""
+    if len(preds) == 1:
+        return preds[0]
+    return "(" + sep.join(preds) + ")"

--- a/backend/server/core_server/servicers/assistants.py
+++ b/backend/server/core_server/servicers/assistants.py
@@ -23,6 +23,7 @@ from server.core_server._convert import (
     assistant_version_to_proto,
     loads,
 )
+from server.core_server._filters import filters_clause
 from server.grpc_common.conversion.config import config_from_proto
 from server.grpc_common.proto import core_api_pb2 as pb
 from server.grpc_common.proto.core_api_pb2_grpc import AssistantsServicer
@@ -76,13 +77,16 @@ def _merge_config_context(config: dict, context: dict) -> tuple[dict, dict]:
 class AssistantsServicerImpl(AssistantsServicer):
     async def Get(self, request: pb.GetAssistantRequest, context) -> pb.Assistant:
         graphs = _registered_graphs()
-        sql = "SELECT * FROM assistant WHERE assistant_id = %s"
-        args: list = [request.assistant_id]
+        sql = "SELECT * FROM assistant WHERE assistant_id = %(aid)s"
+        params: dict = {"aid": request.assistant_id}
         if graphs is not None:
-            sql += " AND graph_id = ANY(%s)"
-            args.append(list(graphs))
+            sql += " AND graph_id = ANY(%(graphs)s)"
+            params["graphs"] = list(graphs)
+        fc = filters_clause(request.filters, params)
+        if fc:
+            sql += f" AND {fc}"
         async with db.pool().connection() as conn, conn.cursor() as cur:
-            await cur.execute(sql, args)
+            await cur.execute(sql, params)
             row = await cur.fetchone()
         if row is None:
             await context.abort(
@@ -255,6 +259,9 @@ class AssistantsServicerImpl(AssistantsServicer):
             if meta:
                 where.append("metadata @> %(meta)s")
                 params["meta"] = Jsonb(meta)
+        fc = filters_clause(request.filters, params)
+        if fc:
+            where.append(fc)
         params["limit"] = request.limit if request.HasField("limit") else 1000
         params["offset"] = request.offset if request.HasField("offset") else 0
         col = _sort_col(request.sort_by) if request.HasField("sort_by") else "created_at"
@@ -346,6 +353,9 @@ class AssistantsServicerImpl(AssistantsServicer):
             if meta:
                 where.append("metadata @> %(meta)s")
                 params["meta"] = Jsonb(meta)
+        fc = filters_clause(request.filters, params)
+        if fc:
+            where.append(fc)
         clause = (" WHERE " + " AND ".join(where)) if where else ""
         async with db.pool().connection() as conn, conn.cursor() as cur:
             await cur.execute(f"SELECT count(*) AS n FROM assistant{clause}", params)

--- a/backend/server/core_server/servicers/crons.py
+++ b/backend/server/core_server/servicers/crons.py
@@ -21,6 +21,7 @@ from psycopg.types.json import Jsonb
 
 from server.core_server import db
 from server.core_server._convert import json_bytes, loads, ts
+from server.core_server._filters import filters_clause
 from server.grpc_common.conversion.config import config_from_proto, config_to_proto
 from server.grpc_common.proto import core_api_pb2 as pb
 from server.grpc_common.proto import enum_cron_on_run_completed_pb2 as cron_orc_pb2
@@ -196,10 +197,13 @@ class CronsServicerImpl(CronsServicer):
         return cron_to_proto(row)
 
     async def Get(self, request: pb.GetCronRequest, context) -> pb.Cron:
+        params: dict = {"cid": request.cron_id.value}
+        fc = filters_clause(request.filters, params)
+        cond = f" AND {fc}" if fc else ""
         async with db.pool().connection() as conn, conn.cursor() as cur:
             await cur.execute(
-                "SELECT * FROM cron WHERE cron_id = %s",
-                (request.cron_id.value,),
+                f"SELECT * FROM cron WHERE cron_id = %(cid)s{cond}",
+                params,
             )
             row = await cur.fetchone()
         if row is None:
@@ -240,10 +244,12 @@ class CronsServicerImpl(CronsServicer):
             sets.append("metadata = %(metadata)s")
             params["metadata"] = Jsonb(loads(request.metadata_json))
         set_clause = (", " + ", ".join(sets)) if sets else ""
+        fc = filters_clause(request.filters, params)
+        cond = f" AND {fc}" if fc else ""
         async with db.pool().connection() as conn, conn.cursor() as cur:
             await cur.execute(
                 f"UPDATE cron SET updated_at = now(){set_clause} "
-                "WHERE cron_id = %(cron_id)s RETURNING *",
+                f"WHERE cron_id = %(cron_id)s{cond} RETURNING *",
                 params,
             )
             row = await cur.fetchone()
@@ -255,10 +261,13 @@ class CronsServicerImpl(CronsServicer):
         return cron_to_proto(row)
 
     async def Delete(self, request: pb.DeleteCronRequest, context) -> Empty:
+        params: dict = {"cid": request.cron_id.value}
+        fc = filters_clause(request.filters, params)
+        cond = f" AND {fc}" if fc else ""
         async with db.pool().connection() as conn, conn.cursor() as cur:
             await cur.execute(
-                "DELETE FROM cron WHERE cron_id = %s",
-                (request.cron_id.value,),
+                f"DELETE FROM cron WHERE cron_id = %(cid)s{cond}",
+                params,
             )
         return Empty()
 
@@ -282,6 +291,9 @@ class CronsServicerImpl(CronsServicer):
             if meta:
                 where.append("metadata @> %(meta)s")
                 params["meta"] = Jsonb(meta)
+        fc = filters_clause(request.filters, params)
+        if fc:
+            where.append(fc)
         params["limit"] = request.limit if request.HasField("limit") else 1000
         params["offset"] = request.offset if request.HasField("offset") else 0
         col = _SORT.get(request.sort_by, "created_at")
@@ -309,6 +321,9 @@ class CronsServicerImpl(CronsServicer):
             if meta:
                 where.append("metadata @> %(meta)s")
                 params["meta"] = Jsonb(meta)
+        fc = filters_clause(request.filters, params)
+        if fc:
+            where.append(fc)
         clause = (" WHERE " + " AND ".join(where)) if where else ""
         async with db.pool().connection() as conn, conn.cursor() as cur:
             await cur.execute(f"SELECT count(*) AS n FROM cron{clause}", params)

--- a/backend/server/core_server/servicers/runs.py
+++ b/backend/server/core_server/servicers/runs.py
@@ -20,6 +20,7 @@ from psycopg.types.json import Jsonb
 
 from server.core_server import db
 from server.core_server._convert import json_bytes, loads, ts
+from server.core_server._filters import filters_clause, thread_owner_clause
 from server.core_server.redis_db import (
     LIST_RUN_QUEUE,
     THREAD_EVENTS_MAXLEN,
@@ -150,10 +151,13 @@ def run_to_proto(row: dict) -> pb.Run:
 
 class RunsServicerImpl(RunsServicer):
     async def Get(self, request: pb.GetRunRequest, context) -> pb.Run:
+        params: dict = {"rid": request.run_id.value, "tid": request.thread_id.value}
+        toc = thread_owner_clause(request.filters, params, thread_id_expr="run.thread_id")
+        cond = f" AND {toc}" if toc else ""
         async with db.pool().connection() as conn, conn.cursor() as cur:
             await cur.execute(
-                "SELECT * FROM run WHERE run_id = %s AND thread_id = %s",
-                (request.run_id.value, request.thread_id.value),
+                f"SELECT * FROM run WHERE run_id = %(rid)s AND thread_id = %(tid)s{cond}",
+                params,
             )
             row = await cur.fetchone()
         if row is None:
@@ -169,6 +173,9 @@ class RunsServicerImpl(RunsServicer):
         if request.HasField("status"):
             where.append("status = %(status)s")
             params["status"] = RUN_STATUS_FROM_PB.get(request.status, "pending")
+        toc = thread_owner_clause(request.filters, params, thread_id_expr="run.thread_id")
+        if toc:
+            where.append(toc)
         params["limit"] = request.limit if request.HasField("limit") else 10
         params["offset"] = request.offset if request.HasField("offset") else 0
         async with db.pool().connection() as conn, conn.cursor() as cur:
@@ -194,10 +201,14 @@ class RunsServicerImpl(RunsServicer):
         return pb.CountResponse(count=n)
 
     async def Delete(self, request: pb.DeleteRunRequest, context) -> pb.UUID:
+        params: dict = {"rid": request.run_id.value, "tid": request.thread_id.value}
+        toc = thread_owner_clause(request.filters, params, thread_id_expr="run.thread_id")
+        cond = f" AND {toc}" if toc else ""
         async with db.pool().connection() as conn, conn.cursor() as cur:
             await cur.execute(
-                "DELETE FROM run WHERE run_id = %s AND thread_id = %s RETURNING run_id",
-                (request.run_id.value, request.thread_id.value),
+                f"DELETE FROM run WHERE run_id = %(rid)s AND thread_id = %(tid)s{cond} "
+                "RETURNING run_id",
+                params,
             )
             row = await cur.fetchone()
         if row is None:
@@ -316,26 +327,36 @@ class RunsServicerImpl(RunsServicer):
             "after_seconds": f"{int(after_seconds)} seconds",
         }
 
+        # Auth filters (empty in single-user mode → conditions collapse to ""):
+        # thread_filters gate attaching runs to an existing thread the caller
+        # doesn't own; assistant_filters gate the assistant join. A filtered-out
+        # row means the CTEs produce nothing → no run row → NOT_FOUND upstream.
+        tf = filters_clause(request.thread_filters, params, column="thread.metadata")
+        tf_cond = f" AND {tf}" if tf else ""
+        af = filters_clause(request.assistant_filters, params, column="assistant.metadata")
+        af_cond = f" AND {af}" if af else ""
+
         if create_thread:
-            thread_cte = """WITH inserted_thread AS (
+            thread_cte = f"""WITH inserted_thread AS (
                 INSERT INTO thread (thread_id, status, metadata, config, state_updated_at)
                 SELECT %(thread_id)s, 'busy',
                     jsonb_build_object('graph_id', assistant.graph_id, 'assistant_id', assistant.assistant_id) || %(metadata)s::jsonb,
                     assistant.config || %(config)s::jsonb || jsonb_build_object('configurable',
-                        coalesce((assistant.config -> 'configurable'), '{}'::jsonb) || coalesce(%(config)s::jsonb -> 'configurable', '{}'::jsonb)),
+                        coalesce((assistant.config -> 'configurable'), '{{}}'::jsonb) || coalesce(%(config)s::jsonb -> 'configurable', '{{}}'::jsonb)),
                     now()
-                FROM assistant WHERE assistant_id = %(assistant_id)s
+                FROM assistant WHERE assistant_id = %(assistant_id)s{af_cond}
                 ON CONFLICT (thread_id) DO NOTHING
                 RETURNING *
             ),
             run_thread AS (
-                SELECT * FROM thread WHERE thread_id = %(thread_id)s
+                SELECT * FROM thread WHERE thread_id = %(thread_id)s{tf_cond}
                 UNION ALL
                 SELECT * FROM inserted_thread
             ),"""
         else:
             thread_cte = (
-                "WITH run_thread AS (SELECT * FROM thread WHERE thread_id = %(thread_id)s),"
+                "WITH run_thread AS "
+                f"(SELECT * FROM thread WHERE thread_id = %(thread_id)s{tf_cond}),"
             )
 
         query = (
@@ -372,7 +393,8 @@ class RunsServicerImpl(RunsServicer):
                 FROM run_thread CROSS JOIN assistant
                 WHERE run_thread.thread_id = %(thread_id)s AND assistant.assistant_id = %(assistant_id)s
             """
-            + ("AND NOT EXISTS (SELECT 1 FROM inflight_runs)" if prevent else "")
+            + af_cond
+            + (" AND NOT EXISTS (SELECT 1 FROM inflight_runs)" if prevent else "")
             + """
                 RETURNING run.*
             ),
@@ -615,6 +637,20 @@ class RunsServicerImpl(RunsServicer):
                     (statuses,),
                 )
                 targets = [(str(x["thread_id"]), str(x["run_id"])) for x in await cur.fetchall()]
+
+            # Ownership gate: drop targets on threads the caller can't see —
+            # otherwise any authenticated user could interrupt/rollback
+            # another user's runs by id.
+            fparams: dict = {}
+            fc = filters_clause(request.filters, fparams)
+            if fc and targets:
+                fparams["tids"] = list({tid for tid, _rid in targets})
+                await cur.execute(
+                    f"SELECT thread_id FROM thread WHERE thread_id = ANY(%(tids)s) AND {fc}",
+                    fparams,
+                )
+                owned = {str(x["thread_id"]) for x in await cur.fetchall()}
+                targets = [(tid, rid) for tid, rid in targets if tid in owned]
 
             r = get_redis()
             run_ids = [rid for _tid, rid in targets]

--- a/backend/server/core_server/servicers/threads.py
+++ b/backend/server/core_server/servicers/threads.py
@@ -22,6 +22,7 @@ from server.core_server._convert import (
     loads,
     thread_to_proto,
 )
+from server.core_server._filters import filters_clause
 from server.core_server.redis_db import channel_run_stream, get_redis, stream_thread_events
 from server.grpc_common.proto import core_api_pb2 as pb
 from server.grpc_common.proto import enum_thread_stream_mode_pb2 as etsm
@@ -63,10 +64,13 @@ def _sort_dir(value: int) -> str:
 
 class ThreadsServicerImpl(ThreadsServicer):
     async def Get(self, request: pb.GetThreadRequest, context) -> pb.Thread:
+        params: dict = {"tid": request.thread_id.value}
+        fc = filters_clause(request.filters, params)
+        cond = f" AND {fc}" if fc else ""
         async with db.pool().connection() as conn, conn.cursor() as cur:
             await cur.execute(
-                "SELECT * FROM thread WHERE thread_id = %s",
-                (request.thread_id.value,),
+                f"SELECT * FROM thread WHERE thread_id = %(tid)s{cond}",
+                params,
             )
             row = await cur.fetchone()
         if row is None:
@@ -100,19 +104,35 @@ class ThreadsServicerImpl(ThreadsServicer):
                         grpc.StatusCode.ALREADY_EXISTS,
                         f"Thread {tid} already exists",
                     )
-                await cur.execute("SELECT * FROM thread WHERE thread_id = %s", (tid,))
+                # Re-select respecting auth filters: a conflicting thread the
+                # caller doesn't own reports a conflict, never silent adoption.
+                params: dict = {"tid": tid}
+                fc = filters_clause(request.filters, params)
+                cond = f" AND {fc}" if fc else ""
+                await cur.execute(
+                    f"SELECT * FROM thread WHERE thread_id = %(tid)s{cond}",
+                    params,
+                )
                 row = await cur.fetchone()
+                if row is None:
+                    await context.abort(
+                        grpc.StatusCode.ALREADY_EXISTS,
+                        f"Thread {tid} already exists",
+                    )
         return thread_to_proto(row)
 
     async def Patch(self, request: pb.PatchThreadRequest, context) -> pb.Thread:
         meta = loads(request.metadata_json) if request.HasField("metadata_json") else {}
+        params: dict = {"meta": Jsonb(meta), "tid": request.thread_id.value}
+        fc = filters_clause(request.filters, params)
+        cond = f" AND {fc}" if fc else ""
         async with db.pool().connection() as conn, conn.cursor() as cur:
             await cur.execute(
-                """
-                UPDATE thread SET metadata = metadata || %s, updated_at = now()
-                WHERE thread_id = %s RETURNING *
+                f"""
+                UPDATE thread SET metadata = metadata || %(meta)s, updated_at = now()
+                WHERE thread_id = %(tid)s{cond} RETURNING *
                 """,
-                (Jsonb(meta), request.thread_id.value),
+                params,
             )
             row = await cur.fetchone()
         if row is None:
@@ -125,6 +145,20 @@ class ThreadsServicerImpl(ThreadsServicer):
     async def Delete(self, request: pb.DeleteThreadRequest, context) -> pb.UUID:
         tid = request.thread_id.value
         async with db.pool().connection() as conn, conn.transaction(), conn.cursor() as cur:
+            # Ownership check before the FK-less cascade below touches
+            # anything: an unowned thread must look exactly like a missing one.
+            params: dict = {"tid": tid}
+            fc = filters_clause(request.filters, params)
+            if fc:
+                await cur.execute(
+                    f"SELECT 1 FROM thread WHERE thread_id = %(tid)s AND {fc}",
+                    params,
+                )
+                if await cur.fetchone() is None:
+                    await context.abort(
+                        grpc.StatusCode.NOT_FOUND,
+                        f"Thread {tid} not found",
+                    )
             for table in (
                 "checkpoint_writes",
                 "checkpoint_blobs",
@@ -168,6 +202,9 @@ class ThreadsServicerImpl(ThreadsServicer):
         if request.ids:
             where.append("thread_id = ANY(%(ids)s)")
             params["ids"] = [u.value for u in request.ids]
+        fc = filters_clause(request.filters, params)
+        if fc:
+            where.append(fc)
         params["limit"] = request.limit if request.HasField("limit") else 1000
         params["offset"] = request.offset if request.HasField("offset") else 0
         col = _SORT.get(request.sort_by, "created_at")
@@ -197,6 +234,9 @@ class ThreadsServicerImpl(ThreadsServicer):
         if request.HasField("status"):
             where.append("status = %(status)s")
             params["status"] = THREAD_STATUS_FROM_PB.get(request.status, "idle")
+        fc = filters_clause(request.filters, params)
+        if fc:
+            where.append(fc)
         clause = (" WHERE " + " AND ".join(where)) if where else ""
         async with db.pool().connection() as conn, conn.cursor() as cur:
             await cur.execute(f"SELECT count(*) AS n FROM thread{clause}", params)
@@ -326,7 +366,10 @@ class ThreadsServicerImpl(ThreadsServicer):
         tid = request.thread_id.value
         new_tid = str(uuid.uuid4())
         async with db.pool().connection() as conn, conn.transaction(), conn.cursor() as cur:
-            await cur.execute("SELECT 1 FROM thread WHERE thread_id = %s", (tid,))
+            params: dict = {"tid": tid}
+            fc = filters_clause(request.filters, params)
+            cond = f" AND {fc}" if fc else ""
+            await cur.execute(f"SELECT 1 FROM thread WHERE thread_id = %(tid)s{cond}", params)
             if await cur.fetchone() is None:
                 await context.abort(grpc.StatusCode.NOT_FOUND, f"Thread {tid} not found")
             await cur.execute(
@@ -393,6 +436,24 @@ class ThreadsServicerImpl(ThreadsServicer):
         executed but their events had no subscriber.
         """
         tid = request.thread_id.value
+
+        # Ownership gate before any subscription: without it, any
+        # authenticated caller could stream another user's live events
+        # (including token-by-token message content) by thread id.
+        params: dict = {"tid": tid}
+        fc = filters_clause(request.filters, params)
+        if fc:
+            async with db.pool().connection() as conn, conn.cursor() as cur:
+                await cur.execute(
+                    f"SELECT 1 FROM thread WHERE thread_id = %(tid)s AND {fc}",
+                    params,
+                )
+                if await cur.fetchone() is None:
+                    await context.abort(
+                        grpc.StatusCode.NOT_FOUND,
+                        f"Thread {tid} not found",
+                    )
+
         modes = {etsm.ThreadStreamMode.Name(m) for m in request.stream_modes}
 
         def should_filter(event_name: str, message: bytes) -> bool:

--- a/backend/tests/server/test_filters.py
+++ b/backend/tests/server/test_filters.py
@@ -1,0 +1,113 @@
+"""Unit tests for the AuthFilter→SQL translation (`server.core_server._filters`).
+
+These protos are what the ops layer ships after running the custom-auth
+handlers; the servicers must turn them into parameterized predicates without
+ever interpolating a value into SQL.
+"""
+
+from psycopg.types.json import Jsonb
+
+from server.core_server._filters import filters_clause, thread_owner_clause
+from server.grpc_common.proto import core_api_pb2 as pb
+
+
+def _eq(key: str, match_json: str) -> pb.AuthFilter:
+    f = pb.AuthFilter()
+    f.eq.CopyFrom(pb.EqAuthFilter(key=key, match=match_json))
+    return f
+
+
+def _contains(key: str, matches: list[str]) -> pb.AuthFilter:
+    f = pb.AuthFilter()
+    f.contains.CopyFrom(pb.ContainsAuthFilter(key=key, matches=matches))
+    return f
+
+
+def _obj(param: Jsonb) -> dict:
+    return param.obj
+
+
+def test_no_filters_is_a_noop() -> None:
+    params: dict = {}
+    assert filters_clause([], params) == ""
+    assert params == {}
+
+
+def test_single_eq_binds_jsonb_containment() -> None:
+    params: dict = {}
+    clause = filters_clause([_eq("owner", '"user-1"')], params)
+    assert clause == "(metadata @> %(_af0)s)"
+    assert _obj(params["_af0"]) == {"owner": "user-1"}
+
+
+def test_hostile_key_and_value_never_reach_the_sql_text() -> None:
+    hostile_key = "owner') OR 1=1; DROP TABLE thread; --"
+    hostile_value = '"\'; DELETE FROM run; --"'
+    params: dict = {}
+    clause = filters_clause([_eq(hostile_key, hostile_value)], params)
+    assert clause == "(metadata @> %(_af0)s)"
+    assert "DROP" not in clause
+    assert "DELETE" not in clause
+    assert _obj(params["_af0"]) == {hostile_key: "'; DELETE FROM run; --"}
+
+
+def test_contains_ors_each_match_as_array_containment() -> None:
+    params: dict = {}
+    clause = filters_clause([_contains("tags", ['"a"', '"b"'])], params)
+    assert clause == "((metadata @> %(_af0)s OR metadata @> %(_af1)s))"
+    assert _obj(params["_af0"]) == {"tags": ["a"]}
+    assert _obj(params["_af1"]) == {"tags": ["b"]}
+
+
+def test_top_level_filters_are_anded() -> None:
+    params: dict = {}
+    clause = filters_clause([_eq("owner", '"u1"'), _eq("org", '"o1"')], params)
+    assert clause == "(metadata @> %(_af0)s AND metadata @> %(_af1)s)"
+
+
+def test_or_and_nesting() -> None:
+    or_filter = pb.AuthFilter()
+    and_branch = pb.AuthFilter()
+    and_branch.and_filter.CopyFrom(
+        pb.AndAuthFilter(filters=[_eq("owner", '"u1"'), _eq("org", '"o1"')]),
+    )
+    or_filter.or_filter.CopyFrom(pb.OrAuthFilter(filters=[and_branch, _eq("owner", '"u2"')]))
+    params: dict = {}
+    clause = filters_clause([or_filter], params)
+    assert clause == ("(((metadata @> %(_af0)s AND metadata @> %(_af1)s) OR metadata @> %(_af2)s))")
+
+
+def test_param_names_never_collide_with_existing_bindings() -> None:
+    params: dict = {"_af0": "taken", "tid": "x"}
+    clause = filters_clause([_eq("owner", '"u1"')], params)
+    assert clause == "(metadata @> %(_af1)s)"
+    assert params["_af0"] == "taken"
+
+
+def test_column_qualification_is_used_verbatim() -> None:
+    params: dict = {}
+    clause = filters_clause([_eq("owner", '"u1"')], params, column="thread.metadata")
+    assert clause == "(thread.metadata @> %(_af0)s)"
+
+
+def test_thread_owner_clause_wraps_in_exists_subquery() -> None:
+    params: dict = {}
+    clause = thread_owner_clause([_eq("owner", '"u1"')], params, thread_id_expr="run.thread_id")
+    assert clause == (
+        "EXISTS (SELECT 1 FROM thread AS _af_thread "
+        "WHERE _af_thread.thread_id = run.thread_id AND (_af_thread.metadata @> %(_af0)s))"
+    )
+    assert _obj(params["_af0"]) == {"owner": "u1"}
+
+
+def test_thread_owner_clause_empty_without_filters() -> None:
+    params: dict = {}
+    assert thread_owner_clause([], params, thread_id_expr="run.thread_id") == ""
+    assert params == {}
+
+
+def test_non_scalar_eq_value_binds_as_object() -> None:
+    params: dict = {}
+    clause = filters_clause([_eq("owner", '{"team": "a"}')], params)
+    assert clause == "(metadata @> %(_af0)s)"
+    assert _obj(params["_af0"]) == {"owner": {"team": "a"}}

--- a/backend/tests/test_files_api_auth.py
+++ b/backend/tests/test_files_api_auth.py
@@ -1,0 +1,64 @@
+"""Auth-guard behavior of the files API in multi-user mode.
+
+The server's auth middleware (enable_custom_route_auth) populates
+``scope["user"]``; the app's own guard 401s when multi-user mode is on and no
+authenticated user reached a handler (belt-and-braces for the misconfigured
+case where the custom-route flag is missing).
+"""
+
+import pytest
+from backend.agents import files_api
+from obstore.store import MemoryStore
+from starlette.authentication import SimpleUser
+from starlette.testclient import TestClient
+
+
+@pytest.fixture
+def mem_store(monkeypatch: pytest.MonkeyPatch) -> MemoryStore:
+    """Swap the module's store factory for a fresh in-memory store."""
+    store = MemoryStore()
+    monkeypatch.setattr(files_api, "get_store", lambda: store)
+    return store
+
+
+class _PlantUser:
+    """ASGI wrapper standing in for the server's auth middleware."""
+
+    def __init__(self, app, user) -> None:
+        self.app = app
+        self.user = user
+
+    async def __call__(self, scope, receive, send) -> None:
+        if scope["type"] == "http" and self.user is not None:
+            scope["user"] = self.user
+        await self.app(scope, receive, send)
+
+
+def _client(monkeypatch: pytest.MonkeyPatch, *, auth_enabled: bool, user=None) -> TestClient:
+    monkeypatch.setattr(files_api, "_AUTH_ENABLED", auth_enabled)
+    return TestClient(_PlantUser(files_api.app, user), raise_server_exceptions=True)
+
+
+def test_single_user_mode_stays_open(monkeypatch, mem_store) -> None:
+    client = _client(monkeypatch, auth_enabled=False)
+    res = client.get("/files/list", params={"prefixes": "/upload/"})
+    assert res.status_code == 200
+
+
+def test_multi_user_mode_401s_without_a_user(monkeypatch, mem_store) -> None:
+    client = _client(monkeypatch, auth_enabled=True)
+    for method, path, kwargs in [
+        ("get", "/files/list", {"params": {"prefixes": "/upload/"}}),
+        ("get", "/files/read", {"params": {"path": "/upload/cv.pdf"}}),
+        ("post", "/files/upload", {"data": {"path": "/upload"}}),
+        ("put", "/files/write", {"json": {"path": "/upload/x.md", "content": "hi"}}),
+        ("delete", "/files/delete", {"params": {"path": "/upload/cv.pdf"}}),
+    ]:
+        res = getattr(client, method)(path, **kwargs)
+        assert res.status_code == 401, f"{method} {path} → {res.status_code}"
+
+
+def test_multi_user_mode_serves_authenticated_requests(monkeypatch, mem_store) -> None:
+    client = _client(monkeypatch, auth_enabled=True, user=SimpleUser("user-1"))
+    res = client.get("/files/list", params={"prefixes": "/upload/"})
+    assert res.status_code == 200

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -220,8 +220,17 @@ services:
       OBJECT_STORE_ENDPOINT: http://object-store:8333
       # Mounts the artifact files API (backend/agents/files_api.py) into the
       # agent server — the vendored server's designed custom-app hook.
+      # enable_custom_route_auth puts the mounted routes behind the server's
+      # auth middleware: a no-op under noop auth, required in multi-user mode.
       LANGGRAPH_HTTP: >-
-        {"app": "/deps/next-role/backend/agents/files_api.py:app"}
+        {"app": "/deps/next-role/backend/agents/files_api.py:app",
+         "enable_custom_route_auth": true}
+      # Multi-user auth verification targets (used only when LANGGRAPH_AUTH is
+      # set in .env; harmless otherwise). In-network JWKS URL — the backend
+      # verifies bearer JWTs minted by the frontend's Better Auth.
+      AUTH_JWKS_URL: http://frontend:3000/api/auth/jwks
+      AUTH_JWT_ISSUER: http://localhost:${FRONTEND_LOCAL_PORT}
+      AUTH_JWT_AUDIENCE: http://localhost:${FRONTEND_LOCAL_PORT}
       POSTGRES_URI: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
       # Selects the postgres backend in the runtime edition router
       # (hard-required — the router raises if unset).

--- a/frontend/src/app/hooks/useThreads.test.tsx
+++ b/frontend/src/app/hooks/useThreads.test.tsx
@@ -80,6 +80,7 @@ describe("useThreads", () => {
     expect(ClientMock).toHaveBeenCalledWith({
       apiUrl: "http://deploy:2024",
       defaultHeaders: { "X-Api-Key": "sk-ls" },
+      onRequest: expect.any(Function),
     });
     expect(searchMock).toHaveBeenCalledWith({
       limit: 20,
@@ -101,6 +102,7 @@ describe("useThreads", () => {
     expect(ClientMock).toHaveBeenCalledWith({
       apiUrl: "http://deploy:2024",
       defaultHeaders: {},
+      onRequest: expect.any(Function),
     });
     const args = searchMock.mock.calls[0][0];
     expect(args).not.toHaveProperty("metadata");

--- a/frontend/src/app/hooks/useThreads.ts
+++ b/frontend/src/app/hooks/useThreads.ts
@@ -2,6 +2,7 @@ import useSWRInfinite from "swr/infinite";
 import type { Thread } from "@langchain/langgraph-sdk";
 import { Client } from "@langchain/langgraph-sdk";
 import { getConfig } from "@/lib/config";
+import { authOnRequest } from "@/lib/auth/token";
 
 export interface ThreadItem {
   id: string;
@@ -60,6 +61,7 @@ export function useThreads(props: { status?: Thread["status"]; limit?: number })
       const client = new Client({
         apiUrl: deploymentUrl,
         defaultHeaders: apiKey ? { "X-Api-Key": apiKey } : {},
+        onRequest: authOnRequest,
       });
 
       // Check if assistantId is a UUID (deployed) or graph name (local)

--- a/frontend/src/app/lib/agentFiles.ts
+++ b/frontend/src/app/lib/agentFiles.ts
@@ -1,6 +1,7 @@
 import type { Client } from "@langchain/langgraph-sdk";
 import { AGENT_FILE_SOURCES, type AgentFileSources } from "@/app/config/agentFiles";
 import { getConfig } from "@/lib/config";
+import { authedFetch } from "@/lib/auth/token";
 
 export type AgentFileSource = "state" | "store" | "artifact";
 
@@ -169,7 +170,7 @@ async function fetchArtifactFiles(
   cfg: NonNullable<AgentFileSources["artifacts"]>
 ): Promise<AgentFile[]> {
   const params = new URLSearchParams({ prefixes: cfg.pathPrefixes.join(",") });
-  const listRes = await fetch(filesApiUrl(`/files/list?${params}`));
+  const listRes = await authedFetch(filesApiUrl(`/files/list?${params}`));
   if (!listRes.ok) {
     console.warn("artifact list failed", listRes.status, await listRes.text());
     return [];
@@ -181,7 +182,7 @@ async function fetchArtifactFiles(
   const reads = await Promise.all(
     listData.files.map(async (f): Promise<AgentFile | null> => {
       try {
-        const r = await fetch(filesApiUrl(`/files/read?path=${encodeURIComponent(f.path)}`));
+        const r = await authedFetch(filesApiUrl(`/files/read?path=${encodeURIComponent(f.path)}`));
         if (!r.ok) return null;
         const data = (await r.json()) as {
           content: string;
@@ -277,7 +278,7 @@ export async function writeAgentFile(args: {
   }
 
   if (file.source === "artifact") {
-    const res = await fetch(filesApiUrl("/files/write"), {
+    const res = await authedFetch(filesApiUrl("/files/write"), {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({

--- a/frontend/src/app/lib/uploadFiles.ts
+++ b/frontend/src/app/lib/uploadFiles.ts
@@ -1,4 +1,5 @@
 import { filesApiUrl } from "@/app/lib/agentFiles";
+import { authedFetch } from "@/lib/auth/token";
 
 export type UploadResponse = {
   uploaded: { path: string; size: number }[];
@@ -14,7 +15,7 @@ export async function uploadAgentFiles(args: {
   form.append("path", targetDir);
   for (const f of files) form.append("file", f, f.name);
 
-  const res = await fetch(filesApiUrl("/files/upload"), { method: "POST", body: form });
+  const res = await authedFetch(filesApiUrl("/files/upload"), { method: "POST", body: form });
   const data = (await res.json().catch(() => null)) as UploadResponse | { error?: string } | null;
 
   if (!res.ok) {
@@ -29,9 +30,12 @@ export async function uploadAgentFiles(args: {
 export const CAREER_AGENT_UPLOAD_DIR = "/upload";
 
 export async function deleteAgentFile(virtualPath: string): Promise<void> {
-  const res = await fetch(filesApiUrl(`/files/delete?path=${encodeURIComponent(virtualPath)}`), {
-    method: "DELETE",
-  });
+  const res = await authedFetch(
+    filesApiUrl(`/files/delete?path=${encodeURIComponent(virtualPath)}`),
+    {
+      method: "DELETE",
+    }
+  );
   if (!res.ok) {
     const data = (await res.json().catch(() => null)) as { error?: string } | null;
     const reason = data?.error ?? `Delete failed (${res.status})`;

--- a/frontend/src/lib/auth/token.test.ts
+++ b/frontend/src/lib/auth/token.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Bearer-token plumbing. token.ts holds module-level cache state, so each
+ * test re-imports it fresh (resetModules) after stubbing the env.
+ */
+
+const tokenMock = vi.fn();
+
+vi.mock("@/lib/auth/client", () => ({
+  authClient: { token: (...args: unknown[]) => tokenMock(...args) },
+}));
+
+function makeJwt(expEpochSecs: number): string {
+  const b64 = (o: object) =>
+    Buffer.from(JSON.stringify(o)).toString("base64").replace(/\+/g, "-").replace(/\//g, "_");
+  return `${b64({ alg: "EdDSA" })}.${b64({ sub: "u1", exp: expEpochSecs })}.sig`;
+}
+
+async function loadModule() {
+  vi.resetModules();
+  return import("./token");
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+});
+
+describe("getBearerToken", () => {
+  it("returns null without calling the API in zero-login mode", async () => {
+    vi.stubEnv("NEXT_PUBLIC_AUTH_ENABLED", "false");
+    const { getBearerToken } = await loadModule();
+    expect(await getBearerToken()).toBeNull();
+    expect(tokenMock).not.toHaveBeenCalled();
+  });
+
+  it("fetches once and serves later calls from the cache", async () => {
+    vi.stubEnv("NEXT_PUBLIC_AUTH_ENABLED", "true");
+    const jwt = makeJwt(Math.floor(Date.now() / 1000) + 900);
+    tokenMock.mockResolvedValue({ data: { token: jwt }, error: null });
+    const { getBearerToken } = await loadModule();
+
+    expect(await getBearerToken()).toBe(jwt);
+    expect(await getBearerToken()).toBe(jwt);
+    expect(tokenMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("refetches once the cached token nears expiry", async () => {
+    vi.stubEnv("NEXT_PUBLIC_AUTH_ENABLED", "true");
+    const stale = makeJwt(Math.floor(Date.now() / 1000) + 5); // inside the 30s slack
+    const fresh = makeJwt(Math.floor(Date.now() / 1000) + 900);
+    tokenMock
+      .mockResolvedValueOnce({ data: { token: stale }, error: null })
+      .mockResolvedValueOnce({ data: { token: fresh }, error: null });
+    const { getBearerToken } = await loadModule();
+
+    expect(await getBearerToken()).toBe(stale);
+    expect(await getBearerToken()).toBe(fresh);
+    expect(tokenMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns null when the session is gone", async () => {
+    vi.stubEnv("NEXT_PUBLIC_AUTH_ENABLED", "true");
+    tokenMock.mockResolvedValue({ data: null, error: { status: 401 } });
+    const { getBearerToken } = await loadModule();
+    expect(await getBearerToken()).toBeNull();
+  });
+});
+
+describe("authOnRequest", () => {
+  it("adds the Authorization header to the request init", async () => {
+    vi.stubEnv("NEXT_PUBLIC_AUTH_ENABLED", "true");
+    const jwt = makeJwt(Math.floor(Date.now() / 1000) + 900);
+    tokenMock.mockResolvedValue({ data: { token: jwt }, error: null });
+    const { authOnRequest } = await loadModule();
+
+    const out = await authOnRequest(new URL("http://x/threads"), { headers: { a: "1" } });
+    const headers = new Headers(out.headers);
+    expect(headers.get("Authorization")).toBe(`Bearer ${jwt}`);
+    expect(headers.get("a")).toBe("1");
+  });
+
+  it("leaves the init untouched in zero-login mode", async () => {
+    vi.stubEnv("NEXT_PUBLIC_AUTH_ENABLED", "false");
+    const { authOnRequest } = await loadModule();
+    const init = { headers: { a: "1" } };
+    expect(await authOnRequest(new URL("http://x/threads"), init)).toBe(init);
+  });
+});
+
+describe("authedFetch", () => {
+  it("retries once with a fresh token on 401", async () => {
+    vi.stubEnv("NEXT_PUBLIC_AUTH_ENABLED", "true");
+    const first = makeJwt(Math.floor(Date.now() / 1000) + 900);
+    const second = makeJwt(Math.floor(Date.now() / 1000) + 1800);
+    tokenMock
+      .mockResolvedValueOnce({ data: { token: first }, error: null })
+      .mockResolvedValueOnce({ data: { token: second }, error: null });
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("expired", { status: 401 }))
+      .mockResolvedValueOnce(new Response("ok", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { authedFetch } = await loadModule();
+    const res = await authedFetch("http://x/files/list");
+
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const retryHeaders = new Headers(fetchMock.mock.calls[1][1].headers);
+    expect(retryHeaders.get("Authorization")).toBe(`Bearer ${second}`);
+  });
+
+  it("does not retry non-401 failures", async () => {
+    vi.stubEnv("NEXT_PUBLIC_AUTH_ENABLED", "true");
+    tokenMock.mockResolvedValue({
+      data: { token: makeJwt(Math.floor(Date.now() / 1000) + 900) },
+      error: null,
+    });
+    const fetchMock = vi.fn().mockResolvedValue(new Response("boom", { status: 500 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { authedFetch } = await loadModule();
+    const res = await authedFetch("http://x/files/list");
+    expect(res.status).toBe(500);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/lib/auth/token.ts
+++ b/frontend/src/lib/auth/token.ts
@@ -1,0 +1,83 @@
+import { authClient } from "./client";
+import { isAuthEnabled } from "./enabled";
+
+/**
+ * Bearer-token plumbing for backend requests in multi-user mode.
+ *
+ * Better Auth's JWT plugin mints short-lived (15 min) tokens from the session
+ * cookie via /api/auth/token; we cache one until shortly before expiry and
+ * refresh on demand. In zero-login mode everything here is a no-op.
+ */
+
+const EXPIRY_SLACK_MS = 30_000;
+
+let cached: { token: string; expiresAtMs: number } | null = null;
+let inflight: Promise<string | null> | null = null;
+
+function decodeExpiryMs(token: string): number {
+  try {
+    const payload = token.split(".")[1];
+    const claims = JSON.parse(atob(payload.replace(/-/g, "+").replace(/_/g, "/")));
+    if (typeof claims.exp === "number") return claims.exp * 1000;
+  } catch {
+    // Fall through to a conservative default below.
+  }
+  return Date.now() + 60_000;
+}
+
+/** Current bearer token, refreshed when missing/near expiry; null when auth is off or signed out. */
+export async function getBearerToken(): Promise<string | null> {
+  if (!isAuthEnabled()) return null;
+  if (cached && Date.now() < cached.expiresAtMs - EXPIRY_SLACK_MS) return cached.token;
+  inflight ??= (async () => {
+    try {
+      const { data, error } = await authClient.token();
+      if (error || !data?.token) return null;
+      cached = { token: data.token, expiresAtMs: decodeExpiryMs(data.token) };
+      return data.token;
+    } catch {
+      return null;
+    } finally {
+      inflight = null;
+    }
+  })();
+  return inflight;
+}
+
+/** Drop the cached token (e.g. after a 401 or sign-out) so the next call refetches. */
+export function clearBearerToken(): void {
+  cached = null;
+}
+
+/**
+ * SDK `onRequest` hook: injects `Authorization: Bearer …` into every
+ * langgraph-sdk request (REST + SSE streams share this path).
+ */
+export async function authOnRequest(_url: URL, init: RequestInit): Promise<RequestInit> {
+  const token = await getBearerToken();
+  if (!token) return init;
+  const headers = new Headers(init.headers);
+  headers.set("Authorization", `Bearer ${token}`);
+  return { ...init, headers };
+}
+
+/**
+ * fetch wrapper for the raw `/files/*` calls: injects the bearer and retries
+ * once with a fresh token on 401 (expired-token race).
+ */
+export async function authedFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+  const token = await getBearerToken();
+  // Zero-login mode: pass the request through untouched (preserving arity).
+  if (!token) return init === undefined ? fetch(input) : fetch(input, init);
+
+  const headers = new Headers(init?.headers);
+  headers.set("Authorization", `Bearer ${token}`);
+  const res = await fetch(input, { ...init, headers });
+  if (res.status !== 401) return res;
+
+  clearBearerToken();
+  const fresh = await getBearerToken();
+  if (!fresh || fresh === token) return res;
+  headers.set("Authorization", `Bearer ${fresh}`);
+  return fetch(input, { ...init, headers });
+}

--- a/frontend/src/providers/ClientProvider.test.tsx
+++ b/frontend/src/providers/ClientProvider.test.tsx
@@ -33,6 +33,7 @@ describe("ClientProvider", () => {
         "Content-Type": "application/json",
         "X-Api-Key": "sk-test",
       },
+      onRequest: expect.any(Function),
     });
     expect(seenClients[0]).toBe(ClientMock.mock.instances[0]);
   });
@@ -73,6 +74,7 @@ describe("ClientProvider", () => {
         "Content-Type": "application/json",
         "X-Api-Key": "sk-other",
       },
+      onRequest: expect.any(Function),
     });
     expect(seenClients.at(-1)).not.toBe(seenClients[0]);
   });

--- a/frontend/src/providers/ClientProvider.tsx
+++ b/frontend/src/providers/ClientProvider.tsx
@@ -2,6 +2,7 @@
 
 import { createContext, useContext, useMemo, ReactNode } from "react";
 import { Client } from "@langchain/langgraph-sdk";
+import { authOnRequest } from "@/lib/auth/token";
 
 interface ClientContextValue {
   client: Client;
@@ -23,6 +24,9 @@ export function ClientProvider({ children, deploymentUrl, apiKey }: ClientProvid
         "Content-Type": "application/json",
         "X-Api-Key": apiKey,
       },
+      // Multi-user mode: stamps Authorization: Bearer <JWT> on every request
+      // (REST + SSE). No-op in zero-login mode.
+      onRequest: authOnRequest,
     });
   }, [deploymentUrl, apiKey]);
 


### PR DESCRIPTION
## Summary

Phase 2 of 4. Activates the vendored server's dormant custom-auth framework and **closes the gap** where the ops layer computes authorization filters but the native `core_server` servicers silently drop them (`grep filters core_server/` → zero matches on `main`). Stacked on #52 (Phase 1).

## Authentication — `backend/agents/auth.py`

`@auth.authenticate` verifies the frontend's Better Auth bearer JWT against its JWKS (`AUTH_JWKS_URL`), **EdDSA pinned** (never trusts the token header alg), issuer/audience checked. The `sub` claim is the owner identity. Uses the `authorization` param (not `request`) so it works on WebSocket scopes too.

`@auth.on` handlers: threads/runs/crons stamp `metadata.owner` + return `{"owner": id}`; assistants are shared (read-all, writes 403); `@auth.on.store` rewrites namespaces to the caller's identity; a global default-deny fails closed.

## Enforcement — `server/core_server/_filters.py` + servicers

New helper translates the shipped `AuthFilter` protos (`$eq`/`$contains`/`$and`/`$or`) into parameterized JSONB predicates — **values always bound, never interpolated** (hostile-key/value test included) — hitting the existing `thread_owner_updated_idx` / GIN indexes. Wired into Get/Search/Count/Patch/Delete/Copy across threads, runs, crons, assistants.

Two non-obvious fixes the audit surfaced:
- **`ThreadsServicerImpl.Stream`** now ownership-gates *before* subscribing — previously any authenticated user could stream any thread's live token-by-token events by id (the highest-severity leak; both v1 `/stream` and the v2 `/stream/events` transport go through here).
- **`RunsServicerImpl.Create`** enforces `thread_filters` + `assistant_filters` — blocks cross-user run injection into an existing thread.

Unowned rows return **NOT_FOUND**, never a 403 existence oracle.

## Files API + guards

`enable_custom_route_auth: true` puts the mounted `/files/*` routes behind the server's auth middleware; a belt-and-braces 401 guard covers the misconfigured case. `REQUIRE_AUTH=true` boot guard refuses to start without `LANGGRAPH_AUTH` (cloud safety).

## Frontend token injection

A bearer-injecting `onRequest` hook on both SDK clients (`ClientProvider`, `useThreads`) + an `authedFetch` wrapper for the 5 raw `/files/*` calls (token cache, refresh-on-401). All no-ops in zero-login mode.

## Dual-mode preserved

With `LANGGRAPH_AUTH` unset, every filter clause collapses to empty and queries are byte-for-byte the pre-auth SQL — verified live.

## Verification

- **Unit**: `test_filters.py` (11 — SQL/param shape, injection safety, nesting, param-collision), `test_files_api_auth.py` (3), frontend `token.test.ts` (8). Full suites green: backend 168 passed, frontend 383 passed; pre-commit clean.
- **Live two-user matrix** (auth on, local stack): user B against user A's thread → **404** on Get/Search/Patch/Delete/state/history, run Get/Delete, **run-create-into-A's-thread**, v1 `/stream` (explicit 404 event) and v2 `/stream/events` (consumer dies, no events); B's search sees 0, A's sees 1. Assistants: both read (1 visible), B create/patch → **403**. Files API: unauth **401**, authed **200**. Survived a `core-server` restart.
- **Zero-login** (auth off): unauth `threads/search` and `files/list` → **200**; behaves as today.

## Next

3. Per-user storage scoping (store namespaces / object keys / memory). 4. Hardening + docs.

> ⚠️ Merge order: Phase 2 + Phase 3 should reach production together — enabling auth with threads isolated but storage still global would share memory/artifacts across users. Both target after this stack lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)