### PR TITLE
fix: repair README Mermaid diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ flowchart LR
     CB{{"CompositeBackend<br/>routes virtual paths"}}
     Agent --> CB
     subgraph Shell["Shell default route · SANDBOX_PROVIDER"]
-        SH["`execute` — local: host subprocess,<br/>/virtual/path → on-disk path ·<br/>e2b: remote E2B microVM<br/>(CubeSandbox self-hosted / E2B Cloud)<br/>renders run in a throwaway scratch dir"]
+        SH["execute — local: host subprocess,<br/>/virtual/path → on-disk path ·<br/>e2b: remote E2B microVM<br/>(CubeSandbox self-hosted / E2B Cloud)<br/>renders run in a throwaway scratch dir"]
     end
     subgraph Store["StoreBackend · Postgres + pgvector"]
         ST["/memory/ · /processed/ · /research/<br/>/interview_coach/<br/>/large_tool_results/ · /workspace/"]


### PR DESCRIPTION
## What & why

Remove an invalid inline backtick delimiter from the memory and storage Mermaid chart so GitHub can render the diagram again.

## Type of change

- [x] 🐛 `fix` — bug fix
- [ ] ✨ `feat` — new feature
- [ ] 📝 `docs` — documentation only
- [ ] ♻️ `refactor` — no behavior change
- [ ] 🧹 `chore` / `test` — tooling, deps, tests

## How was it tested?

- `backend/.venv/bin/pre-commit run --all-files`

## Checklist

- [x] PR is focused on a single logical change
- [ ] Added/updated tests for changed behavior (not applicable: Mermaid documentation syntax only)
- [x] Ran the quality gate locally (`pre-commit run --all-files`)
- [x] Updated docs (README / `CLAUDE.md` / `docs/prd/`) if behavior changed
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] No secrets or user uploads (CVs/JDs) committed

Made with [Cursor](https://cursor.com)