### PR TITLE
chore: align .agents skill mirrors with their .claude copies

### DIFF
--- a/.agents/skills/agent-browser/SKILL.md
+++ b/.agents/skills/agent-browser/SKILL.md
@@ -44,7 +44,7 @@ installed version.
 ## Why agent-browser
 
 - Fast native Rust CLI, not a Node.js wrapper
-- Works with any AI agent (Cursor, Codex, Codex, Continue, Windsurf, etc.)
+- Works with any AI agent (Cursor, Claude Code, Codex, Continue, Windsurf, etc.)
 - Chrome/Chromium via CDP with no Playwright or Puppeteer dependency
 - Accessibility-tree snapshots with element refs for reliable interaction
 - Sessions, authentication vault, state persistence, video recording

--- a/.agents/skills/frontend-design/SKILL.md
+++ b/.agents/skills/frontend-design/SKILL.md
@@ -39,4 +39,4 @@ Interpret creatively and make unexpected choices that feel genuinely designed fo
 
 **IMPORTANT**: Match implementation complexity to the aesthetic vision. Maximalist designs need elaborate code with extensive animations and effects. Minimalist or refined designs need restraint, precision, and careful attention to spacing, typography, and subtle details. Elegance comes from executing the vision well.
 
-Remember: Codex is capable of extraordinary creative work. Don't hold back, show what can truly be created when thinking outside the box and committing fully to a distinctive vision.
+Remember: you are capable of extraordinary creative work. Don't hold back, show what can truly be created when thinking outside the box and committing fully to a distinctive vision.

--- a/.agents/skills/quality/SKILL.md
+++ b/.agents/skills/quality/SKILL.md
@@ -1,41 +1,54 @@
 ---
 name: quality
-description: Run this repository's quality and validation workflow. Use when the user asks for quality checks, pre-commit, linting, formatting, type checking, test validation, or before reporting code changes as done.
+description: Run the repo's quality gate — pre-commit on the files you changed by default, or the full `pre-commit run --all-files` sweep when asked for a full pass, before opening a PR, or after a large refactor. Use when the user asks for quality checks, pre-commit, linting, formatting, type checking, or wants to confirm the whole repo is clean.
 ---
 
 # Quality
 
-Run validation the way `CLAUDE.md` defines it for this repo.
+Run validation the way `CLAUDE.md` defines it for this repo. Two modes — pick by scope, not habit.
 
-## Default Changed-File Check
+## Changed-file check (default after edits)
 
-After code edits, validate all modified and untracked files once at the end:
+Validate everything you touched once at the end of a task — modified tracked files plus new untracked, non-ignored files — in a single run from the repo root:
 
 ```bash
 pre-commit run --files $(git ls-files --modified --others --exclude-standard)
 ```
 
-If hooks auto-fix a file, re-read that file before summarizing the result.
+Don't run it after every individual edit; batch. If `pre-commit` isn't on this shell's PATH, it is a backend dev dependency: `backend/.venv/bin/pre-commit run --files ...`.
 
-## Full Sweep
+## Full sweep (`/quality`, "full quality pass")
 
-When the user asks for a full quality pass or broad repository validation, run:
+When invoked explicitly, when asked for a full quality pass, before opening a PR, or after a large refactor:
 
 ```bash
 pre-commit run --all-files
 ```
 
-## Targeted Checks
+This executes every configured hook on every tracked file:
 
-- Backend fast tests: `cd backend && uv run pytest`
-- Backend single test file: `cd backend && uv run pytest tests/path/test_file.py`
-- Backend integration tests: `cd backend && uv run pytest -m integration`
-- Frontend full test suite: `cd frontend && pnpm test`
-- Frontend type check: `cd frontend && pnpm type-check`
-- Frontend all-in-one check: `cd frontend && pnpm quality`
+- `trailing-whitespace`, `end-of-file-fixer`, `check-yaml`, `check-added-large-files`
+- `gitleaks` (secret scanning)
+- Backend + analytics: `ruff check --fix`, `ruff format`, and `uv run ty check` per project
+- Analytics dbt SQL: `sqlfluff fix` + `sqlfluff lint`
+- Frontend: `eslint --fix`, `prettier --write`, `pnpm --dir frontend type-check`, and `scripts/check-langchain-sdk-sync.mjs` (single installed copy of `@langchain/langgraph-sdk`)
 
-Use targeted checks before the changed-file pre-commit run when they give faster, more relevant feedback.
+## Workflow (both modes)
 
