### PR TITLE
feat: first-run upload guidance — actionable empty states, upload tile, and pulse cue

### DIFF
--- a/docs/prd/27_first_run_upload_guidance.md
+++ b/docs/prd/27_first_run_upload_guidance.md
@@ -1,0 +1,59 @@
+# PRD: First-Run Upload Guidance (v1)
+
+**Status:** shipped · **Scope:** `frontend/` (chat empty state, Workspace Files) · **Extends:** [File Upload](01_file_upload.md)
+
+## Why
+
+NextRole only becomes useful once the user uploads a resume and a job description, but nothing in the UI drove that first action: the chat empty state offered suggestion chips, the hero subhead *said* "Drop in your resume and a job post" without an affordance, and the only upload control was a small ghost button in the Files card header. New users read the chips, typed a prompt, and got generic output because the agent had no documents.
+
+The original idea was an animated arrow pointing from the chat to the Upload button. UX research (NN/g on attention animation, Appcues/Userpilot onboarding studies, empty-state literature) consistently rates coach marks/arrows as skipped and distracting; the reliable pattern for a critical first action is an actionable empty state — put the action where the user is already looking — plus at most a subtle pulsing hotspot on the real control. This feature ships that package instead of the arrow.
+
+## What the user sees
+
+While the user has **zero uploaded files** (paths under `/upload/`), the chat hero shows a dashed **upload card** between the subhead and the suggestion chips ("Add your resume or a job description — click to browse or drop files"). Click opens the picker; drag-and-drop uploads in place, filtering to PDF/DOC/DOCX/TXT/MD and toasting skipped files. The Files card shows a real empty state (icon, "No files yet", one line of copy, a primary **Upload files** button) instead of the old text-only line.
+
+Once files exist, the hero card and empty state retire, and a dashed **Upload files** tile renders as the last item in the file grid — the persistent affordance for uploads #2+ (drag-and-drop works there too; the label swaps to "Drop to upload" while dragging). The Files header keeps an outlined **Upload** button in all states, carrying a small accent **pulse dot** until the user clicks any panel upload control. Every affordance uses the "Upload" verb — one action, one name. Deliberately absent: no arrow, no coach-mark overlay, no tour library, and the composer paperclip stays disabled (`COMPOSER_ATTACH_ENABLED`) — uploads live in the Workspace.
+
+## How — the key architectural choices
+
+**Guidance keys off uploads, not files, behind a `filesReady` gate.** `files` in `useChat` merges agent-generated state/store/artifact files, so "has files" is the wrong signal — `useUploadCue` filters for the `/upload/` prefix. The first `refreshFiles` runs before the assistant resolves (`graphId` null), skipping the artifact list entirely, so a naive "fetch finished" flag would flash the CTA at returning users; `filesReady` only flips after a fetch that ran with a non-null `graphId` (guidance appears ~1s after first paint — by design, never a flash-then-remove).
+
+**One upload path, shared as hooks.** `FilesSection.handleSelect` and `ChatInterface.handleAttach` were near-identical copies; both now consume `useFileUpload` (upload → toasts → `appendUploadNote` → `refreshFiles`), and the drop handling (drag state, extension filter, skipped-toast) lives in `useUploadDrop`, shared by the hero card and the grid tile so the two drop targets cannot drift.
+
+**The dot dismisses on click, not on upload.** The first cut auto-retired the dot when uploads appeared; owner testing immediately hit the gap — a user whose first upload came from the hero card never learned where the panel Upload button is, and after upload #1 all guidance vanished at once. The dot now persists (across sessions, through uploads) until the user clicks a panel upload trigger (header button, empty-state CTA, tile) — cancelling the picker still counts. Dismissal is `localStorage` `nr-upload-cue-dismissed-v2`; the key was bumped because v1 values were written under the old "uploaded once" meaning.
+
+## Files of interest
+
+| Concern | Path |
+|---|---|
+| Shared upload action + drag-and-drop hooks | `frontend/src/app/hooks/useFileUpload.ts` (`useFileUpload`, `useUploadDrop`) |
+| Cue gating and click-to-dismiss persistence | `frontend/src/app/hooks/useUploadCue.ts` |
+| `filesReady` signal (graphId-gated) | `frontend/src/app/hooks/useChat.ts` (lines ~119–123, ~170) |
+| Hero upload card + shared hidden input | `frontend/src/app/components/ChatInterface.tsx` (empty-state block) |
+| Files empty state, outlined Upload button, pulse dot | `frontend/src/app/components/workspace/FilesSection.tsx` |
+| Upload tile in the file grid (`onAddFiles`/`onDropFiles`) | `frontend/src/app/components/TasksFilesSidebar.tsx` (`FilesPopover`) |
+| `UPLOAD_ACCEPT` + `isAcceptedUploadName` drop filter | `frontend/src/app/lib/uploadFiles.ts` |
+| Design language: `upload-dropzone`, `files-empty-state`, `file-add-tile`, `upload-cue-dot` | `frontend/DESIGN.md` |
+| Regression coverage | `frontend/src/app/hooks/useFileUpload.test.tsx`, `useUploadCue.test.tsx`, `frontend/src/app/components/ChatInterface.test.tsx`, `TasksFilesSidebar.test.tsx` |
+
+## Decisions worth remembering
+
+- **The arrow was rejected, not deferred.** A cross-panel animated pointer is the coach-mark antipattern (skipped, naggy, fragile across the resizable panel layout). If guidance ever feels insufficient, strengthen the actionable surfaces — do not add arrows or a tour library; `DESIGN.md` records this as a hard rule on `upload-cue-dot`.
+- **Empty states are permanent UX; only the dot is dismissible.** The hero card and Files empty state render whenever the user has zero uploads — deleting every file brings them back. The dot alone is persisted-dismissed, and deleting files must not resurrect it.
+- **The tile answers "where do the next files go".** After upload #1 the empty states retire, and the owner's testing showed the ghost header button alone read as hidden. The in-grid tile (Drive/Dropbox pattern) is the persistent in-content affordance; the header button (upgraded ghost → outline) stays as the card-level command — the only entry when the card is collapsed, and the dot's anchor. Two entry points are intentional redundancy (NN/g multiple-entry-points), but they must share one label verb: "Upload".
+- **Composer paperclip stayed disabled.** The hero card reuses the same hidden input the paperclip would use (moved out of the `COMPOSER_ATTACH_ENABLED` gate), so flipping the flag back on remains a one-line change without a second upload path.
+
+## Deferred (intentional non-goals for v1)
+
+- **Whole-panel or window-level drop targets.** Drag-and-drop is scoped to the hero card and the tile; a global handler risks hijacking drops meant for the browser and needs drag-enter choreography. Revisit if users demonstrably drop files onto the file list itself.
+- **Per-user dismissal.** The dot's dismissal is per browser (`localStorage`), while `hasUploads` is per-user server truth. A second user on the same browser misses the dot but still gets the non-dismissible empty states. Suffix the key with a user id only if that becomes a real complaint.
+- **Resume-vs-JD completeness guidance** (e.g. "you added a resume — now add the job description"). Needs content-type detection of uploads; the agent already asks for what it's missing.
+
+## How to verify end-to-end
+
+1. `docker compose up -d`; open the frontend port from `docker ps`. With auth enabled, sign up a throwaway user (fresh per-user state).
+2. Fresh user: hero shows the dashed upload card between subhead and chips; Files card shows the empty-state block; the outlined Upload button carries a pulsing accent dot (static under `prefers-reduced-motion`).
+3. Upload via the hero card (click or drop a PDF): card and empty state retire, the file card appears with the **Upload files** tile beside it, the composer pre-fills "Uploaded: …", and the dot **remains**.
+4. Drop a `.pdf` + `.exe` together on the tile: the PDF uploads, a toast reports one skipped unsupported file.
+5. Click any panel upload control, then cancel the picker: the dot disappears and stays gone across reloads (`localStorage` `nr-upload-cue-dismissed-v2` = `1`). Delete all files: empty states return; the dot does not.
+6. Hard-reload with uploads present: no CTA flash at first paint. Run `pnpm --dir frontend test`.

