### PR TITLE
fix: full API docs when a custom HTTP app is mounted

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,8 +41,9 @@ BETTER_AUTH_SECRET=            # generate: openssl rand -base64 32
 AUTH_GOOGLE_ENABLED=false
 GOOGLE_AUTH_CLIENT_ID=
 GOOGLE_AUTH_CLIENT_SECRET=
-# Backend enforcement — pairs with AUTH_ENABLED=true. Value to set:
-#   {"path": "/deps/next-role/backend/agents/auth.py:auth", "disable_studio_auth": true}
+# Backend enforcement — pairs with AUTH_ENABLED=true. Copy the value from
+# README "Authentication & multi-user" step 3 (its optional "openapi" block
+# makes /docs auth-aware).
 LANGGRAPH_AUTH=
 REQUIRE_AUTH=false            # cloud: true → backend refuses to boot without LANGGRAPH_AUTH
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ Frontend and backend hot-reload on source edits — frontend via `pnpm dev` (Tur
 Restart (`docker compose restart <service>`) when:
 
 - Adding a frontend dependency (`pnpm --dir frontend add ...` — boot self-heals `node_modules` from the new lockfile).
-- Changing `.env` values (env vars are read at container start).
+- Changing `.env` values — use `docker compose up -d <service>`, **not** `restart`: env vars are baked in when the container is created, and `restart` reuses the old container, so only a recreate picks them up.
 - Editing `docker-compose.yml` (use `docker compose up -d` to apply the diff).
 - Editing `backend/server/core_server/` or `backend/server/grpc_common/` — **core-server has no hot reload**; run `docker compose restart core-server`.
 

--- a/README.md
+++ b/README.md
@@ -247,7 +247,13 @@ NextRole runs **zero-login single-user by default** — `docker compose up` and 
    BETTER_AUTH_SECRET=<same secret> \
      pnpm --dir frontend dlx @better-auth/cli@latest migrate --config src/lib/auth/server.ts
    ```
-3. `LANGGRAPH_AUTH={"path": "/deps/next-role/backend/agents/auth.py:auth", "disable_studio_auth": true}` — turns on backend enforcement. (Login without this is fine for trying the UI, but provides no isolation.)
+3. `LANGGRAPH_AUTH` — turns on backend enforcement. (Login without this is fine for trying the UI, but provides no isolation.) One line:
+
+   ```env
+   LANGGRAPH_AUTH={"path": "/deps/next-role/backend/agents/auth.py:auth", "disable_studio_auth": true, "openapi": {"securitySchemes": {"bearerAuth": {"type": "http", "scheme": "bearer", "bearerFormat": "JWT", "description": "Better Auth session JWT. While signed in, the frontend's GET /api/auth/token returns one."}}, "security": [{"bearerAuth": []}], "paths": {"/ok": {"GET": []}, "/info": {"GET": []}, "/metrics": {"GET": []}, "/docs": {"GET": []}}}}
+   ```
+
+   The optional `"openapi"` block documents auth in the API reference: `/docs` gets a Bearer Token field for authenticated Test Requests (paste a JWT from the frontend's `GET /api/auth/token`), while the public meta endpoints (`/ok`, `/info`, `/metrics`, `/docs`) stay marked auth-free.
 4. *Optional Google sign-in:* `AUTH_GOOGLE_ENABLED=true` + `GOOGLE_AUTH_CLIENT_ID` / `GOOGLE_AUTH_CLIENT_SECRET` (OAuth client redirect URI `http://localhost:<FRONTEND_LOCAL_PORT>/api/auth/callback/google`). Email + password works without it.
 
 <details>

--- a/backend/server/api/server.py
+++ b/backend/server/api/server.py
@@ -183,6 +183,12 @@ if user_router:
     _store_access_middleware = [Middleware(EnsureStoreAccessible)]
     # Merge routes
     app = user_router
+    # Build the custom-app OpenAPI spec before the built-in routes are merged
+    # into this app: at this point app.routes contains only the user's own
+    # routes. After the merge, the schema-generator fallback below would walk
+    # every built-in route too, emitting empty skeleton entries that override
+    # the documented spec in openapi.json when the two are merged.
+    update_openapi_spec(app)
     if auth_before_custom_middleware:
         # Authentication middleware is only applied to protected routes--
         # it is *not* global middleware. This means that by default,
@@ -221,8 +227,6 @@ if user_router:
         + apply_middleware(shadowable_meta_routes, route_level_custom_middleware)
         + [protected_mount]
     )
