### PR TITLE
feat: scope agent storage per user (KV namespaces + object keys)

### DIFF
--- a/backend/agents/career_agent/agents.py
+++ b/backend/agents/career_agent/agents.py
@@ -13,6 +13,7 @@ from backend.agents.career_agent.middleware import (
     UtcDatetimeMiddleware,
 )
 from backend.agents.career_agent.object_backend import ObjectStoreBackend
+from backend.agents.career_agent.scope import kv_namespace
 from backend.agents.career_agent.shell_backend import VirtualPathShellBackend, default_shell_env
 from backend.agents.career_agent.tools import (
     CAREER_AGENT_DIR,
@@ -92,23 +93,27 @@ _backend = CompositeBackend(
         env=default_shell_env(),
     ),
     routes={
+        # Namespaces are scoped to the authenticated caller at call time
+        # (kv_namespace reads the run's identity via get_config); single-user
+        # mode keeps the original ("career_agent", <area>) tuples. The lambda's
+        # Runtime arg is unused — identity comes from the run config.
         "/memory/": StoreBackend(
-            namespace=lambda _: ("career_agent", "memory"),
+            namespace=lambda _rt: kv_namespace("memory"),
         ),
         "/processed/": StoreBackend(
-            namespace=lambda _: ("career_agent", "processed"),
+            namespace=lambda _rt: kv_namespace("processed"),
         ),
         "/research/": StoreBackend(
-            namespace=lambda _: ("career_agent", "research"),
+            namespace=lambda _rt: kv_namespace("research"),
         ),
         "/interview_coach/": StoreBackend(
-            namespace=lambda _: ("career_agent", "interview_coach"),
+            namespace=lambda _rt: kv_namespace("interview_coach"),
         ),
         "/large_tool_results/": StoreBackend(
-            namespace=lambda _: ("career_agent", "large_tool_results"),
+            namespace=lambda _rt: kv_namespace("large_tool_results"),
         ),
         "/workspace/": StoreBackend(
-            namespace=lambda _: ("career_agent", "workspace"),
+            namespace=lambda _rt: kv_namespace("workspace"),
         ),
         # Binary artifact areas live in S3-compatible object storage (SeaweedFS
         # locally, S3/GCS/Azure in the cloud). NOTE: these prefixes hold the

--- a/backend/agents/career_agent/object_storage.py
+++ b/backend/agents/career_agent/object_storage.py
@@ -6,15 +6,16 @@ local dev via docker compose; S3 / GCS / Azure or any S3-compatible service in
 the cloud — `obstore` speaks all of them). Postgres keeps only text artifacts;
 renders use a throwaway temp dir, so no artifact ever lives on local disk.
 
-Object keys are a pure function of the virtual path — there is no database
-registry. `/upload/cv.pdf` maps to `users/default/career_agent/upload/cv.pdf`;
-the `users/default/` segment is the future multi-user seam (inject a real
-identity here and every artifact is scoped without a key migration).
+Object keys are a pure function of the virtual path and the caller's scope —
+there is no database registry. `/upload/cv.pdf` maps to
+`users/<scope>/career_agent/upload/cv.pdf`; `<scope>` is the authenticated
+identity in multi-user mode and `default` otherwise (see `scope.object_scope`).
 
 Everything here is shared by two consumers: `ObjectStoreBackend` (the
 deepagents filesystem backend mounted as CompositeBackend routes) and
 `backend/agents/files_api.py` (the HTTP file surface for the frontend), so the
-path↔key mapping exists exactly once.
+path↔key mapping exists exactly once. Both pass the resolved `scope` — the
+agent backend from the run's runtime, the files API from the request user.
 """
 
 from __future__ import annotations
@@ -23,14 +24,17 @@ import functools
 from pathlib import PurePosixPath
 from typing import TYPE_CHECKING, Any
 
+from backend.agents.career_agent.scope import object_scope
 from obstore.store import S3Store
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 if TYPE_CHECKING:
     from obstore.store import ObjectStore
 
-# The multi-user seam: swap "default" for an authenticated identity later.
-KEY_SCOPE = "users/default/career_agent"
+# Single-user / unauthenticated key prefix (identity == "default"). Kept as a
+# module constant for the default layout; multi-user callers pass an explicit
+# `scope` to the key builders below.
+KEY_SCOPE = object_scope(None)
 
 # Artifact areas routed to object storage. Keep in sync with the
 # CompositeBackend routes in agents.py and the files-API allowlist.
@@ -101,24 +105,28 @@ def _safe_relative(path: str) -> str | None:
     return "/".join(parts)
 
 
-def area_key_prefix(area: str) -> str:
-    """Object-key prefix (no trailing slash) holding everything in `area`."""
-    return f"{KEY_SCOPE}/{area}"
+def area_key_prefix(area: str, scope: str | None = None) -> str:
+    """Object-key prefix (no trailing slash) holding everything in `area`.
+
+    `scope` is the caller's identity; omitted/`None` uses the default
+    single-user layout (`object_scope` resolves it).
+    """
+    return f"{object_scope(scope)}/{area}"
 
 
-def key_for_area(area: str, rel_path: str) -> str | None:
+def key_for_area(area: str, rel_path: str, scope: str | None = None) -> str | None:
     """Map a composite-stripped path within `area` to its object key.
 
-    `area="upload"`, `rel_path="/cv.pdf"` → `users/default/career_agent/upload/cv.pdf`.
+    `area="upload"`, `rel_path="/cv.pdf"` → `users/<scope>/career_agent/upload/cv.pdf`.
     Returns `None` for unsafe paths.
     """
     rel = _safe_relative(rel_path)
     if rel is None:
         return None
-    return f"{KEY_SCOPE}/{area}/{rel}"
+    return f"{object_scope(scope)}/{area}/{rel}"
 
 
-def key_for_virtual_path(path: str) -> str | None:
+def key_for_virtual_path(path: str, scope: str | None = None) -> str | None:
     """Map a full virtual path (e.g. `/upload/cv.pdf`) to its object key.
 
     Returns `None` when the path is unsafe or its first segment is not a
@@ -130,12 +138,12 @@ def key_for_virtual_path(path: str) -> str | None:
     area, _, remainder = rel.partition("/")
     if area not in AREAS or not remainder:
         return None
-    return f"{KEY_SCOPE}/{rel}"
+    return f"{object_scope(scope)}/{rel}"
 
 
-def virtual_path_for_key(key: str) -> str | None:
+def virtual_path_for_key(key: str, scope: str | None = None) -> str | None:
     """Invert `key_for_virtual_path`: object key → `/area/...` virtual path."""
-    prefix = f"{KEY_SCOPE}/"
+    prefix = f"{object_scope(scope)}/"
     if not key.startswith(prefix):
         return None
     rel = key[len(prefix) :]

--- a/backend/agents/career_agent/scope.py
+++ b/backend/agents/career_agent/scope.py
@@ -1,0 +1,72 @@
+"""Per-user scoping of the agent's persisted artifacts.
+
+Resolves the caller's identity at call time from the LangGraph run config
+(``configurable.langgraph_auth_user`` / ``langgraph_auth_user_id``, injected by
+the server's custom-auth layer and restored by the worker for each run). With
+no custom auth configured the identity is ``None`` and both storage tiers fall
+back to their single-user layout — byte-for-byte what they were before
+multi-user support.
+
+The two tiers scope differently, to keep zero-login data exactly where it is:
+
+* **KV store** (Postgres, DeepAgents ``StoreBackend``) had namespaces
+  ``("career_agent", <area>)`` with no user segment, so a real identity is
+  *prepended* and absent identity yields the original 2-tuple.
+* **Object store** keys already carried a ``users/default/`` segment, so the
+  identity simply *replaces* ``default``.
+"""
+
+from __future__ import annotations
+
+from langgraph.config import get_config
+
+#: Object-store scope for single-user / unauthenticated use. Matches the
+#: historical ``users/default/`` key segment so existing artifacts stay put.
+DEFAULT_OBJECT_SCOPE = "default"
+
+#: Root segment shared by every KV-store namespace (after any user segment).
+KV_ROOT = "career_agent"
+
+
+def current_identity() -> str | None:
+    """Return the authenticated caller's identity for the active run, or ``None``.
+
+    ``None`` in single-user mode (no custom auth) and whenever called outside a
+    runnable context (e.g. a unit test invoking a backend directly).
+    """
+    try:
+        config = get_config()
+    except RuntimeError:
+        return None
+    configurable = config.get("configurable") or {}
+    user = configurable.get("langgraph_auth_user")
+    identity = getattr(user, "identity", None) if user is not None else None
+    if not identity:
+        identity = configurable.get("langgraph_auth_user_id")
+    # Noop auth yields an empty-string identity — treat it as unscoped.
+    return identity or None
+
+
+def kv_namespace(area: str, identity: str | None = None) -> tuple[str, ...]:
+    """Namespace tuple for a KV-store ``area``, scoped to ``identity`` if any.
+
+    ``identity`` defaults to :func:`current_identity`; a user segment is
+    prepended only when an identity is present, so single-user namespaces stay
+    ``(KV_ROOT, area)``.
+    """
+    if identity is None:
+        identity = current_identity()
+    if identity:
+        return (identity, KV_ROOT, area)
+    return (KV_ROOT, area)
+
+
+def object_scope(identity: str | None = None) -> str:
+    """Object-key scope prefix (``users/<identity>/career_agent``).
+
+    ``identity`` defaults to :func:`current_identity`; absence maps to
+    :data:`DEFAULT_OBJECT_SCOPE`, preserving the historical single-user layout.
+    """
+    if identity is None:
+        identity = current_identity()
+    return f"users/{identity or DEFAULT_OBJECT_SCOPE}/{KV_ROOT}"

--- a/backend/agents/files_api.py
+++ b/backend/agents/files_api.py
@@ -74,6 +74,18 @@ def _authenticated(handler):  # noqa: ANN001, ANN202
     return wrapped
 
 
+def _scope(request: Request) -> str | None:
+    """Return the caller's object-store scope (identity), None for single-user.
+
+    The server's auth middleware puts the authenticated user on the request
+    scope; its identity scopes object keys the same way the agent's runtime
+    identity does. None (no user) resolves to the default single-user layout.
+    """
+    user = request.scope.get("user")
+    identity = getattr(user, "identity", None) if user is not None else None
+    return identity or None
+
+
 # Extensions served as base64 (mirrors the frontend's former BINARY_EXTS).
 _BINARY_EXTS = {
     "png", "jpg", "jpeg", "gif", "webp", "bmp", "ico",
@@ -121,12 +133,14 @@ async def list_files(request: Request) -> JSONResponse:
             return JSONResponse({"error": f"Disallowed prefix: {raw}"}, status_code=403)
         areas.append(area)
 
+    scope = _scope(request)
+
     def _collect() -> list[dict[str, Any]]:
         store = get_store()
         files: list[dict[str, Any]] = []
         for area in areas:
-            for meta in list_meta(store, area_key_prefix(area) + "/"):
-                vpath = virtual_path_for_key(str(meta["path"]))
+            for meta in list_meta(store, area_key_prefix(area, scope) + "/"):
+                vpath = virtual_path_for_key(str(meta["path"]), scope)
                 if vpath is None:
                     continue
                 files.append(
@@ -152,7 +166,7 @@ async def read_file(request: Request) -> JSONResponse:
     path = request.query_params.get("path")
     if not path:
         return JSONResponse({"error": "Missing 'path'"}, status_code=400)
-    key = key_for_virtual_path(path)
+    key = key_for_virtual_path(path, _scope(request))
     if key is None:
         return JSONResponse({"error": "Forbidden path"}, status_code=403)
 
@@ -191,6 +205,7 @@ async def upload_files(request: Request) -> JSONResponse:
     uploaded: list[dict[str, Any]] = []
     errors: list[dict[str, str]] = []
     store = get_store()
+    scope = _scope(request)
 
     for file in file_entries:
         name = file.filename or ""
@@ -203,7 +218,7 @@ async def upload_files(request: Request) -> JSONResponse:
             continue
 
         target = f"{dir_field.rstrip('/')}/{name}"
-        key = key_for_virtual_path(target)
+        key = key_for_virtual_path(target, scope)
         if key is None:
             errors.append({"name": name, "reason": "Forbidden path"})
             continue
@@ -237,7 +252,7 @@ async def write_file(request: Request) -> JSONResponse:
     encoding = body.get("encoding", "utf-8")
     if not path or not isinstance(content, str):
         return JSONResponse({"error": "Missing 'path' or 'content'"}, status_code=400)
-    key = key_for_virtual_path(path)
+    key = key_for_virtual_path(path, _scope(request))
     if key is None:
         return JSONResponse({"error": "Forbidden path"}, status_code=403)
 
@@ -262,7 +277,7 @@ async def delete_file(request: Request) -> JSONResponse:
     path = request.query_params.get("path")
     if not path:
         return JSONResponse({"error": "Missing 'path'"}, status_code=400)
-    key = key_for_virtual_path(path)
+    key = key_for_virtual_path(path, _scope(request))
     if key is None:
         return JSONResponse({"error": "Forbidden path"}, status_code=403)
 

--- a/backend/tests/career_agent/test_object_backend.py
+++ b/backend/tests/career_agent/test_object_backend.py
@@ -7,6 +7,7 @@ in-band errors, and prefix-stripped path semantics under `CompositeBackend`.
 """
 
 import base64
+from unittest.mock import patch
 
 import pytest
 from backend.agents.career_agent.object_backend import ObjectStoreBackend
@@ -37,6 +38,36 @@ def test_keys_carry_the_scoped_area_prefix(backend, mem_store):
 
     keys = [str(m["path"]) for m in mem_store.list().collect()]
     assert keys == [f"{KEY_SCOPE}/upload/cv.yaml"]
+
+
+def test_backend_scopes_keys_to_the_runtime_identity(backend, mem_store):
+    """With an authenticated run, keys land under `users/<identity>/…`.
+
+    The backend resolves identity at call time via `object_storage`'s builders,
+    which read `scope.current_identity()`; patch it to simulate two users.
+    """
+    import backend.agents.career_agent.scope as scope_mod
+
+    with patch.object(scope_mod, "current_identity", return_value="alice"):
+        backend.write("/cv.yaml", "name: Alice")
+    with patch.object(scope_mod, "current_identity", return_value="bob"):
+        backend.write("/cv.yaml", "name: Bob")
+
+    keys = sorted(str(m["path"]) for m in mem_store.list().collect())
+    assert keys == [
+        "users/alice/career_agent/upload/cv.yaml",
+        "users/bob/career_agent/upload/cv.yaml",
+    ]
+
+    # Each user reads only their own object.
+    with patch.object(scope_mod, "current_identity", return_value="alice"):
+        alice_read = backend.read("/cv.yaml")
+    with patch.object(scope_mod, "current_identity", return_value="bob"):
+        bob_read = backend.read("/cv.yaml")
+    assert alice_read.file_data is not None
+    assert alice_read.file_data["content"] == "name: Alice"
+    assert bob_read.file_data is not None
+    assert bob_read.file_data["content"] == "name: Bob"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/career_agent/test_object_storage.py
+++ b/backend/tests/career_agent/test_object_storage.py
@@ -110,6 +110,33 @@ def test_area_key_prefix():
 
 
 # ---------------------------------------------------------------------------
+# per-user scoping
+# ---------------------------------------------------------------------------
+
+
+def test_scoped_keys_isolate_users():
+    a = key_for_area("upload", "/cv.pdf", "alice")
+    b = key_for_area("upload", "/cv.pdf", "bob")
+    assert a == "users/alice/career_agent/upload/cv.pdf"
+    assert b == "users/bob/career_agent/upload/cv.pdf"
+    assert a != b
+
+
+def test_scoped_virtual_path_builders_agree():
+    key = key_for_virtual_path("/tailored_resume/r/j.yaml", "alice")
+    assert key == "users/alice/career_agent/tailored_resume/r/j.yaml"
+    assert area_key_prefix("tailored_resume", "alice") == "users/alice/career_agent/tailored_resume"
+    # Round-trips only under the same scope; a mismatched scope rejects the key.
+    assert virtual_path_for_key(key, "alice") == "/tailored_resume/r/j.yaml"
+    assert virtual_path_for_key(key, "bob") is None
+
+
+def test_scoped_keys_still_reject_traversal():
+    assert key_for_area("upload", "../x", "alice") is None
+    assert key_for_virtual_path("/upload/../processed/x.md", "alice") is None
+
+
+# ---------------------------------------------------------------------------
 # byte helpers (MemoryStore)
 # ---------------------------------------------------------------------------
 

--- a/backend/tests/career_agent/test_scope.py
+++ b/backend/tests/career_agent/test_scope.py
@@ -1,0 +1,69 @@
+"""Per-user scope resolution (`backend.agents.career_agent.scope`).
+
+`current_identity()` reads the run config; here we drive the pure derivations
+(`kv_namespace`, `object_scope`) with explicit identities and assert the
+single-user fallbacks match the historical layout.
+"""
+
+from unittest.mock import patch
+
+from backend.agents.career_agent import scope as scope_mod
+from backend.agents.career_agent.scope import kv_namespace, object_scope
+
+
+def test_object_scope_defaults_to_users_default() -> None:
+    with patch.object(scope_mod, "current_identity", return_value=None):
+        assert object_scope() == "users/default/career_agent"
+
+
+def test_object_scope_uses_explicit_identity() -> None:
+    assert object_scope("user-1") == "users/user-1/career_agent"
+
+
+def test_kv_namespace_single_user_has_no_user_segment() -> None:
+    # Byte-for-byte the pre-multi-user layout.
+    assert kv_namespace("memory", identity=None) == ("career_agent", "memory")
+
+
+def test_kv_namespace_prepends_identity_when_present() -> None:
+    assert kv_namespace("memory", identity="user-1") == ("user-1", "career_agent", "memory")
+
+
+def test_kv_namespace_resolves_identity_from_runtime_when_omitted() -> None:
+    with patch.object(scope_mod, "current_identity", return_value="user-2"):
+        assert kv_namespace("research") == ("user-2", "career_agent", "research")
+
+
+def test_object_scope_resolves_identity_from_runtime_when_omitted() -> None:
+    with patch.object(scope_mod, "current_identity", return_value="user-3"):
+        assert object_scope() == "users/user-3/career_agent"
+
+
+def test_current_identity_none_outside_runtime() -> None:
+    # get_config() raises RuntimeError outside a runnable context.
+    assert scope_mod.current_identity() is None
+
+
+def test_current_identity_reads_langgraph_auth_user() -> None:
+    class _User:
+        identity = "user-9"
+
+    fake_config = {"configurable": {"langgraph_auth_user": _User()}}
+    with patch.object(scope_mod, "get_config", return_value=fake_config):
+        assert scope_mod.current_identity() == "user-9"
+
+
+def test_current_identity_falls_back_to_user_id_key() -> None:
+    fake_config = {"configurable": {"langgraph_auth_user_id": "user-10"}}
+    with patch.object(scope_mod, "get_config", return_value=fake_config):
+        assert scope_mod.current_identity() == "user-10"
+
+
+def test_current_identity_empty_string_is_unscoped() -> None:
+    # Noop auth yields identity "" — must not scope.
+    class _User:
+        identity = ""
+
+    fake_config = {"configurable": {"langgraph_auth_user": _User()}}
+    with patch.object(scope_mod, "get_config", return_value=fake_config):
+        assert scope_mod.current_identity() is None

--- a/backend/tests/test_files_api_auth.py
+++ b/backend/tests/test_files_api_auth.py
@@ -9,8 +9,15 @@ case where the custom-route flag is missing).
 import pytest
 from backend.agents import files_api
 from obstore.store import MemoryStore
-from starlette.authentication import SimpleUser
 from starlette.testclient import TestClient
+
+
+class _AuthedUser:
+    """Stands in for the custom-auth ProxyUser (concrete `identity`)."""
+
+    def __init__(self, identity: str) -> None:
+        self.identity = identity
+        self.is_authenticated = True
 
 
 @pytest.fixture
@@ -59,6 +66,24 @@ def test_multi_user_mode_401s_without_a_user(monkeypatch, mem_store) -> None:
 
 
 def test_multi_user_mode_serves_authenticated_requests(monkeypatch, mem_store) -> None:
-    client = _client(monkeypatch, auth_enabled=True, user=SimpleUser("user-1"))
+    client = _client(monkeypatch, auth_enabled=True, user=_AuthedUser("user-1"))
     res = client.get("/files/list", params={"prefixes": "/upload/"})
     assert res.status_code == 200
+
+
+def test_files_api_scopes_keys_to_the_request_user(monkeypatch, mem_store) -> None:
+    """Uploads land under the authenticated user's object-key scope."""
+    client = _client(monkeypatch, auth_enabled=True, user=_AuthedUser("alice"))
+    res = client.post(
+        "/files/upload",
+        data={"path": "/upload"},
+        files={"file": ("cv.pdf", b"%PDF-1.4 alice", "application/pdf")},
+    )
+    assert res.status_code == 200
+    keys = [str(m["path"]) for m in mem_store.list().collect()]
+    assert keys == ["users/alice/career_agent/upload/cv.pdf"]
+
+    # Bob sees nothing of Alice's.
+    bob = _client(monkeypatch, auth_enabled=True, user=_AuthedUser("bob"))
+    listing = bob.get("/files/list", params={"prefixes": "/upload/"})
+    assert listing.json()["files"] == []


### PR DESCRIPTION
## Summary

Phase 3 of 4. Scopes every persisted artifact — Postgres KV store, object-store keys, and (for free) memory — to the authenticated caller. Resolved at **call time**, since the agent backends are import-time singletons with no per-run construction hook. Stacked on #53 (Phase 2).

## How

New `backend/agents/career_agent/scope.py` centralizes identity resolution from the run config (`configurable.langgraph_auth_user` / `langgraph_auth_user_id`). The two tiers scope differently, chosen so **single-user data stays byte-for-byte where it is**:

| Tier | Single-user (today) | Multi-user |
| --- | --- | --- |
| KV store namespace | `("career_agent", <area>)` | `(<identity>, "career_agent", <area>)` |
| Object key prefix | `users/default/career_agent/…` | `users/<identity>/career_agent/…` |

- **KV store**: the six `StoreBackend` namespace lambdas (`agents.py`) now call `kv_namespace(area)` — prepends a user segment only when authenticated. Per-user memory (`/memory/preferences.md`) falls out automatically.
- **Object store**: the `object_storage.py` key builders take an explicit `scope`; the agent backend resolves it from the run runtime (via `current_identity()`), the files API from `request.user.identity`.

## Frontend: no change needed

The FE reconstructs store paths from `item.key` (identity-independent), and the Phase 2 `@auth.on.store` handler rewrites namespaces by prepending identity on both read and write — landing on the exact rows the agent writes. So the FE keeps sending logical `["career_agent", …]` namespaces and stays oblivious to the user segment.

## Verification

- **Unit** (183 backend passed): new `test_scope.py` (identity resolution, single-user fallbacks, empty-identity guard), scope cases in `test_object_storage.py` (per-identity keys + traversal still rejected), `test_object_backend.py` (two runtimes never see each other's files), `test_files_api_auth.py` (uploads scoped to `request.user`). Existing storage tests pass unchanged (default scope == `users/default/`).
- **Live two-user** (auth on): A and B both upload `cv.pdf` to `/upload` and both `PUT` store key `preferences.md` under logical `["career_agent","memory"]`. Result — each reads only their own bytes/value; physical object keys are `users/<A>/…` vs `users/<B>/…`; store rows are `<A>.career_agent.memory` vs `<B>.career_agent.memory`. Confirmed via SeaweedFS filer + a direct `store`-table query.
- **Zero-login** (auth off): the pre-existing global `career_agent.memory` row is untouched and still reachable; new per-user rows sit alongside it.

## Next

4. Hardening + docs (meta-route exposure, MCP/A2A audit, README/CLAUDE/.env docs, cloud cutover checklist).

> ⚠️ Ship Phase 2 + Phase 3 together: enabling auth (Phase 2) without this PR would isolate threads but still share memory/artifacts globally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)