--- a/frontend/DESIGN.md
+++ b/frontend/DESIGN.md
@@ -466,7 +466,9 @@ Depth is **color-block first** — surface contrast (canvas → surface → surf
 
 ### Conversation
 
-**`hero`** — centered empty state: glowing brand mark, `{typography.hero}` headline with the accent italic emphasis, a `{colors.text-2}` subtitle, and a row of `{component.suggestion-chip}` that fill the composer.
+**`hero`** — centered empty state: glowing brand mark, `{typography.hero}` headline with the accent italic emphasis, a `{colors.text-2}` subtitle, then (first-run only) `{component.upload-dropzone}`, and a row of `{component.suggestion-chip}` that fill the composer.
+
+**`upload-dropzone`** — the first-run featured action: a dashed-hairline `{rounded.card}`-scale card (`{colors.surface-2}` at 70%) with a `{component.card-icon-chip}`, a bold one-line ask ("Add your resume or a job description") and a `{colors.text-3}` sub-line; click opens the file picker, drag-over/drop uploads in place (accent border + `{colors.accent-soft}` wash while dragging). Renders only while the user has **zero uploads** (`filesReady && !hasUploads` from `useUploadCue`) — it retires permanently on the first upload, never via a dismiss control.
 
 **`suggestion-chip`** — icon + label, `{colors.surface-2}` + hairline, hover lifts + accent border. Order: Research → Tailor → Prepare for an interview → Build a battlecard.
 
@@ -493,6 +495,12 @@ Depth is **color-block first** — surface contrast (canvas → surface → surf
 **`progress-bar`** (Plan) — `{colors.surface-3}` track, `{colors.accent}` fill, 10px, `{rounded.pill}`, with a moving sheen while active. Below it, a todo timeline mirrors the tool rail: done = struck-through check, active = spinner, todo = hollow circle.
 
 **`file-card`** — `{colors.surface-2}` + hairline, `{rounded.file-card}`, hover lifts + accent border. Top row: a type squircle + a `{component.badge-type}` (format label, colored by `{colors.cat-*}`). Then the file name (`{typography.title}`) and a mono dir `{typography.path}`.
+
+**`files-empty-state`** — the Files card with zero entries: centered `{component.card-icon-chip}` with an Upload glyph, "No files yet" title, one supporting line, and a `{component.button-primary}` "Upload files" CTA wired to the same picker as the header Upload button (the header action is `{component.button-outline}` — one primary per card).
+
+**`file-add-tile`** — the last item in the file grid, always present while the card has files: a dashed-hairline tile matching `{component.file-card}` footprint, accent Upload glyph, "Upload files" label, mono format hint. It is the persistent upload affordance once the empty states retire — uploads #2+ happen where the files live. Click opens the picker; drag-over swaps the label to "Drop to upload" with accent border + `{colors.accent-soft}` wash (same drop filtering as `{component.upload-dropzone}`); disabled while uploading or the agent streams. **Label rule:** every upload affordance uses the "Upload" verb ("Upload" header action, "Upload files" empty-state CTA and tile) — one action, one name.
+
+**`upload-cue-dot`** — first-run hotspot on the Files header Upload button: an 8px `{colors.accent}` dot ringed in `{colors.surface-2}`, pulsing via `motion-safe:animate-pulse` (static but visible under reduced motion). Shows while `filesReady && !dismissed` — it survives the first upload (a hero-card upload doesn't teach where the button is) and only retires when the user clicks a panel upload trigger (header button, empty-state CTA, add-files tile), persisted as localStorage `nr-upload-cue-dismissed-v2`. The dot is the **only** dismissible guidance piece — never add arrows, coach marks, or tours.
 
 **`source-row`** — square letter badge + title + domain (`{colors.text-3}`) + external-link icon; hover `{colors.surface-3}`.
 

--- a/frontend/src/app/components/ChatInterface.test.tsx
+++ b/frontend/src/app/components/ChatInterface.test.tsx
@@ -1,6 +1,7 @@
-import { render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
+import { toast } from "sonner";
 import { AIMessage, HumanMessage, ToolMessage, type BaseMessage } from "@langchain/core/messages";
 import type { Assistant } from "@langchain/langgraph-sdk";
 import type { ToolCall } from "@/app/types/types";
@@ -19,10 +20,18 @@ const resumeInterrupt = vi.fn();
 const refreshFiles = vi.fn(async () => {});
 const appendUploadNote = vi.fn();
 
-const ctx: { messages: BaseMessage[]; isLoading: boolean; isThreadLoading: boolean } = {
+const ctx: {
+  messages: BaseMessage[];
+  isLoading: boolean;
+  isThreadLoading: boolean;
+  files: Record<string, string>;
+  filesReady: boolean;
+} = {
   messages: [],
   isLoading: false,
   isThreadLoading: false,
+  files: {},
+  filesReady: true,
 };
 
 function useMockChatContext() {
@@ -32,6 +41,8 @@ function useMockChatContext() {
     messages: ctx.messages,
     isLoading: ctx.isLoading,
     isThreadLoading: ctx.isThreadLoading,
+    files: ctx.files,
+    filesReady: ctx.filesReady,
     interrupt: undefined,
     sendMessage,
     stopStream,
@@ -56,10 +67,10 @@ vi.mock("sonner", () => ({
 const uploadAgentFilesMock = vi.hoisted(() =>
   vi.fn(async () => ({ uploaded: [] as { path: string; size: number }[], errors: [] }))
 );
-vi.mock("@/app/lib/uploadFiles", () => ({
-  CAREER_AGENT_UPLOAD_DIR: "backend/agents/career_agent/upload",
-  uploadAgentFiles: uploadAgentFilesMock,
-}));
+vi.mock("@/app/lib/uploadFiles", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/app/lib/uploadFiles")>();
+  return { ...actual, uploadAgentFiles: uploadAgentFilesMock };
+});
 
 vi.mock("@/app/components/ChatMessage", () => ({
   ChatMessage: ({
@@ -100,9 +111,12 @@ const composer = () => screen.getByPlaceholderText(/Message NextRole/);
 
 beforeEach(() => {
   vi.clearAllMocks();
+  localStorage.clear();
   ctx.messages = [];
   ctx.isLoading = false;
   ctx.isThreadLoading = false;
+  ctx.files = {};
+  ctx.filesReady = true;
 });
 
 // ---------------------------------------------------------------------------
@@ -197,16 +211,60 @@ describe("ChatInterface", () => {
   });
 
   // COMPOSER_ATTACH_ENABLED is hardcoded to false in the component, so the
-  // hidden file input never renders and the uploadAgentFiles/appendUploadNote
-  // path is unreachable from the composer. Documented here as the flag-off
-  // behavior; the upload flow itself lives in Workspace > Files.
+  // paperclip button never renders. The hidden file input DOES render — it's
+  // shared with the hero upload CTA — but nothing in the composer reaches it.
   it("renders no attach control while the composer paperclip flag is off", () => {
     renderChat();
 
     expect(screen.queryByTitle("Attach a file")).not.toBeInTheDocument();
-    expect(document.querySelector('input[type="file"]')).toBeNull();
+    expect(document.querySelector('input[type="file"]')).not.toBeNull();
     expect(uploadAgentFilesMock).not.toHaveBeenCalled();
     expect(appendUploadNote).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// First-run upload CTA (hero dropzone)
+// ---------------------------------------------------------------------------
+
+describe("ChatInterface first-run upload CTA", () => {
+  const cta = () => screen.queryByRole("button", { name: /add your resume or a job description/i });
+
+  it("features the upload card in the hero for a fresh user", () => {
+    renderChat();
+    expect(cta()).toBeInTheDocument();
+  });
+
+  it("hides the card until the file list is ready (no returning-user flash)", () => {
+    ctx.filesReady = false;
+    renderChat();
+    expect(screen.getByRole("heading", { name: /land your next role/i })).toBeInTheDocument();
+    expect(cta()).not.toBeInTheDocument();
+  });
+
+  it("hides the card once the user has an upload", () => {
+    ctx.files = { "/upload/cv.pdf": "…" };
+    renderChat();
+    expect(cta()).not.toBeInTheDocument();
+  });
+
+  it("keeps the card when only agent-generated files exist", () => {
+    ctx.files = { "/tailored_resume/v1.md": "…" };
+    renderChat();
+    expect(cta()).toBeInTheDocument();
+  });
+
+  it("uploads accepted files on drop and reports skipped ones", async () => {
+    renderChat();
+    const pdf = new File(["x"], "cv.pdf", { type: "application/pdf" });
+    const exe = new File(["x"], "setup.exe", { type: "application/octet-stream" });
+
+    fireEvent.drop(cta()!, { dataTransfer: { files: [pdf, exe] } });
+
+    await waitFor(() => expect(uploadAgentFilesMock).toHaveBeenCalledTimes(1));
+    expect(uploadAgentFilesMock).toHaveBeenCalledWith({ files: [pdf], targetDir: "/upload" });
+    expect(toast.error).toHaveBeenCalledWith(expect.stringContaining("Skipped 1 unsupported file"));
+    await act(async () => {});
   });
 });
 

--- a/frontend/src/app/components/ChatInterface.tsx
+++ b/frontend/src/app/components/ChatInterface.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useRef, useCallback, useMemo, useEffect, useState, FormEvent } from "react";
+import React, { useRef, useCallback, useMemo, useEffect, FormEvent } from "react";
 import {
   Square,
   ArrowUp,
@@ -10,8 +10,8 @@ import {
   Search,
   ClipboardList,
   GraduationCap,
+  Upload,
 } from "lucide-react";
-import { toast } from "sonner";
 import { ChatMessage } from "@/app/components/ChatMessage";
 import { LogoMark } from "@/app/components/LogoMark";
 import type { ToolCall, ActionRequest, ReviewConfig } from "@/app/types/types";
@@ -25,7 +25,9 @@ import {
 } from "@langchain/core/messages";
 import { extractStringFromMessageContent, parsePartialArgs } from "@/app/utils/utils";
 import { useChatContext } from "@/providers/ChatProvider";
-import { CAREER_AGENT_UPLOAD_DIR, uploadAgentFiles } from "@/app/lib/uploadFiles";
+import { useFileUpload, useUploadDrop } from "@/app/hooks/useFileUpload";
+import { useUploadCue } from "@/app/hooks/useUploadCue";
+import { UPLOAD_ACCEPT } from "@/app/lib/uploadFiles";
 import { useStickToBottom } from "use-stick-to-bottom";
 import { cn } from "@/lib/utils";
 
@@ -65,7 +67,9 @@ const COMPOSER_ATTACH_ENABLED = false;
 export const ChatInterface = React.memo<ChatInterfaceProps>(({ assistant }) => {
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const attachInputRef = useRef<HTMLInputElement | null>(null);
-  const [uploading, setUploading] = useState(false);
+  const { uploading, uploadFiles, onInputChange } = useFileUpload();
+  const { dragActive, dropHandlers } = useUploadDrop(uploadFiles, uploading);
+  const { showUploadCta } = useUploadCue();
 
   const { scrollRef, contentRef } = useStickToBottom();
 
@@ -81,8 +85,6 @@ export const ChatInterface = React.memo<ChatInterfaceProps>(({ assistant }) => {
     input,
     setInput,
     focusComposerNonce,
-    refreshFiles,
-    appendUploadNote,
   } = useChatContext();
 
   const submitDisabled = isLoading || !assistant;
@@ -158,35 +160,6 @@ export const ChatInterface = React.memo<ChatInterfaceProps>(({ assistant }) => {
       });
     },
     [setInput]
-  );
-
-  // Attach (paperclip) — reuses the same upload path as Workspace > Files.
-  const handleAttach = useCallback(
-    async (e: React.ChangeEvent<HTMLInputElement>) => {
-      const list = e.target.files;
-      if (!list || list.length === 0) return;
-      const picked = Array.from(list);
-      e.target.value = "";
-      setUploading(true);
-      try {
-        const res = await uploadAgentFiles({ files: picked, targetDir: CAREER_AGENT_UPLOAD_DIR });
-        if (res.uploaded.length > 0) {
-          toast.success(
-            `Uploaded ${res.uploaded.length} file${res.uploaded.length > 1 ? "s" : ""}`
-          );
-          appendUploadNote(
-            res.uploaded.map((u) => u.path.split("/").pop()).filter((n): n is string => !!n)
-          );
-        }
-        for (const err of res.errors) toast.error(`${err.name}: ${err.reason}`);
-        await refreshFiles?.();
-      } catch (err) {
-        toast.error(err instanceof Error ? err.message : "Upload failed");
-      } finally {
-        setUploading(false);
-      }
-    },
-    [appendUploadNote, refreshFiles]
   );
 
   // Cache stable references for finalized ToolCall objects and per-message
@@ -393,6 +366,15 @@ export const ChatInterface = React.memo<ChatInterfaceProps>(({ assistant }) => {
 
   return (
     <div className="flex flex-1 flex-col overflow-hidden bg-canvas">
+      {/* Shared picker for the hero upload CTA and the composer paperclip. */}
+      <input
+        ref={attachInputRef}
+        type="file"
+        multiple
+        accept={UPLOAD_ACCEPT}
+        className="hidden"
+        onChange={onInputChange}
+      />
       <div className="flex-1 overflow-x-hidden overflow-y-auto overscroll-contain" ref={scrollRef}>
         <div ref={contentRef}>
           {isThreadLoading ? (
@@ -417,7 +399,42 @@ export const ChatInterface = React.memo<ChatInterfaceProps>(({ assistant }) => {
                 Drop in your resume and a job post. NextRole tailors your application, researches
                 the company, and preps you for every round — all in one workspace.
               </p>
-              <div className="mt-7 flex max-w-[560px] flex-wrap justify-center gap-2.5">
+              {showUploadCta && (
+                <button
+                  type="button"
+                  onClick={() => attachInputRef.current?.click()}
+                  disabled={uploading}
+                  {...dropHandlers}
+                  className={cn(
+                    "mt-8 flex w-full max-w-[480px] items-center gap-3.5 rounded-2xl border border-dashed border-border2 bg-surface-raised/70 px-5 py-4 text-left shadow-sm transition-colors hover:border-brand-strong hover:bg-brand-accent-soft/40 disabled:opacity-60",
+                    dragActive && "border-brand-strong bg-brand-accent-soft/40"
+                  )}
+                >
+                  <span className="grid size-10 shrink-0 place-items-center rounded-[9px] bg-brand-accent-soft text-brand-accent">
+                    {uploading ? (
+                      <Loader2 size={18} className="animate-spin" />
+                    ) : (
+                      <Upload size={18} />
+                    )}
+                  </span>
+                  <span className="min-w-0">
+                    <span className="block text-[14px] font-semibold text-primary">
+                      Add your resume or a job description
+                    </span>
+                    <span className="mt-0.5 block text-[12.5px] text-tertiary">
+                      {uploading
+                        ? "Uploading…"
+                        : "Click to browse or drop files — PDF, DOC, DOCX, TXT, MD"}
+                    </span>
+                  </span>
+                </button>
+              )}
+              <div
+                className={cn(
+                  "flex max-w-[560px] flex-wrap justify-center gap-2.5",
+                  showUploadCta ? "mt-5" : "mt-7"
+                )}
+              >
                 {SUGGESTIONS.map((s) => (
                   <button
                     key={s.label}
@@ -482,29 +499,19 @@ export const ChatInterface = React.memo<ChatInterfaceProps>(({ assistant }) => {
               <div className="flex items-center justify-between gap-2 px-3 pb-3">
                 <div className="flex min-w-0 items-center gap-1.5">
                   {COMPOSER_ATTACH_ENABLED && (
-                    <>
-                      <input
-                        ref={attachInputRef}
-                        type="file"
-                        multiple
-                        accept=".pdf,.doc,.docx,.txt,.md"
-                        className="hidden"
-                        onChange={handleAttach}
-                      />
-                      <button
-                        type="button"
-                        title="Attach a file"
-                        onClick={() => attachInputRef.current?.click()}
-                        disabled={uploading || submitDisabled}
-                        className="grid size-9 shrink-0 place-items-center rounded-full text-tertiary transition-colors hover:bg-surface3 hover:text-primary disabled:opacity-50"
-                      >
-                        {uploading ? (
-                          <Loader2 size={16} className="animate-spin" />
-                        ) : (
-                          <Paperclip size={16} />
-                        )}
-                      </button>
-                    </>
+                    <button
+                      type="button"
+                      title="Attach a file"
+                      onClick={() => attachInputRef.current?.click()}
+                      disabled={uploading || submitDisabled}
+                      className="grid size-9 shrink-0 place-items-center rounded-full text-tertiary transition-colors hover:bg-surface3 hover:text-primary disabled:opacity-50"
+                    >
+                      {uploading ? (
+                        <Loader2 size={16} className="animate-spin" />
+                      ) : (
+                        <Paperclip size={16} />
+                      )}
+                    </button>
                   )}
                   <span className="truncate text-xs text-tertiary">
                     Enter to send · Shift+Enter for newline

--- a/frontend/src/app/components/TasksFilesSidebar.test.tsx
+++ b/frontend/src/app/components/TasksFilesSidebar.test.tsx
@@ -1,7 +1,7 @@
-import { act, render, screen, waitFor, within } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { TodoItem } from "@/app/types/types";
-import { TasksFilesSidebar } from "./TasksFilesSidebar";
+import { FilesPopover, TasksFilesSidebar } from "./TasksFilesSidebar";
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -275,5 +275,58 @@ describe("TasksFilesSidebar", () => {
     } finally {
       consoleError.mockRestore();
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FilesPopover upload-files tile (persistent upload affordance in the grid)
+// ---------------------------------------------------------------------------
+
+describe("FilesPopover upload-files tile", () => {
+  const baseProps = {
+    files: { [PATH_UPLOAD]: "cv body" },
+    setFiles: vi.fn(async () => {}),
+    removeFile,
+    removeFiles,
+    editDisabled: false,
+  };
+
+  it("renders the tile alongside file cards and forwards clicks", async () => {
+    const onAddFiles = vi.fn();
+    const user = userEvent.setup();
+    render(<FilesPopover {...baseProps} onAddFiles={onAddFiles} />);
+
+    const tile = screen.getByRole("button", { name: /upload files/i });
+    await user.click(tile);
+    expect(onAddFiles).toHaveBeenCalledTimes(1);
+  });
+
+  it("omits the tile when onAddFiles is not provided", () => {
+    render(<FilesPopover {...baseProps} />);
+    expect(screen.queryByRole("button", { name: /upload files/i })).not.toBeInTheDocument();
+  });
+
+  it("disables the tile and shows progress while uploading", () => {
+    render(<FilesPopover {...baseProps} onAddFiles={vi.fn()} uploading />);
+    expect(screen.getByRole("button", { name: /uploading/i })).toBeDisabled();
+  });
+
+  it("disables the tile while the agent is streaming (editDisabled)", () => {
+    render(<FilesPopover {...baseProps} onAddFiles={vi.fn()} editDisabled />);
+    expect(screen.getByRole("button", { name: /upload files/i })).toBeDisabled();
+  });
+
+  it("uploads accepted files dropped on the tile and reports skipped ones", async () => {
+    const onDropFiles = vi.fn();
+    render(<FilesPopover {...baseProps} onAddFiles={vi.fn()} onDropFiles={onDropFiles} />);
+
+    const pdf = new File(["x"], "jd.pdf", { type: "application/pdf" });
+    const exe = new File(["x"], "setup.exe", { type: "application/octet-stream" });
+    fireEvent.drop(screen.getByRole("button", { name: /upload files/i }), {
+      dataTransfer: { files: [pdf, exe] },
+    });
+
+    await waitFor(() => expect(onDropFiles).toHaveBeenCalledWith([pdf]));
+    expect(toast.error).toHaveBeenCalledWith(expect.stringContaining("Skipped 1 unsupported file"));
   });
 });

--- a/frontend/src/app/components/TasksFilesSidebar.tsx
+++ b/frontend/src/app/components/TasksFilesSidebar.tsx
@@ -10,6 +10,7 @@ import {
   Trash2,
   Loader2,
   Check,
+  Upload,
 } from "lucide-react";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Button } from "@/components/ui/button";
@@ -23,6 +24,7 @@ import {
 import { toast } from "sonner";
 import type { TodoItem, FileItem } from "@/app/types/types";
 import { useChatContext } from "@/providers/ChatProvider";
+import { useUploadDrop } from "@/app/hooks/useFileUpload";
 import { cn } from "@/lib/utils";
 import { FileViewDialog } from "@/app/components/FileViewDialog";
 import { getFileCategory, splitBasename, splitFilePath } from "@/app/lib/fileCategories";
@@ -132,6 +134,9 @@ export function FilesPopover({
   removeFile,
   removeFiles,
   editDisabled,
+  onAddFiles,
+  onDropFiles,
+  uploading = false,
 }: {
   files: Record<string, string>;
   setFiles: (files: Record<string, string>) => Promise<void>;
@@ -140,6 +145,11 @@ export function FilesPopover({
     virtualPaths: string[]
   ) => Promise<{ deleted: string[]; errors: { path: string; reason: string }[] }>;
   editDisabled: boolean;
+  /** Renders a persistent "Upload files" tile in the grid that opens the upload picker. */
+  onAddFiles?: () => void;
+  /** Enables drag-and-drop onto the tile; receives the accepted dropped files. */
+  onDropFiles?: (files: File[]) => void | Promise<void>;
+  uploading?: boolean;
 }) {
   const [selectedFile, setSelectedFile] = useState<FileItem | null>(null);
   const [pendingDelete, setPendingDelete] = useState<string[] | null>(null);
@@ -147,6 +157,7 @@ export function FilesPopover({
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [anchor, setAnchor] = useState<string | null>(null);
   const wrapperRef = useRef<HTMLDivElement>(null);
+  const { dragActive, dropHandlers } = useUploadDrop(onDropFiles ?? (() => {}), uploading);
 
   const filePaths = useMemo(() => Object.keys(files), [files]);
 
@@ -339,6 +350,28 @@ export function FilesPopover({
                 />
               );
             })}
+            {onAddFiles && (
+              <button
+                type="button"
+                onClick={onAddFiles}
+                disabled={uploading || editDisabled}
+                {...(onDropFiles ? dropHandlers : {})}
+                className={cn(
+                  "flex min-h-[110px] cursor-pointer flex-col items-center justify-center gap-1.5 rounded-xl border border-dashed border-border2 px-3 py-3 text-center transition-colors hover:border-brand-strong hover:bg-brand-accent-soft/30 disabled:pointer-events-none disabled:opacity-60",
+                  dragActive && "border-brand-strong bg-brand-accent-soft/30"
+                )}
+              >
+                {uploading ? (
+                  <Loader2 size={17} className="animate-spin text-brand-accent" />
+                ) : (
+                  <Upload size={17} className="text-brand-accent" />
+                )}
+                <span className="text-[12.5px] font-semibold text-foreground">
+                  {uploading ? "Uploading…" : dragActive ? "Drop to upload" : "Upload files"}
+                </span>
+                <span className="font-mono text-[10.5px] text-tertiary">PDF · DOC · TXT · MD</span>
+              </button>
+            )}
           </div>
         </div>
       )}

--- a/frontend/src/app/components/workspace/FilesSection.tsx
+++ b/frontend/src/app/components/workspace/FilesSection.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import React, { useRef, useState } from "react";
+import { useRef } from "react";
 import { FileText, Loader2, Upload } from "lucide-react";
-import { toast } from "sonner";
 import { FilesPopover } from "@/app/components/TasksFilesSidebar";
 import { WorkspaceCard } from "@/app/components/workspace/WorkspaceCard";
 import { Button } from "@/components/ui/button";
-import { CAREER_AGENT_UPLOAD_DIR, uploadAgentFiles } from "@/app/lib/uploadFiles";
-import { useChatContext } from "@/providers/ChatProvider";
+import { useFileUpload } from "@/app/hooks/useFileUpload";
+import { useUploadCue } from "@/app/hooks/useUploadCue";
+import { UPLOAD_ACCEPT } from "@/app/lib/uploadFiles";
 
 interface FilesSectionProps {
   files: Record<string, string>;
@@ -21,8 +21,6 @@ interface FilesSectionProps {
   onToggle: () => void;
 }
 
-const UPLOAD_ACCEPT = ".pdf,.doc,.docx,.txt,.md";
-
 export function FilesSection({
   files,
   setFiles,
@@ -34,33 +32,14 @@ export function FilesSection({
 }: FilesSectionProps) {
   const count = Object.keys(files).length;
   const inputRef = useRef<HTMLInputElement | null>(null);
-  const [uploading, setUploading] = useState(false);
-  const { refreshFiles, appendUploadNote } = useChatContext();
+  const { uploading, uploadFiles, onInputChange } = useFileUpload();
+  const { showPulseCue, dismissCue } = useUploadCue();
 
-  const handleSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const list = e.target.files;
-    if (!list || list.length === 0) return;
-    const picked = Array.from(list);
-    e.target.value = "";
-
-    setUploading(true);
-    try {
-      const res = await uploadAgentFiles({ files: picked, targetDir: CAREER_AGENT_UPLOAD_DIR });
-      if (res.uploaded.length > 0) {
-        toast.success(`Uploaded ${res.uploaded.length} file${res.uploaded.length > 1 ? "s" : ""}`);
-        appendUploadNote(
-          res.uploaded.map((u) => u.path.split("/").pop()).filter((n): n is string => !!n)
-        );
-      }
-      for (const err of res.errors) {
-        toast.error(`${err.name}: ${err.reason}`);
-      }
-      await refreshFiles?.();
-    } catch (err) {
-      toast.error(err instanceof Error ? err.message : "Upload failed");
-    } finally {
-      setUploading(false);
-    }
+  // Dismiss on click, not on upload: opening the picker proves the user found
+  // the button, which is all the cue exists for — cancelling still counts.
+  const openPicker = () => {
+    dismissCue();
+    inputRef.current?.click();
   };
 
   const uploadButton = (
@@ -71,19 +50,27 @@ export function FilesSection({
         multiple
         accept={UPLOAD_ACCEPT}
         className="hidden"
-        onChange={handleSelect}
+        onChange={onInputChange}
       />
-      <Button
-        type="button"
-        variant="ghost"
-        size="sm"
-        className="gap-1.5"
-        disabled={uploading || editDisabled}
-        onClick={() => inputRef.current?.click()}
-      >
-        {uploading ? <Loader2 size={14} className="animate-spin" /> : <Upload size={14} />}
-        <span>Upload</span>
-      </Button>
+      <span className="relative inline-flex">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="gap-1.5"
+          disabled={uploading || editDisabled}
+          onClick={openPicker}
+        >
+          {uploading ? <Loader2 size={14} className="animate-spin" /> : <Upload size={14} />}
+          <span>Upload</span>
+        </Button>
+        {showPulseCue && (
+          <span
+            aria-hidden="true"
+            className="pointer-events-none absolute -top-0.5 -right-0.5 size-2 rounded-full bg-brand-accent ring-2 ring-surface-raised motion-safe:animate-pulse"
+          />
+        )}
+      </span>
     </>
   );
 
@@ -97,9 +84,28 @@ export function FilesSection({
       headerAction={uploadButton}
     >
       {count === 0 ? (
-        <p className="py-2 text-sm text-muted-foreground">
-          No files yet. Upload your CV or job description to get started.
-        </p>
+        <div className="flex flex-col items-center gap-3 py-6 text-center">
+          <span className="flex size-10 items-center justify-center rounded-[9px] bg-brand-accent-soft text-brand-accent">
+            <Upload size={18} />
+          </span>
+          <div>
+            <p className="text-sm font-semibold text-foreground">No files yet</p>
+            <p className="mx-auto mt-1 max-w-[280px] text-sm text-muted-foreground">
+              Add your resume or a job description and NextRole will tailor everything to it.
+            </p>
+          </div>
+          <Button
+            type="button"
+            variant="primary"
+            size="sm"
+            className="gap-1.5"
+            disabled={uploading || editDisabled}
+            onClick={openPicker}
+          >
+            {uploading ? <Loader2 size={14} className="animate-spin" /> : <Upload size={14} />}
+            Upload files
+          </Button>
+        </div>
       ) : (
         <FilesPopover
           files={files}
@@ -107,6 +113,9 @@ export function FilesSection({
           removeFile={removeFile}
           removeFiles={removeFiles}
           editDisabled={editDisabled}
+          onAddFiles={openPicker}
+          onDropFiles={uploadFiles}
+          uploading={uploading}
         />
       )}
     </WorkspaceCard>

--- a/frontend/src/app/hooks/useChat.ts
+++ b/frontend/src/app/hooks/useChat.ts
@@ -114,6 +114,10 @@ export function useChat({
 
   // Files surfaced to the UI: state files + (per-agent) store + disk files.
   const [extendedFiles, setExtendedFiles] = useState<AgentFile[]>([]);
+  // True once refreshFiles has run with a resolved graphId — i.e. a fetch that
+  // could actually see artifact uploads. First-run guidance (hero upload CTA,
+  // pulse cue) gates on this so returning users get no first-paint flash.
+  const [filesReady, setFilesReady] = useState(false);
   const extendedFilesRef = useRef<AgentFile[]>([]);
   extendedFilesRef.current = extendedFiles;
 
@@ -165,6 +169,9 @@ export function useChat({
     } catch (e) {
       console.warn("fetchAgentFiles failed", e);
     }
+    // Flip on failure too: the Files panel then shows the same (empty) picture,
+    // so the first-run guidance stays consistent with it.
+    if (graphId) setFilesReady(true);
   }, [client, graphId, stateFilesSig]);
 
   useEffect(() => {
@@ -354,6 +361,7 @@ export function useChat({
     email: stream.values.email,
     setFiles,
     refreshFiles,
+    filesReady,
     removeFile,
     removeFiles,
     input,

--- a/frontend/src/app/hooks/useFileUpload.test.tsx
+++ b/frontend/src/app/hooks/useFileUpload.test.tsx
@@ -1,0 +1,177 @@
+import { act, renderHook } from "@testing-library/react";
+import type { ChangeEvent, DragEvent, ReactNode } from "react";
+import { toast } from "sonner";
+import { ChatContext, type ChatContextType } from "@/providers/ChatProvider";
+import { useFileUpload, useUploadDrop } from "@/app/hooks/useFileUpload";
+import { uploadAgentFiles, type UploadResponse } from "@/app/lib/uploadFiles";
+
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock("@/app/lib/uploadFiles", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/app/lib/uploadFiles")>();
+  return { ...actual, uploadAgentFiles: vi.fn() };
+});
+
+const mockUpload = vi.mocked(uploadAgentFiles);
+
+function renderUpload() {
+  const refreshFiles = vi.fn(async () => {});
+  const appendUploadNote = vi.fn();
+  const ctx = { refreshFiles, appendUploadNote } as unknown as ChatContextType;
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <ChatContext.Provider value={ctx}>{children}</ChatContext.Provider>
+  );
+  const hook = renderHook(() => useFileUpload(), { wrapper });
+  return { ...hook, refreshFiles, appendUploadNote };
+}
+
+const file = (name: string) => new File(["data"], name, { type: "application/pdf" });
+
+describe("useFileUpload", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uploads to the /upload dir, toasts, notes basenames, and refreshes", async () => {
+    mockUpload.mockResolvedValue({
+      uploaded: [{ path: "/upload/cv.pdf", size: 1 }],
+      errors: [],
+    });
+    const { result, refreshFiles, appendUploadNote } = renderUpload();
+
+    const picked = [file("cv.pdf")];
+    await act(() => result.current.uploadFiles(picked));
+
+    expect(mockUpload).toHaveBeenCalledWith({ files: picked, targetDir: "/upload" });
+    expect(toast.success).toHaveBeenCalledWith("Uploaded 1 file");
+    expect(appendUploadNote).toHaveBeenCalledWith(["cv.pdf"]);
+    expect(refreshFiles).toHaveBeenCalledTimes(1);
+    expect(result.current.uploading).toBe(false);
+  });
+
+  it("toasts each per-file error and skips the note when nothing uploaded", async () => {
+    mockUpload.mockResolvedValue({
+      uploaded: [],
+      errors: [{ name: "cv.pdf", reason: "too large" }],
+    });
+    const { result, appendUploadNote } = renderUpload();
+
+    await act(() => result.current.uploadFiles([file("cv.pdf")]));
+
+    expect(toast.error).toHaveBeenCalledWith("cv.pdf: too large");
+    expect(toast.success).not.toHaveBeenCalled();
+    expect(appendUploadNote).not.toHaveBeenCalled();
+  });
+
+  it("toasts a thrown failure and resets uploading", async () => {
+    mockUpload.mockRejectedValue(new Error("boom"));
+    const { result } = renderUpload();
+
+    await act(() => result.current.uploadFiles([file("cv.pdf")]));
+
+    expect(toast.error).toHaveBeenCalledWith("boom");
+    expect(result.current.uploading).toBe(false);
+  });
+
+  it("ignores a second call while one is in flight", async () => {
+    let resolve!: (v: UploadResponse) => void;
+    mockUpload.mockReturnValue(new Promise<UploadResponse>((r) => (resolve = r)));
+    const { result } = renderUpload();
+
+    await act(async () => {
+      void result.current.uploadFiles([file("a.pdf")]);
+    });
+    expect(result.current.uploading).toBe(true);
+
+    await act(() => result.current.uploadFiles([file("b.pdf")]));
+    expect(mockUpload).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolve({ uploaded: [], errors: [] });
+    });
+    expect(result.current.uploading).toBe(false);
+  });
+
+  it("onInputChange delegates picked files and clears the input value", async () => {
+    mockUpload.mockResolvedValue({ uploaded: [], errors: [] });
+    const { result } = renderUpload();
+
+    const target = { files: [file("cv.pdf")], value: "cv.pdf" };
+    await act(async () => {
+      result.current.onInputChange({ target } as unknown as ChangeEvent<HTMLInputElement>);
+    });
+
+    expect(target.value).toBe("");
+    expect(mockUpload).toHaveBeenCalledTimes(1);
+  });
+
+  it("onInputChange is a no-op on an empty selection", () => {
+    const { result } = renderUpload();
+    const target = { files: null, value: "" };
+    act(() => {
+      result.current.onInputChange({ target } as unknown as ChangeEvent<HTMLInputElement>);
+    });
+    expect(mockUpload).not.toHaveBeenCalled();
+  });
+});
+
+describe("useUploadDrop", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const dragEvent = (files: File[]) =>
+    ({
+      preventDefault: vi.fn(),
+      dataTransfer: { files },
+      relatedTarget: null,
+      currentTarget: document.createElement("div"),
+    }) as unknown as DragEvent;
+
+  it("tracks drag-over state and filters dropped files by extension", () => {
+    const uploadFiles = vi.fn();
+    const { result } = renderHook(() => useUploadDrop(uploadFiles, false));
+
+    act(() => result.current.dropHandlers.onDragOver(dragEvent([])));
+    expect(result.current.dragActive).toBe(true);
+
+    const pdf = file("cv.pdf");
+    act(() => result.current.dropHandlers.onDrop(dragEvent([pdf, file("virus.exe")])));
+    expect(result.current.dragActive).toBe(false);
+    expect(uploadFiles).toHaveBeenCalledWith([pdf]);
+    expect(toast.error).toHaveBeenCalledWith(expect.stringContaining("Skipped 1 unsupported file"));
+  });
+
+  it("ignores drops while an upload is already in flight", () => {
+    const uploadFiles = vi.fn();
+    const { result } = renderHook(() => useUploadDrop(uploadFiles, true));
+
+    act(() => result.current.dropHandlers.onDrop(dragEvent([file("cv.pdf")])));
+    expect(uploadFiles).not.toHaveBeenCalled();
+  });
+
+  it("keeps dragActive while moving across the target's children", () => {
+    const { result } = renderHook(() => useUploadDrop(vi.fn(), false));
+    act(() => result.current.dropHandlers.onDragOver(dragEvent([])));
+
+    const parent = document.createElement("div");
+    const child = document.createElement("span");
+    parent.appendChild(child);
+    act(() =>
+      result.current.dropHandlers.onDragLeave({
+        preventDefault: vi.fn(),
+        relatedTarget: child,
+        currentTarget: parent,
+      } as unknown as DragEvent)
+    );
+    expect(result.current.dragActive).toBe(true);
+
+    act(() =>
+      result.current.dropHandlers.onDragLeave({
+        preventDefault: vi.fn(),
+        relatedTarget: document.createElement("div"),
+        currentTarget: parent,
+      } as unknown as DragEvent)
+    );
+    expect(result.current.dragActive).toBe(false);
+  });
+});

--- a/frontend/src/app/hooks/useFileUpload.ts
+++ b/frontend/src/app/hooks/useFileUpload.ts
@@ -1,0 +1,103 @@
+"use client";
+
+import { type ChangeEvent, type DragEvent, useCallback, useState } from "react";
+import { toast } from "sonner";
+import {
+  CAREER_AGENT_UPLOAD_DIR,
+  isAcceptedUploadName,
+  uploadAgentFiles,
+} from "@/app/lib/uploadFiles";
+import { useChatContext } from "@/providers/ChatProvider";
+
+/**
+ * Shared upload action for every surface that sends files to the agent's
+ * `/upload` artifacts (Workspace > Files, composer paperclip, hero dropzone):
+ * uploads, toasts results, appends the "Uploaded: ..." composer note, and
+ * refreshes the merged file list.
+ */
+export function useFileUpload() {
+  const { refreshFiles, appendUploadNote } = useChatContext();
+  const [uploading, setUploading] = useState(false);
+
+  const uploadFiles = useCallback(
+    async (picked: File[]) => {
+      if (picked.length === 0 || uploading) return;
+      setUploading(true);
+      try {
+        const res = await uploadAgentFiles({ files: picked, targetDir: CAREER_AGENT_UPLOAD_DIR });
+        if (res.uploaded.length > 0) {
+          toast.success(
+            `Uploaded ${res.uploaded.length} file${res.uploaded.length > 1 ? "s" : ""}`
+          );
+          appendUploadNote(
+            res.uploaded.map((u) => u.path.split("/").pop()).filter((n): n is string => !!n)
+          );
+        }
+        for (const err of res.errors) toast.error(`${err.name}: ${err.reason}`);
+        await refreshFiles?.();
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "Upload failed");
+      } finally {
+        setUploading(false);
+      }
+    },
+    [appendUploadNote, refreshFiles, uploading]
+  );
+
+  const onInputChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      const list = e.target.files;
+      if (!list || list.length === 0) return;
+      const picked = Array.from(list);
+      e.target.value = "";
+      void uploadFiles(picked);
+    },
+    [uploadFiles]
+  );
+
+  return { uploading, uploadFiles, onInputChange };
+}
+
+/**
+ * Drag-and-drop for an upload target (hero dropzone, files add tile): tracks
+ * drag-over state and, on drop, filters against the accepted extensions,
+ * toasts what got skipped, and hands the rest to `uploadFiles`. Scoped to the
+ * element the handlers are spread on — no window-level listener.
+ */
+export function useUploadDrop(
+  uploadFiles: (files: File[]) => void | Promise<void>,
+  uploading: boolean
+) {
+  const [dragActive, setDragActive] = useState(false);
+
+  const onDragOver = useCallback((e: DragEvent) => {
+    e.preventDefault();
+    setDragActive(true);
+  }, []);
+
+  const onDragLeave = useCallback((e: DragEvent) => {
+    // Ignore leave events fired while moving across the target's own children.
+    if (e.relatedTarget && e.currentTarget.contains(e.relatedTarget as Node)) return;
+    setDragActive(false);
+  }, []);
+
+  const onDrop = useCallback(
+    (e: DragEvent) => {
+      e.preventDefault();
+      setDragActive(false);
+      if (uploading) return;
+      const dropped = Array.from(e.dataTransfer.files);
+      const accepted = dropped.filter((f) => isAcceptedUploadName(f.name));
+      const skipped = dropped.length - accepted.length;
+      if (skipped > 0) {
+        toast.error(
+          `Skipped ${skipped} unsupported file${skipped > 1 ? "s" : ""} — PDF, DOC, DOCX, TXT, MD only`
+        );
+      }
+      if (accepted.length > 0) void uploadFiles(accepted);
+    },
+    [uploadFiles, uploading]
+  );
+
+  return { dragActive, dropHandlers: { onDragOver, onDragLeave, onDrop } };
+}

--- a/frontend/src/app/hooks/useUploadCue.test.tsx
+++ b/frontend/src/app/hooks/useUploadCue.test.tsx
@@ -1,0 +1,75 @@
+import { act, renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { ChatContext, type ChatContextType } from "@/providers/ChatProvider";
+import { useUploadCue } from "@/app/hooks/useUploadCue";
+
+const DISMISSED_KEY = "nr-upload-cue-dismissed-v2";
+
+type CueContext = { files: Record<string, string>; filesReady: boolean };
+
+function renderCue(initial: Partial<CueContext> = {}) {
+  let ctx: CueContext = { files: initial.files ?? {}, filesReady: initial.filesReady ?? true };
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <ChatContext.Provider value={ctx as unknown as ChatContextType}>
+      {children}
+    </ChatContext.Provider>
+  );
+  const hook = renderHook(() => useUploadCue(), { wrapper });
+  const setContext = (next: Partial<CueContext>) => {
+    ctx = { ...ctx, ...next };
+    hook.rerender();
+  };
+  return { ...hook, setContext };
+}
+
+describe("useUploadCue", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("hides both cues until filesReady (no first-paint flash)", () => {
+    const { result, setContext } = renderCue({ filesReady: false });
+    expect(result.current.showUploadCta).toBe(false);
+    expect(result.current.showPulseCue).toBe(false);
+
+    setContext({ filesReady: true });
+    expect(result.current.showUploadCta).toBe(true);
+    expect(result.current.showPulseCue).toBe(true);
+  });
+
+  it("treats agent-generated files as no uploads", () => {
+    const { result } = renderCue({ files: { "/custom_resume/draft.md": "…" } });
+    expect(result.current.hasUploads).toBe(false);
+    expect(result.current.showUploadCta).toBe(true);
+    expect(result.current.showPulseCue).toBe(true);
+  });
+
+  it("an /upload/ file hides the CTA but keeps the dot until a panel control is clicked", () => {
+    const { result } = renderCue({ files: { "/upload/cv.pdf": "…" } });
+    expect(result.current.hasUploads).toBe(true);
+    expect(result.current.showUploadCta).toBe(false);
+    // Uploading (e.g. from the hero card) must not retire the dot — the user
+    // still needs pointing at where the next resume/JD goes.
+    expect(result.current.showPulseCue).toBe(true);
+    expect(localStorage.getItem(DISMISSED_KEY)).toBeNull();
+
+    act(() => result.current.dismissCue());
+    expect(result.current.showPulseCue).toBe(false);
+    expect(localStorage.getItem(DISMISSED_KEY)).toBe("1");
+  });
+
+  it("dismissCue hides the dot, keeps the CTA, and persists", () => {
+    const { result } = renderCue();
+    act(() => result.current.dismissCue());
+    expect(result.current.showPulseCue).toBe(false);
+    expect(result.current.showUploadCta).toBe(true);
+    expect(localStorage.getItem(DISMISSED_KEY)).toBe("1");
+  });
+
+  it("respects a stored dismissal on init", () => {
+    localStorage.setItem(DISMISSED_KEY, "1");
+    const { result } = renderCue();
+    expect(result.current.showUploadCta).toBe(true);
+    expect(result.current.showPulseCue).toBe(false);
+  });
+});

--- a/frontend/src/app/hooks/useUploadCue.ts
+++ b/frontend/src/app/hooks/useUploadCue.ts
@@ -1,0 +1,61 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import { CAREER_AGENT_UPLOAD_DIR } from "@/app/lib/uploadFiles";
+import { useChatContext } from "@/providers/ChatProvider";
+
+// v2: dismissal now means "clicked a Files-panel upload control", no longer
+// "uploaded once" — an upload from the hero card must NOT retire the dot,
+// since that user still hasn't found where later uploads live.
+const DISMISSED_KEY = "nr-upload-cue-dismissed-v2";
+
+function readDismissed(): boolean {
+  try {
+    return typeof window !== "undefined" && localStorage.getItem(DISMISSED_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * First-run "upload something" guidance state.
+ *
+ *  - The actionable empty states (chat hero CTA, Files panel block) render
+ *    whenever the user has no uploads — permanent UX, never dismissed;
+ *  - the pulse dot on the Files-panel Upload button persists — through the
+ *    first upload, across sessions — until the user clicks any panel upload
+ *    trigger (header button, empty-state CTA, add-files tile). Finding the
+ *    button is the dismissal, so post-first-upload users still get pointed
+ *    at where the next resume/JD goes; cancelling the picker still counts.
+ *
+ * Both gate on `filesReady` so returning users never see a first-paint flash
+ * while the artifact list is still loading.
+ */
+export function useUploadCue() {
+  const { files, filesReady } = useChatContext();
+
+  const hasUploads = useMemo(
+    () => Object.keys(files).some((p) => p.startsWith(`${CAREER_AGENT_UPLOAD_DIR}/`)),
+    [files]
+  );
+
+  // Lazy init is safe: this subtree mounts client-only behind the config gate,
+  // so there is no SSR/hydration pass to mismatch (same as useThreadsPanel).
+  const [dismissed, setDismissed] = useState(readDismissed);
+
+  const dismissCue = useCallback(() => {
+    setDismissed(true);
+    try {
+      localStorage.setItem(DISMISSED_KEY, "1");
+    } catch {
+      // ignore storage failures
+    }
+  }, []);
+
+  return {
+    hasUploads,
+    showUploadCta: filesReady && !hasUploads,
+    showPulseCue: filesReady && !dismissed,
+    dismissCue,
+  };
+}

--- a/frontend/src/app/lib/uploadFiles.ts
+++ b/frontend/src/app/lib/uploadFiles.ts
@@ -29,6 +29,18 @@ export async function uploadAgentFiles(args: {
 /** Virtual artifact path for user uploads (backend files API contract). */
 export const CAREER_AGENT_UPLOAD_DIR = "/upload";
 
+/** Accepted upload types — file-picker `accept` attribute and drag-drop filter. */
+export const UPLOAD_ACCEPT = ".pdf,.doc,.docx,.txt,.md";
+
+const UPLOAD_ACCEPT_EXTS = new Set(UPLOAD_ACCEPT.split(","));
+
+/** True when a filename carries one of the accepted upload extensions. */
+export function isAcceptedUploadName(name: string): boolean {
+  const dot = name.lastIndexOf(".");
+  if (dot < 0) return false;
+  return UPLOAD_ACCEPT_EXTS.has(name.slice(dot).toLowerCase());
+}
+
 export async function deleteAgentFile(virtualPath: string): Promise<void> {
   const res = await authedFetch(
     filesApiUrl(`/files/delete?path=${encodeURIComponent(virtualPath)}`),


### PR DESCRIPTION
# First-run upload guidance

NextRole only becomes useful once a resume/JD is uploaded, but nothing drove that first action — the hero copy *said* "Drop in your resume" with no affordance, and the only upload control was a small ghost button in the Files header. Instead of the coach-mark/arrow antipattern (skipped and distracting per NN/g / Appcues / Userpilot research), this ships the actionable-empty-state package:

## What's new

- **Hero upload card** in the chat empty state (click to browse or drag-and-drop, PDF/DOC/DOCX/TXT/MD filtered with a skipped-files toast) — shown only while the user has zero uploads.
- **Files panel empty state** upgraded from a text line to icon + copy + primary **Upload files** CTA.
- **Persistent "Upload files" tile** as the last file-grid item, so uploads #2+ have a visible home after the empty states retire (also a drop target; label swaps to "Drop to upload" while dragging).
- **Pulse dot** on the (now outlined) header Upload button — survives the first upload and only retires when the user clicks a panel upload control (persisted as `nr-upload-cue-dismissed-v2`); static under `prefers-reduced-motion`.
- All upload affordances share one verb ("Upload"); `DESIGN.md` documents `upload-dropzone`, `files-empty-state`, `file-add-tile`, `upload-cue-dot`.

## Implementation notes

- `useFileUpload` / `useUploadDrop` consolidate the previously duplicated upload + drop handling; hero card and tile share the same code path.
- `filesReady` in `useChat` flips only after a file fetch with a resolved `graphId` — the first fetch skips the artifact list, so anything earlier would flash the CTA at returning users.
- Guidance keys off `/upload/`-prefixed paths (user uploads), not the merged `files` map, which includes agent-generated artifacts.

Full rationale and decisions: `docs/prd/27_first_run_upload_guidance.md`.

## Test plan

- [x] `pnpm --dir frontend test` — 408 passed (16 new: upload/drop hooks, cue gating/dismissal, hero CTA + tile rendering and drop filtering)
- [x] `pre-commit run` clean (eslint, prettier, tsc, gitleaks)
- [x] Browser-verified with a fresh user: hero card / empty state / dot render after `filesReady`; upload retires the CTA, tile appears, dot persists; clicking a panel control retires the dot across reloads; no first-paint flash for returning users; light + dark + 700px viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)