-
-    update_openapi_spec(app)
 
     # Merge lifespans (base + user)
     user_lifespan = app.router.lifespan_context

--- a/backend/tests/server/test_smoke.py
+++ b/backend/tests/server/test_smoke.py
@@ -46,6 +46,26 @@ def test_info_reports_server_version() -> None:
     assert payload["host"]["kind"] == "self-hosted"
 
 
+def test_openapi_spec_keeps_builtin_docs_with_custom_app() -> None:
+    """`/openapi.json` serves the documented spec plus the mounted files API.
+
+    Regression: with a custom HTTP app mounted (LANGGRAPH_HTTP), the server
+    generated a skeleton spec from every route — built-ins included — and
+    merged it over server/openapi.json with precedence, wiping each operation
+    to `{}`; /docs rendered a flat, detail-less endpoint list.
+    """
+    response = httpx.get(f"{_base_url()}/openapi.json", timeout=10)
+
+    assert response.status_code == 200
+    paths = response.json()["paths"]
+    create_assistant = paths["/assistants"]["post"]
+    assert create_assistant["tags"] == ["Assistants"]
+    assert create_assistant["summary"] == "Create Assistant"
+    assert "requestBody" in create_assistant
+    # The custom app's own routes must still be merged into the served spec.
+    assert "/files/list" in paths
+
+
 def test_store_roundtrip() -> None:
     """PUT → GET → search → DELETE through the KV store (DeepAgents memory path)."""
     base = _base_url()


### PR DESCRIPTION
## Problem

`/docs` on the backend rendered every endpoint flat — no tag grouping, no summaries, request/response schemas, or examples — while a stock deployment (no custom HTTP app) rendered full docs.

## Root cause

With a custom HTTP app mounted (`LANGGRAPH_HTTP`, used for the artifact files API), `update_openapi_spec()` ran **after** the built-in routes were merged into the custom app. The Starlette `SchemaGenerator` fallback then walked every route — built-ins included — and produced empty skeleton entries (`"post": {}`), and `merge_openapi_specs()` gives the generated spec precedence per method, wiping all 63 documented operations from the served spec. `backend/server/openapi.json` itself was always fine; deployments without a custom app never enter this code path.

## Changes

- **fix** (`backend/server/api/server.py`): build the custom-app spec before the built-in route merge, so it only covers the custom app's own routes. The static spec stays authoritative for built-in paths; `/files/*` still gets appended, and the skeleton noise paths (`/`, `/openapi.json`, `/ui/{graph_id}`, …) disappear.
- **test** (`backend/tests/server/test_smoke.py`): integration check that `/openapi.json` serves documented built-in ops (tags/summary/requestBody on `POST /assistants`) and still includes the mounted `/files/list`.
- **docs** (`.env.example`, README): the documented `LANGGRAPH_AUTH` value now includes the `openapi` security block — `/docs` shows a Bearer Token field for authenticated Test Requests, curl samples carry the `Authorization` header, and the public meta endpoints (`/ok`, `/info`, `/metrics`, `/docs`) stay marked auth-free.
- **docs** (`CLAUDE.md`): `.env` changes need `docker compose up -d <service>` (recreate), not `restart` — restart reuses the container's baked-in environment (verified empirically).

## Verification

- Served spec restored: 49 documented paths + 5 `/files/*`; built-in ops carry full `tags`/`summary`/`requestBody`/`responses`; previously clobbered descriptions back to the curated text.
- Scalar UI verified in-browser: grouped sidebar, request-body docs and examples, `graph_id` enum patched to `career_agent`, Auth Required badges with the bearer scheme.
- New smoke test passes against the local stack; pre-commit (ruff, format, ty) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)