-## Local Stack
+1. Run the command from the repo root.
+2. If hooks **modify files** (ruff/prettier auto-fix, EOL fixer): re-read those files before reporting — the on-disk content differs from what you wrote — then re-stage and re-run until the run is clean.
+3. If hooks **fail with errors** (type errors, lint errors that aren't auto-fixable, secrets detected): report the errors. Do not edit unrelated files to make them pass — fix only what's broken.
+4. Report the final status: green (everything passed) or red (the remaining failures).
 
-If integration tests or visual checks need services and `docker ps` shows the stack is not running, remind the user to run `docker compose up -d`. Do not silently start the stack yourself.
+## Targeted checks
+
+Pre-commit runs linters and type checkers, not tests. Run the relevant suite before the pre-commit step when it gives faster, more relevant feedback:
+
+- Backend unit tests: `cd backend && uv run pytest` (one file: `uv run pytest tests/path/test_file.py`)
+- Backend integration tests: `cd backend && uv run pytest -m integration` (needs the local stack)
+- Frontend tests: `cd frontend && pnpm test`
+- Frontend type check only: `cd frontend && pnpm type-check`; lint + format + type-check together: `pnpm quality`
+
+## Local stack
+
+If integration tests or visual checks need services and `docker ps` shows the stack is not running, remind the user to run `docker compose up -d`. Do not start the stack yourself — they may have stopped it intentionally.

--- a/.agents/skills/upgrade-frontend-deps/SKILL.md
+++ b/.agents/skills/upgrade-frontend-deps/SKILL.md
@@ -8,7 +8,7 @@ Upgrade the frontend's pnpm dependencies in revertable waves, preserving exact-p
 ## Ground rules
 
 - **Exact pins stay exact.** `react`, `react-dom`, and `@langchain/langgraph-sdk` have no `^` in `package.json`. Upgrade them with `pnpm --dir frontend add -E pkg@x.y.z`; everything else gets a new `^` floor (`pnpm --dir frontend add pkg@^x.y.z`).
-- **One resolved version per dep.** The lockfile must not carry two copies of anything that crosses a package boundary (the `@langchain/langgraph-sdk` single-copy invariant in `frontend/AGENTS.md` is the critical one; `scripts/check-langchain-sdk-sync.mjs` guards it).
+- **One resolved version per dep.** The lockfile must not carry two copies of anything that crosses a package boundary (the `@langchain/langgraph-sdk` single-copy invariant in `frontend/CLAUDE.md` is the critical one; `scripts/check-langchain-sdk-sync.mjs` guards it).
 - **One commit per wave** (majors: one per package) so any regression reverts surgically.
 - **Lockfile changes need `docker compose restart frontend`; source edits hot-reload.** Never restart for source-only changes; never skip the restart after `pnpm add/remove`.
 - **`@types/node` tracks the Docker runtime**, not npm `latest`. Read the major from `frontend/Dockerfile`'s `FROM node:XX-alpine` and stay on `@types/node@^XX`. Document it under "Held back".
@@ -78,7 +78,7 @@ Gate G + restart + a quick browser smoke (page loads, open an existing thread). 
 
 ### 4. Wave: @langchain/react + langgraph-sdk lockstep
 
-Follow the protocol in `frontend/AGENTS.md` exactly: bump `@langchain/react` first, read its pinned SDK version (`pnpm view "@langchain/react@<ver>" dependencies`), then `pnpm --dir frontend add -E @langchain/langgraph-sdk@<that-version>`, then:
+Follow the protocol in `frontend/CLAUDE.md` exactly: bump `@langchain/react` first, read its pinned SDK version (`pnpm view "@langchain/react@<ver>" dependencies`), then `pnpm --dir frontend add -E @langchain/langgraph-sdk@<that-version>`, then:
 
 ```bash
 pnpm --dir frontend run check:sdk-sync   # must print "single copy"
@@ -127,7 +127,7 @@ Push  using `gh` or `git push` (already uses the right SSH identity), open the P
 - **Upgraded:** direct deps with old → new (the wave commits are the ledger).
 - **Removed:** with the verification evidence (zero imports / config-only / dead config).
 - **Held back:** package, available version, and the concrete blocker (peer range, runtime match, failed gate + revert).
-- Surprises that cost time — they're the seed of the next AGENTS.md/skill update.
+- Surprises that cost time — they're the seed of the next CLAUDE.md/skill update.
 
 ## Gotchas
 

--- a/.claude/skills/frontend-design/SKILL.md
+++ b/.claude/skills/frontend-design/SKILL.md
@@ -39,4 +39,4 @@ Interpret creatively and make unexpected choices that feel genuinely designed fo
 
 **IMPORTANT**: Match implementation complexity to the aesthetic vision. Maximalist designs need elaborate code with extensive animations and effects. Minimalist or refined designs need restraint, precision, and careful attention to spacing, typography, and subtle details. Elegance comes from executing the vision well.
 
-Remember: Claude is capable of extraordinary creative work. Don't hold back, show what can truly be created when thinking outside the box and committing fully to a distinctive vision.
+Remember: you are capable of extraordinary creative work. Don't hold back, show what can truly be created when thinking outside the box and committing fully to a distinctive vision.

--- a/.claude/skills/quality/SKILL.md
+++ b/.claude/skills/quality/SKILL.md
@@ -1,9 +1,25 @@
 ---
 name: quality
-description: Run the full quality gate across backend and frontend (pre-commit run --all-files). Use before opening a PR, after a large refactor, or when you want to confirm the whole repo is clean.
+description: Run the repo's quality gate — pre-commit on the files you changed by default, or the full `pre-commit run --all-files` sweep when asked for a full pass, before opening a PR, or after a large refactor. Use when the user asks for quality checks, pre-commit, linting, formatting, type checking, or wants to confirm the whole repo is clean.
 ---
 
-Run the full quality gate from the repo root:
+# Quality
+
+Run validation the way `CLAUDE.md` defines it for this repo. Two modes — pick by scope, not habit.
+
+## Changed-file check (default after edits)
+
+Validate everything you touched once at the end of a task — modified tracked files plus new untracked, non-ignored files — in a single run from the repo root:
+
+```bash
+pre-commit run --files $(git ls-files --modified --others --exclude-standard)
+```
+
+Don't run it after every individual edit; batch. If `pre-commit` isn't on this shell's PATH, it is a backend dev dependency: `backend/.venv/bin/pre-commit run --files ...`.
+
+## Full sweep (`/quality`, "full quality pass")
+
+When invoked explicitly, when asked for a full quality pass, before opening a PR, or after a large refactor:
 
 ```bash
 pre-commit run --all-files
@@ -13,16 +29,26 @@ This executes every configured hook on every tracked file:
 
 - `trailing-whitespace`, `end-of-file-fixer`, `check-yaml`, `check-added-large-files`
 - `gitleaks` (secret scanning)
-- Backend: `ruff check --fix`, `ruff format`, `uv run ty check`
-- Frontend: `eslint --fix`, `prettier --write`, `pnpm --dir frontend type-check`
+- Backend + analytics: `ruff check --fix`, `ruff format`, and `uv run ty check` per project
+- Analytics dbt SQL: `sqlfluff fix` + `sqlfluff lint`
+- Frontend: `eslint --fix`, `prettier --write`, `pnpm --dir frontend type-check`, and `scripts/check-langchain-sdk-sync.mjs` (single installed copy of `@langchain/langgraph-sdk`)
 
-## Workflow
+## Workflow (both modes)
 
-1. From the repo root, run `pre-commit run --all-files`.
-2. If hooks **modify files** (ruff/prettier auto-fix, EOL fixer): re-stage them and re-run until the run is clean.
-3. If hooks **fail with errors** (type errors, lint errors that aren't auto-fixable, secrets detected): report the errors to the user. Do not edit unrelated files in an attempt to make them pass — fix only what's broken.
-4. Report the final status: green (everything passed) or red (list of remaining failures).
+1. Run the command from the repo root.
+2. If hooks **modify files** (ruff/prettier auto-fix, EOL fixer): re-read those files before reporting — the on-disk content differs from what you wrote — then re-stage and re-run until the run is clean.
+3. If hooks **fail with errors** (type errors, lint errors that aren't auto-fixable, secrets detected): report the errors. Do not edit unrelated files to make them pass — fix only what's broken.
+4. Report the final status: green (everything passed) or red (the remaining failures).
 
-## When NOT to use
+## Targeted checks
 
-For files you just edited, prefer the narrower `pre-commit run --files <paths>` — it's much faster and validates exactly what you changed.
+Pre-commit runs linters and type checkers, not tests. Run the relevant suite before the pre-commit step when it gives faster, more relevant feedback:
+
+- Backend unit tests: `cd backend && uv run pytest` (one file: `uv run pytest tests/path/test_file.py`)
+- Backend integration tests: `cd backend && uv run pytest -m integration` (needs the local stack)
+- Frontend tests: `cd frontend && pnpm test`
+- Frontend type check only: `cd frontend && pnpm type-check`; lint + format + type-check together: `pnpm quality`
+
+## Local stack
+
+If integration tests or visual checks need services and `docker ps` shows the stack is not running, remind the user to run `docker compose up -d`. Do not start the stack yourself — they may have stopped it intentionally.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
         env:
           # File-hygiene hooks + gitleaks run in the hygiene pipeline, not here.
           # Keep in sync with hygiene.yml — the two SKIP lists partition the hooks.
-          SKIP: trailing-whitespace,end-of-file-fixer,check-yaml,check-added-large-files,gitleaks
+          SKIP: trailing-whitespace,end-of-file-fixer,check-yaml,check-added-large-files,gitleaks,skill-mirror-sync
         # --project as a flag, NOT env UV_PROJECT: uv 0.12+ propagates the env var into
         # the backend-typecheck hook's nested `uv run`, which cd's into backend/ and
         # would resolve the project as backend/backend.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -102,3 +102,13 @@ repos:
         language: system
         files: ^frontend/(package\.json|pnpm-lock\.yaml)$
         pass_filenames: false
+
+      # Claude Code skills (.claude/skills) and their Codex mirrors (.agents/skills)
+      # must stay byte-identical, or the two agents get conflicting instructions
+      # for the same task. The script explains each mismatch and prints the fix.
+      - id: skill-mirror-sync
+        name: Skill mirror sync (.claude <-> .agents)
+        entry: scripts/check-skill-mirrors.sh
+        language: script
+        files: ^(\.claude|\.agents)/skills/
+        pass_filenames: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,10 @@ Per-feature design docs are an [OKF](https://github.com/GoogleCloudPlatform/know
 2. Open only the PRDs relevant to your task; follow their relative `Extends:`/`Supersedes:` links for lineage.
 3. Never read `docs/prd/viz.html` — the generated human-facing graph (guarded like `.ua/` via a deny rule and `.cursorignore`; for tools without an enforced ignore, this instruction is the guard). Humans view/regenerate it per `docs/prd/README.md`.
 
+## `.claude/skills/` and `.agents/skills/` — mirrored agent skills
+
+Every skill under `.claude/skills/<name>/` (Claude Code) has a byte-identical Codex mirror under `.agents/skills/<name>/`. Edit one copy, then `cp` it over the other; keep the wording agent-neutral (no "Claude"/"Codex" in the body) and reference the `CLAUDE.md` files, which Codex also loads via `project_doc_fallback_filenames`. The `.agents` side may carry Codex-only extras (`agents/openai.yaml`, the `current-docs` skill) that are not mirrored back. The `skill-mirror-sync` pre-commit hook (`scripts/check-skill-mirrors.sh`, also run by the hygiene CI job) fails on any drift and prints the fix.
+
 ## Local development
 
 The local stack runs in Docker via `docker compose up -d`. To find host ports for any running service:

--- a/scripts/check-skill-mirrors.sh
+++ b/scripts/check-skill-mirrors.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Guard: every Claude Code skill under .claude/skills/<name>/ must have a
+# byte-identical Codex mirror under .agents/skills/<name>/.
+#
+# The two trees give two different agents their instructions for the same task;
+# when they drift (PR #50 seeded .agents/ with a mechanical "Claude -> Codex"
+# rewrite that later diverged) the agents receive conflicting guidance. Rule:
+#   - every file under .claude/skills/<name>/ must exist with identical content
+#     under .agents/skills/<name>/ (SKILL.md, LICENSE.txt, ...);
+#   - the .agents side may carry extra Codex-only files (agents/openai.yaml) and
+#     Codex-only skills (current-docs) — those are not mirrored back.
+# Edit the .claude copy, then `cp` it over the .agents copy (or vice versa); the
+# script prints the exact command for each mismatch.
+#
+# Runs in pre-commit (skill-mirror-sync) and the hygiene CI workflow.
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+status=0
+checked=0
+while IFS= read -r -d '' src; do
+  rel="${src#.claude/skills/}"
+  dst=".agents/skills/${rel}"
+  checked=$((checked + 1))
+  if [[ ! -f "$dst" ]]; then
+    echo "✗ missing mirror: $dst"
+    echo "    fix: mkdir -p \"$(dirname "$dst")\" && cp \"$src\" \"$dst\""
+    status=1
+  elif ! cmp -s "$src" "$dst"; then
+    echo "✗ drifted: $src != $dst"
+    echo "    diff: diff \"$src\" \"$dst\""
+    echo "    fix (if .claude is canonical): cp \"$src\" \"$dst\""
+    status=1
+  fi
+done < <(find .claude/skills -type f -print0 | sort -z)
+
+if [[ $status -eq 0 ]]; then
+  echo "✓ $checked skill file(s) mirrored identically between .claude/skills and .agents/skills"
+fi
+exit $status


### PR DESCRIPTION
## What & why

Every skill under `.claude/skills/` has a Codex mirror under `.agents/skills/` (PR #50). The mirrors were produced by a mechanical "Claude → Codex" substitution and then drifted, so four skills gave the two agents different instructions. This PR makes all mirrored skills byte-identical again **and adds a guard so they cannot drift silently a second time.** Two commits:

1. `chore: align .agents skill mirrors with their .claude copies`
2. `chore: add skill-mirror-sync pre-commit hook`

### Alignment

| Skill | Drift | Resolution |
| --- | --- | --- |
| `agent-browser` | compatibility list read "Cursor, Codex, Codex, Continue, …" | restored the full agent list from the `.claude` copy |
| `frontend-design` | "Claude is capable…" vs "Codex is capable…" | agent-neutral "you are capable…" in both |
| `upgrade-frontend-deps` | `.agents` copy pointed at `frontend/AGENTS.md`, which does not exist (Codex reads `CLAUDE.md` via `project_doc_fallback_filenames`) | both reference `frontend/CLAUDE.md` |
| `quality` | `.claude`: "always `pre-commit run --all-files`"; `.agents`: "changed files by default" — a real conflict | one merged skill matching the root `CLAUDE.md`: changed-file check by default, full sweep on explicit `/quality`, before a PR, or after a large refactor; refreshed hook list (analytics, sqlfluff, SDK-sync), re-read-after-autofix rule, targeted test commands, local-stack reminder, `backend/.venv/bin/pre-commit` PATH fallback |

`.agents/skills/current-docs` stays Codex-only by design (Claude has `.claude/rules/context7.md`). `upgrade-backend-deps` was updated on #78 and is identical across trees there.

### Guard

- `scripts/check-skill-mirrors.sh` — every file under `.claude/skills/<name>/` must exist byte-identical under `.agents/skills/<name>/` (SKILL.md, LICENSE.txt, …). Codex-only extras on the `.agents` side (`agents/openai.yaml`, `current-docs`) are allowed. Each drifted or missing mirror is reported with the `diff` and the `cp` command that fixes it.
- `.pre-commit-config.yaml` — local hook `skill-mirror-sync` (`language: script`), fires on any change under either skills tree.
- `.github/workflows/ci.yml` — the hook is added to code-quality's SKIP list; the **hygiene** workflow runs it on every PR (docs-only included), so the two pipelines keep partitioning the hook set as documented in `hygiene.yml`.
- `CLAUDE.md` — new section documenting the mirror rule, the agent-neutral wording, and the hook.

## Type of change

- [ ] 🐛 `fix` — bug fix
- [ ] ✨ `feat` — new feature
- [ ] 📝 `docs` — documentation only
- [ ] ♻️ `refactor` — no behavior change
- [x] 🧹 `chore` / `test` — tooling, deps, tests

## How was it tested?

- `pre-commit run skill-mirror-sync --all-files` on the aligned tree: passes ("7 skill file(s) mirrored identically").
- Simulated drift (appended a line to one `.agents` copy) plus a `.claude` skill without a mirror: the hook fails with both messages and the exact fix commands; reverted, passes again.
- `pre-commit run --files` on the config, the script, `ci.yml` and `CLAUDE.md`: green (`check-yaml` included).
- The hook is not in `hygiene.yml`'s SKIP list, so this PR's own hygiene run exercises it in CI.

## Checklist

- [x] PR is focused on a single logical change (mirror alignment + its guard)
- [x] Added/updated tests for changed behavior — the hook is the test; fail path exercised manually
- [x] Ran the quality gate locally
- [x] Updated docs (`CLAUDE.md`; the skills are the docs)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] No secrets or user uploads (CVs/JDs) committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)