### PR TITLE
fix: stream Claude tool-call args live on Anthropic and Bedrock

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ The agent's behavior is configured by files, not hardcoded — making it easy to
 | **Subagents** | `subagents.yaml` | Specialist delegates → the `task` tool | Always |
 | **Tools** | `tools.py` + DeepAgents built-ins | `parse_document`, `extract_jd`, `render_resume_pdf`, `render_battlecard_pdf`, `list_files`, plus `read/write/edit_file`, `ls/glob/grep`, `delete`, `execute` | — |
 | **Filesystem** | `CompositeBackend` | Routes virtual paths to the right store (see below) | — |
-| **Middleware** | `middleware.py` | `ModelOverrideMiddleware` (runtime LLM swap) + `UtcDatetimeMiddleware` | — |
+| **Middleware** | `middleware.py` | `ModelOverrideMiddleware` (runtime LLM swap; opts Claude tool calls — direct API and Bedrock — into fine-grained arg streaming) + `UtcDatetimeMiddleware` | — |
 
 Subagents only receive the tools they opt into in YAML — tool whitelisting keeps `interview-coach`, for example, from inheriting the main agent's full toolset.
 

--- a/backend/agents/career_agent/middleware.py
+++ b/backend/agents/career_agent/middleware.py
@@ -6,8 +6,11 @@ from typing import Any
 
 from langchain.agents.middleware import AgentMiddleware
 from langchain.chat_models import init_chat_model
+from langchain_anthropic import ChatAnthropic
+from langchain_aws import ChatBedrock, ChatBedrockConverse
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import SystemMessage
+from langchain_core.tools import BaseTool
 from langgraph.config import get_config
 
 logger = logging.getLogger(__name__)
@@ -158,10 +161,120 @@ def _without_streaming(model: BaseChatModel) -> BaseChatModel:
         return model
 
 
+# Claude buffers each tool-input parameter server-side until its value is
+# complete unless the request opts into fine-grained tool streaming, so a large
+# `write_file.content` reached the client as one late chunk — the UI showed
+# `file_path`, then nothing until the whole document landed. Opted in, fragments
+# stream as generated (like OpenAI does by default). Two knobs, one per transport:
+#   - Direct Anthropic API: the per-tool definition field `eager_input_streaming`.
+#   - Bedrock (Converse or legacy InvokeModel): no per-tool field — the tool
+#     schema is AWS-normalized — but the legacy beta flag on the Anthropic-native
+#     request body still turns it on for every tool that leaves the field unset.
+# Gemini's generateContent API has no equivalent: a function call arrives whole.
+_EAGER_INPUT_STREAMING = "eager_input_streaming"
+_FINE_GRAINED_TOOL_STREAMING_BETA = "fine-grained-tool-streaming-2025-05-14"
+
+
+def _with_eager_tool_streaming(tools: list[Any]) -> list[Any] | None:
+    """Return copies of `tools` opted into Anthropic fine-grained tool streaming.
+
+    `langchain_anthropic` lifts `BaseTool.extras["eager_input_streaming"]` onto
+    the wire tool definition (`convert_to_anthropic_tool`), so the flag rides
+    the tool objects handed to `bind_tools`. `model_copy` keeps the agent's
+    shared tool instances provider-neutral (the same objects are bound to
+    OpenAI/Gemini/Bedrock requests, whose converters ignore the key). Dict tools
+    (provider built-ins) and tools that already set the key — an explicit
+    `False` keeps buffered streaming — pass through untouched.
+
+    Returns `None` when no tool needed the flag so the caller skips the override.
+    """
+    changed = False
+    out: list[Any] = []
+    for tool in tools:
+        if not isinstance(tool, BaseTool):
+            out.append(tool)
+            continue
+        extras = tool.extras or {}
+        if _EAGER_INPUT_STREAMING in extras:
+            out.append(tool)
+            continue
+        out.append(tool.model_copy(update={"extras": {**extras, _EAGER_INPUT_STREAMING: True}}))
+        changed = True
+    return out if changed else None
+
+
+def _serves_anthropic(model: ChatBedrockConverse | ChatBedrock) -> bool:
+    """Whether a Bedrock model wrapper fronts a Claude model (mirrors `langchain_aws`).
+
+    Inference-profile ids (`global.anthropic.claude-…`, `us.anthropic.…`) and
+    foundation-model ARNs all carry the `anthropic.` provider segment; an
+    application inference profile hides it, so `provider`/`base_model_id` are
+    consulted too. Unknown → `False`: buffered streaming, never a bad request.
+    """
+    ids = f"{getattr(model, 'base_model_id', None) or ''} {model.model_id}".lower()
+    return (model.provider or "") == "anthropic" or "anthropic" in ids
+
+
+def _with_fine_grained_beta(betas: object) -> list[str] | None:
+    """Append the fine-grained flag to a user-configured `anthropic_beta` list.
+
+    Returns `None` when the flag is already present so callers skip the copy.
+    """
+    existing = [betas] if isinstance(betas, str) else list(betas) if isinstance(betas, list) else []
+    if _FINE_GRAINED_TOOL_STREAMING_BETA in existing:
+        return None
+    return [*existing, _FINE_GRAINED_TOOL_STREAMING_BETA]
+
+
+def _with_bedrock_fine_grained_streaming(
+    model: ChatBedrockConverse | ChatBedrock,
+) -> ChatBedrockConverse | ChatBedrock:
+    """Return a copy of a Bedrock Claude model with fine-grained tool streaming on.
+
+    `anthropic_beta` rides `additional_model_request_fields` on the Converse API
+    and `model_kwargs` (merged into the InvokeModel body) on legacy `ChatBedrock`.
+    Both are passed through verbatim by `langchain_aws`; other keys the user
+    configured (e.g. `reasoningConfig`) are preserved. Returns `model` itself
+    when the flag is already set.
+    """
+    if isinstance(model, ChatBedrockConverse):
+        fields = dict(model.additional_model_request_fields or {})
+        betas = _with_fine_grained_beta(fields.get("anthropic_beta"))
+        if betas is None:
+            return model
+        fields["anthropic_beta"] = betas
+        return model.model_copy(update={"additional_model_request_fields": fields})
+    kwargs = dict(model.model_kwargs or {})
+    betas = _with_fine_grained_beta(kwargs.get("anthropic_beta"))
+    if betas is None:
+        return model
+    kwargs["anthropic_beta"] = betas
+    return model.model_copy(update={"model_kwargs": kwargs})
+
+
+def _fine_grained_tool_streaming_overrides(
+    model: BaseChatModel,
+    tools: list[Any],
+) -> dict[str, Any]:
+    """`ModelRequest.override` kwargs that opt a Claude call into fine-grained streaming.
+
+    Keyed off the model the call will actually use (default or override, main
+    or subagent). Empty for non-Claude providers and when nothing needs changing.
+    """
+    if isinstance(model, ChatAnthropic):
+        tools_ = _with_eager_tool_streaming(tools)
+        return {"tools": tools_} if tools_ is not None else {}
+    if isinstance(model, ChatBedrockConverse | ChatBedrock) and _serves_anthropic(model):
+        model_ = _with_bedrock_fine_grained_streaming(model)
+        return {"model": model_} if model_ is not model else {}
+    return {}
+
+
 class ModelOverrideMiddleware(AgentMiddleware):
     """Shape the request model per main-agent-vs-subagent context.
 
-    Two responsibilities, both keyed off whether the call belongs to a subagent:
+    Three responsibilities; the first two are keyed off whether the call
+    belongs to a subagent, the third off the model the call ends up using:
 
     1. **Model override.** Reads two `RunnableConfig.configurable` keys:
          - `main_agent_model` — applies to the top-level career_agent call.
@@ -177,6 +290,20 @@ class ModelOverrideMiddleware(AgentMiddleware):
        or default model) gets `disable_streaming=True` so parallel subagents
        emitting large tool-call args don't flood the client (see
        `_without_streaming`). The main agent always keeps streaming.
+
+    3. **Fine-grained tool streaming for Claude.** Keyed off the *effective*
+       model (default or override, main or subagent) so large tool-call args
+       (`write_file.content`, `edit_file.new_string`) stream token-by-token in
+       the UI instead of arriving in one late chunk — see
+       `_fine_grained_tool_streaming_overrides`:
+         - `ChatAnthropic` (direct API): the request's tools are swapped for
+           copies carrying `extras["eager_input_streaming"]=True`.
+         - `ChatBedrockConverse` / legacy `ChatBedrock` fronting a Claude model:
+           the model is swapped for a copy whose Anthropic-native request body
+           carries the `fine-grained-tool-streaming-2025-05-14` beta flag.
+       Lives here rather than in its own middleware because it must see the
+       model *after* the override in (1) — the same ordering argument that put
+       (2) here (PRD 16).
 
     Subagent vs. main is differentiated by `metadata.lc_agent_name`, which
     deepagents stamps onto each subagent's runnable (see
@@ -206,13 +333,17 @@ class ModelOverrideMiddleware(AgentMiddleware):
     def _maybe_override(cls, request: Any) -> Any:  # noqa: ANN401
         is_subagent, name, disable_streaming = cls._read_config()
         model = _resolve_model(name) if name else None  # None → keep request's default
+        overrides: dict[str, Any] = {}
         if is_subagent and disable_streaming:
             # Disable streaming on whichever model the subagent ends up using.
             base = model if model is not None else request.model
-            return request.override(model=_without_streaming(base))
-        if model is not None:
-            return request.override(model=model)
-        return request
+            overrides["model"] = _without_streaming(base)
+        elif model is not None:
+            overrides["model"] = model
+        # Provider tweak keyed off the model the call will actually use.
+        effective_model = overrides.get("model", request.model)
+        overrides.update(_fine_grained_tool_streaming_overrides(effective_model, request.tools))
+        return request.override(**overrides) if overrides else request
 
     def wrap_model_call(self, request: Any, handler: Any) -> Any:  # noqa: ANN401
         """Sync entry point."""

--- a/backend/tests/career_agent/test_middleware_model_override.py
+++ b/backend/tests/career_agent/test_middleware_model_override.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
+from pydantic import SecretStr
 
 
 class _FakeModel:
@@ -41,7 +42,7 @@ def _clear_model_cache():
     mw._MODEL_CACHE.clear()  # noqa: SLF001
 
 
-def _fake_request(model=None):
+def _fake_request(model=None, tools=None):
     """Minimal `ModelRequest` stand-in that records `override()` kwargs."""
     captured = {}
 
@@ -49,7 +50,10 @@ def _fake_request(model=None):
         captured.update(kwargs)
         return SimpleNamespace(captured=captured)
 
-    return SimpleNamespace(model=model or _FakeModel(), override=_override), captured
+    return (
+        SimpleNamespace(model=model or _FakeModel(), tools=tools or [], override=_override),
+        captured,
+    )
 
 
 def _fake_handler(received: dict):
@@ -378,3 +382,300 @@ async def test_async_path_also_overrides(middleware):
 
     assert captured["model"] is fake_model
     assert fake_model.disable_streaming is False
+
+
+# --- Anthropic fine-grained tool streaming ---------------------------------------------------
+
+
+def _anthropic_model():
+    from langchain_anthropic import ChatAnthropic
+
+    # Offline: constructing the client never talks to the API.
+    return ChatAnthropic(model="claude-sonnet-5", api_key="test-key")
+
+
+def _write_file_tool():
+    from langchain_core.tools import tool
+
+    @tool
+    def write_file(file_path: str, content: str) -> str:
+        """Write `content` to `file_path`."""
+        return "ok"
+
+    return write_file
+
+
+def _buffered_tool():
+    """A tool that explicitly opted out of fine-grained streaming."""
+    from langchain_core.tools import tool
+
+    @tool(extras={"eager_input_streaming": False})
+    def edit_file(file_path: str, old_string: str, new_string: str) -> str:
+        """Edit a file."""
+        return "ok"
+
+    return edit_file
+
+
+_BUILTIN_TOOL = {"type": "web_search_20260209", "name": "web_search"}
+
+
+def test_anthropic_default_model_opts_tools_into_eager_streaming(middleware):
+    """Tools bound to a `ChatAnthropic` request get `eager_input_streaming` copies."""
+    write_file, buffered = _write_file_tool(), _buffered_tool()
+    request, captured = _fake_request(
+        model=_anthropic_model(),
+        tools=[write_file, _BUILTIN_TOOL, buffered],
+    )
+    received: dict = {}
+
+    config: dict = {"configurable": {}, "metadata": {}}
+    with (
+        patch("backend.agents.career_agent.middleware.get_config", return_value=config),
+        patch("backend.agents.career_agent.middleware.init_chat_model") as mocked_init,
+    ):
+        middleware.wrap_model_call(request, _fake_handler(received))
+
+    mocked_init.assert_not_called()
+    assert set(captured) == {"tools"}  # model untouched, only the tools were swapped
+    flagged, builtin, kept = captured["tools"]
+    assert flagged is not write_file  # a copy…
+    assert flagged.name == "write_file"  # …that the tool node still resolves by name
+    assert flagged.extras == {"eager_input_streaming": True}
+    assert write_file.extras is None  # shared instance stays provider-neutral
+    assert builtin is _BUILTIN_TOOL  # provider built-ins pass through
+    assert kept is buffered  # an explicit opt-out is respected
+    assert kept.extras == {"eager_input_streaming": False}
+
+
+def test_eager_flag_reaches_anthropic_tool_definition(middleware):
+    """Contract tripwire: `langchain_anthropic` must lift the extra onto the wire tool def."""
+    write_file, buffered = _write_file_tool(), _buffered_tool()
+    model = _anthropic_model()
+    request, captured = _fake_request(model=model, tools=[write_file, buffered])
+
+    config: dict = {"configurable": {}, "metadata": {}}
+    with patch("backend.agents.career_agent.middleware.get_config", return_value=config):
+        middleware.wrap_model_call(request, _fake_handler({}))
+
+    wire_tools = model.bind_tools(captured["tools"]).kwargs["tools"]
+    assert wire_tools[0]["name"] == "write_file"
+    assert wire_tools[0]["eager_input_streaming"] is True
+    assert wire_tools[1]["name"] == "edit_file"
+    assert wire_tools[1]["eager_input_streaming"] is False
+    # Without the middleware the flag is absent → the API buffers whole parameters.
+    assert "eager_input_streaming" not in model.bind_tools([write_file]).kwargs["tools"][0]
+
+
+def test_anthropic_override_model_opts_tools_into_eager_streaming(middleware):
+    """The flag keys off the *effective* model — here an Anthropic `main_agent_model` override."""
+    write_file = _write_file_tool()
+    request, captured = _fake_request(tools=[write_file])  # default model is not Anthropic
+    anthropic_model = _anthropic_model()
+
+    config = {"configurable": {"main_agent_model": "anthropic:claude-sonnet-5"}, "metadata": {}}
+    with (
+        patch("backend.agents.career_agent.middleware.get_config", return_value=config),
+        patch(
+            "backend.agents.career_agent.middleware.init_chat_model",
+            return_value=anthropic_model,
+        ),
+    ):
+        middleware.wrap_model_call(request, _fake_handler({}))
+
+    assert captured["model"] is anthropic_model
+    assert captured["tools"][0].extras == {"eager_input_streaming": True}
+    assert write_file.extras is None
+
+
+def test_anthropic_subagent_no_stream_copy_still_gets_eager_flag(middleware, monkeypatch):
+    """With the rollback lever on, the no-stream copy is still recognised as Anthropic."""
+    monkeypatch.setattr(
+        "backend.agents.career_agent.middleware.DISABLE_SUBAGENT_STREAMING",
+        True,
+    )
+    write_file = _write_file_tool()
+    request, captured = _fake_request(model=_anthropic_model(), tools=[write_file])
+
+    config = {"configurable": {}, "metadata": {"lc_agent_name": "resume-tailor"}}
+    with patch("backend.agents.career_agent.middleware.get_config", return_value=config):
+        middleware.wrap_model_call(request, _fake_handler({}))
+
+    assert captured["model"].disable_streaming is True
+    assert captured["tools"][0].extras == {"eager_input_streaming": True}
+
+
+def test_non_anthropic_model_leaves_tools_alone(middleware):
+    """OpenAI/Gemini requests keep the shared tool instances — no copies, no override."""
+    write_file = _write_file_tool()
+    request, captured = _fake_request(tools=[write_file])
+    received: dict = {}
+
+    config: dict = {"configurable": {}, "metadata": {}}
+    with patch("backend.agents.career_agent.middleware.get_config", return_value=config):
+        middleware.wrap_model_call(request, _fake_handler(received))
+
+    assert captured == {}
+    assert received["request"] is request
+    assert write_file.extras is None
+
+
+def test_anthropic_tools_already_flagged_skip_the_override(middleware):
+    """Nothing to change (every tool already chose) → no `tools` override at all."""
+    request, captured = _fake_request(model=_anthropic_model(), tools=[_buffered_tool()])
+    received: dict = {}
+
+    config: dict = {"configurable": {}, "metadata": {}}
+    with patch("backend.agents.career_agent.middleware.get_config", return_value=config):
+        middleware.wrap_model_call(request, _fake_handler(received))
+
+    assert captured == {}
+    assert received["request"] is request
+
+
+# --- Claude on Bedrock: beta flag on the request body -----------------------------------------
+
+_BETA = "fine-grained-tool-streaming-2025-05-14"
+
+
+def _converse_model(model_id="global.anthropic.claude-sonnet-5", **kwargs):
+    from langchain_aws import ChatBedrockConverse
+
+    # Static creds → boto3 builds a client without touching the network.
+    return ChatBedrockConverse(
+        model=model_id,
+        region_name="us-east-1",
+        aws_access_key_id=SecretStr("test"),
+        aws_secret_access_key=SecretStr("test"),
+        **kwargs,
+    )
+
+
+def _legacy_bedrock_model(model_id="global.anthropic.claude-sonnet-5", **kwargs):
+    from langchain_aws import ChatBedrock
+
+    return ChatBedrock(
+        model=model_id,
+        region_name="us-east-1",
+        aws_access_key_id=SecretStr("test"),
+        aws_secret_access_key=SecretStr("test"),
+        **kwargs,
+    )
+
+
+def test_bedrock_converse_claude_gets_fine_grained_beta(middleware):
+    """Converse has no per-tool field: the beta flag rides `additional_model_request_fields`."""
+    write_file = _write_file_tool()
+    model = _converse_model(additional_model_request_fields={"reasoningConfig": {"type": "x"}})
+    request, captured = _fake_request(model=model, tools=[write_file])
+
+    config: dict = {"configurable": {}, "metadata": {}}
+    with patch("backend.agents.career_agent.middleware.get_config", return_value=config):
+        middleware.wrap_model_call(request, _fake_handler({}))
+
+    assert set(captured) == {"model"}  # model swapped, tools untouched
+    flagged = captured["model"]
+    assert flagged is not model  # a copy…
+    assert flagged.additional_model_request_fields == {
+        "reasoningConfig": {"type": "x"},  # …that keeps the user's other request fields
+        "anthropic_beta": [_BETA],
+    }
+    assert model.additional_model_request_fields == {"reasoningConfig": {"type": "x"}}
+    assert write_file.extras is None  # the extras path is a direct-API-only mechanism
+
+
+def test_bedrock_converse_appends_to_existing_betas_once(middleware):
+    model = _converse_model(additional_model_request_fields={"anthropic_beta": ["other-beta"]})
+    request, captured = _fake_request(model=model, tools=[_write_file_tool()])
+
+    config: dict = {"configurable": {}, "metadata": {}}
+    with patch("backend.agents.career_agent.middleware.get_config", return_value=config):
+        middleware.wrap_model_call(request, _fake_handler({}))
+
+    assert captured["model"].additional_model_request_fields["anthropic_beta"] == [
+        "other-beta",
+        _BETA,
+    ]
+
+    # Already flagged → nothing to change, no override at all.
+    flagged = captured["model"]
+    request2, captured2 = _fake_request(model=flagged, tools=[_write_file_tool()])
+    received: dict = {}
+    with patch("backend.agents.career_agent.middleware.get_config", return_value=config):
+        middleware.wrap_model_call(request2, _fake_handler(received))
+    assert captured2 == {}
+    assert received["request"] is request2
+
+
+def test_bedrock_converse_non_claude_model_is_left_alone(middleware):
+    """The flag is Anthropic-specific — a Nova/Llama request must not carry it."""
+    model = _converse_model("amazon.nova-pro-v1:0")
+    request, captured = _fake_request(model=model, tools=[_write_file_tool()])
+    received: dict = {}
+
+    config: dict = {"configurable": {}, "metadata": {}}
+    with patch("backend.agents.career_agent.middleware.get_config", return_value=config):
+        middleware.wrap_model_call(request, _fake_handler(received))
+
+    assert captured == {}
+    assert received["request"] is request
+
+
+def test_legacy_chat_bedrock_claude_gets_fine_grained_beta_in_model_kwargs(middleware):
+    """Legacy InvokeModel path: `model_kwargs` is merged into the Anthropic request body."""
+    model = _legacy_bedrock_model(model_kwargs={"max_tokens": 4096})
+    request, captured = _fake_request(model=model, tools=[_write_file_tool()])
+
+    config: dict = {"configurable": {}, "metadata": {}}
+    with patch("backend.agents.career_agent.middleware.get_config", return_value=config):
+        middleware.wrap_model_call(request, _fake_handler({}))
+
+    flagged = captured["model"]
+    assert flagged is not model
+    # ChatBedrock hoists `max_tokens`/`temperature` out of `model_kwargs` at init, so only
+    # the beta key is added; whatever else was there is preserved.
+    assert flagged.model_kwargs == {**(model.model_kwargs or {}), "anthropic_beta": [_BETA]}
+    assert "anthropic_beta" not in (model.model_kwargs or {})  # shared instance untouched
+
+
+def test_bedrock_override_string_gets_fine_grained_beta(middleware):
+    """`bedrock_converse:…` typed into Settings → the resolved override model is flagged."""
+    request, captured = _fake_request(tools=[_write_file_tool()])
+    bedrock_model = _converse_model()
+
+    config = {
+        "configurable": {"main_agent_model": "bedrock_converse:global.anthropic.claude-sonnet-5"},
+        "metadata": {},
+    }
+    with (
+        patch("backend.agents.career_agent.middleware.get_config", return_value=config),
+        patch(
+            "backend.agents.career_agent.middleware.init_chat_model",
+            return_value=bedrock_model,
+        ),
+    ):
+        middleware.wrap_model_call(request, _fake_handler({}))
+
+    flagged = captured["model"]
+    assert flagged is not bedrock_model
+    assert flagged.additional_model_request_fields["anthropic_beta"] == [_BETA]
+    assert not bedrock_model.additional_model_request_fields  # cached instance untouched
+
+
+def test_bedrock_subagent_no_stream_copy_keeps_both_tweaks(middleware, monkeypatch):
+    """Rollback lever on + Bedrock Claude subagent: one copy carries both changes."""
+    monkeypatch.setattr(
+        "backend.agents.career_agent.middleware.DISABLE_SUBAGENT_STREAMING",
+        True,
+    )
+    model = _converse_model()
+    request, captured = _fake_request(model=model, tools=[_write_file_tool()])
+
+    config = {"configurable": {}, "metadata": {"lc_agent_name": "resume-tailor"}}
+    with patch("backend.agents.career_agent.middleware.get_config", return_value=config):
+        middleware.wrap_model_call(request, _fake_handler({}))
+
+    flagged = captured["model"]
+    assert flagged.disable_streaming is True
+    assert flagged.additional_model_request_fields["anthropic_beta"] == [_BETA]
+    assert model.disable_streaming is False


### PR DESCRIPTION
## What & why

With Claude models, a `write_file` card showed `file_path` and then nothing until the whole `content` landed at the end; with the Azure OpenAI default the same arg streams token-by-token. Root cause is provider behaviour, not the frontend: Claude buffers each tool-input parameter server-side until its value is complete unless the request opts into **fine-grained tool streaming**.

`ModelOverrideMiddleware` now opts the *effective* model (default or Settings override, main agent or subagent) into fine-grained streaming:

- **`ChatAnthropic` (direct API)** — the request's tools are swapped for `model_copy` clones carrying `extras["eager_input_streaming"]=True`, which `langchain-anthropic` lifts onto the wire tool definition (the GA replacement for the old beta header). The agent's shared tool instances stay provider-neutral; dict built-ins and tools with an explicit value pass through untouched.
- **`ChatBedrockConverse` / legacy `ChatBedrock` fronting a Claude model** — the Converse tool schema is AWS-normalised and has no per-tool field (`langchain-aws` drops `extras` and unknown keys), so the model is swapped for a copy carrying the `fine-grained-tool-streaming-2025-05-14` flag in `additional_model_request_fields["anthropic_beta"]` (Converse) / `model_kwargs["anthropic_beta"]` (InvokeModel). Existing betas/fields are preserved; non-Claude Bedrock models are left alone.

It lives in the existing middleware rather than a new one because it must see the model *after* the override is applied (same ordering argument as PRD 16). Gemini is unchanged: `generateContent` returns a function call as one complete part (the SDK's partial-args mode is Vertex-only and `langchain-google-genai` ignores it), so the card can only appear once the model finishes the call.

## Type of change

- [x] 🐛 `fix` — bug fix
- [ ] ✨ `feat` — new feature
- [ ] 📝 `docs` — documentation only
- [ ] ♻️ `refactor` — no behavior change
- [ ] 🧹 `chore` / `test` — tooling, deps, tests

## How was it tested?

- `cd backend && uv run pytest` — 302 passed; 12 new cases in `test_middleware_model_override.py` (copies vs. shared instances, explicit opt-out respected, built-in dict tools untouched, override + rollback-lever interplay, Bedrock beta merge/idempotence, non-Claude Bedrock untouched, and a tripwire that the extra reaches `ChatAnthropic.bind_tools(...).kwargs["tools"]`).
- Direct probes against the APIs with a `write_file`-shaped tool (`claude-sonnet-5` / `global.anthropic.claude-sonnet-5`), time until the `content` key is first seen:

  | Path | before | after |
  | --- | --- | --- |
  | Anthropic direct API | 12.7 s (one burst) | 1.8 s, fragments every ~0.5 s |
  | Bedrock Converse | 12.6 s | 3.4 s |
  | Bedrock legacy InvokeModel | 12.2 s | 2.7 s |

- In-app with a throwaway demo user: Settings → main agent `anthropic:claude-sonnet-5` and then `bedrock_converse:global.anthropic.claude-sonnet-5`; a DOM poller sampling the expanded `write_file` card showed `content` growing from ~300 to ~2500 chars over ~12 s in both cases (previously it appeared only on completion).

## Checklist

- [x] PR is focused on a single logical change
- [x] Added/updated tests for changed behavior (backend: `cd backend && uv run pytest`; frontend: `cd frontend && pnpm test`)
- [x] Ran the quality gate locally (`pre-commit run --all-files`)
- [x] Updated docs (README / `CLAUDE.md` / `docs/prd/`) if behavior changed
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] No secrets or user uploads (CVs/JDs) committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)