### PR TITLE
docs: refresh README architecture and layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ docker ps                     # read the 0.0.0.0:<host>->... mappings
 
 **Object storage.** Binary artifacts (uploads + rendered PDFs) live in S3-compatible object storage. Locally that's the compose `object-store` service (SeaweedFS) and the presets work as-is: S3 API on `OBJECT_STORE_LOCAL_PORT`, a browsable bucket UI on `OBJECT_STORE_UI_LOCAL_PORT`, and placeholder credentials that the local emulator accepts but doesn't enforce. For the cloud, point `OBJECT_STORE_ENDPOINT` / `OBJECT_STORE_BUCKET` / credentials at a managed bucket — AWS S3, GCS, Azure, or any S3-compatible store — with no code changes. Note: the `AWS_*` variables are reserved for Bedrock models; the object store reads only `OBJECT_STORE_*`.
 
-**Analytics.** A self-contained analytics stack ([`docs/ideas/analytics-platform-plan.html`](docs/ideas/analytics-platform-plan.html) Phase 0) rides the same compose file: dlt extracts the operational Postgres into a ClickHouse warehouse (structure and metrics only — chat/CV text never lands there), dbt models it into star-schema marts, Cube serves the metric definitions, and Superset ships a seeded **NextRole Overview** dashboard (users, threads & runs, reliability, tokens + estimated cost), all orchestrated by Dagster on an hourly schedule. Fill the three `generate:` secrets in the analytics block of `.env`, then after first boot trigger the initial pipeline run once — `docker compose exec dagster-daemon dagster asset materialize --select "*" -m nextrole_analytics.definitions` (or "Materialize all" in the Dagster UI on `DAGSTER_LOCAL_PORT`) — and log into Superset on `SUPERSET_LOCAL_PORT` with `SUPERSET_ADMIN_USERNAME`/`SUPERSET_ADMIN_PASSWORD`. Cube's Playground is on `CUBE_LOCAL_PORT`, the generated dbt docs site (model/column catalog + lineage) on `DBT_DOCS_LOCAL_PORT`, ClickHouse's query UI on `CLICKHOUSE_HTTP_LOCAL_PORT``/play`. Budget ~2–4 GB extra RAM; overview and screenshots in [`analytics/README.md`](analytics/README.md), developer guide in [`analytics/CLAUDE.md`](analytics/CLAUDE.md). Product analytics (PostHog) and LLM-trace storage (Langfuse) are deliberate follow-ups per the blueprint.
+**Analytics.** A self-contained analytics stack ([`docs/ideas/analytics-platform-plan.html`](docs/ideas/analytics-platform-plan.html) Phase 0) rides the same compose file: dlt extracts the operational Postgres into a ClickHouse warehouse (structure and metrics only — chat/CV text never lands there), dbt models it into star-schema marts, Cube serves the metric definitions, and Superset ships a seeded **NextRole Overview** dashboard (users, threads & runs, reliability, tokens + estimated cost), all orchestrated by Dagster on an hourly schedule. Fill the three `generate:` secrets in the analytics block of `.env`, then after first boot trigger the initial pipeline run once — `docker compose exec dagster-daemon dagster asset materialize --select "*" -m nextrole_analytics.definitions` (or "Materialize all" in the Dagster UI on `DAGSTER_LOCAL_PORT`) — and log into Superset on `SUPERSET_LOCAL_PORT` with `SUPERSET_ADMIN_USERNAME`/`SUPERSET_ADMIN_PASSWORD`. Cube's Playground is on `CUBE_LOCAL_PORT`, the generated dbt docs site (model/column catalog + lineage) on `DBT_DOCS_LOCAL_PORT`, ClickHouse's query UI on `http://localhost:<CLICKHOUSE_HTTP_LOCAL_PORT>/play`. Budget ~2–4 GB extra RAM; overview and screenshots in [`analytics/README.md`](analytics/README.md), developer guide in [`analytics/CLAUDE.md`](analytics/CLAUDE.md). Product analytics (PostHog) and LLM-trace storage (Langfuse) are deliberate follow-ups per the blueprint.
 
 **Analytics agent.** A second agent, picked from the agent switcher in the top bar, answers questions about the product itself — activity, reliability, LLM cost, agent behaviour — by querying the warehouse above and drawing the answer. It reads the marts' own documentation (dbt descriptions, Cube metric definitions, ClickHouse schema) before writing SQL, and charts persist with the conversation, so reopening a thread months later still shows them. It connects as a dedicated ClickHouse user with SELECT on the marts and staging databases only, under a settings profile whose limits it cannot raise — generate `CLICKHOUSE_AGENT_PASSWORD` alongside the other analytics secrets. Because it reads every user's activity, access is an explicit allowlist: with auth on, list the user ids or emails allowed to run it in `ANALYTICS_AGENT_ALLOWED_USERS` (empty denies everyone; single-user deployments are unaffected). Details in [`backend/agents/analytics_agent/README.md`](backend/agents/analytics_agent/README.md).
 
@@ -145,7 +145,7 @@ Output quality tracks the model you pick — smaller local models trade some qua
 - **Code edits** hot-reload in both containers — just save the file.
 - **Add a frontend dep:** `pnpm --dir frontend add <pkg>` → `docker compose restart frontend`
 - **Add a backend dep:** `uv add <pkg>` → `docker compose up -d --build backend`
-- **Change `.env`:** `docker compose restart <service>`
+- **Change `.env`:** `docker compose up -d <service>` (recreates the container with the new values)
 - **Stop:** `docker compose down` (add `-v` to wipe the DB, Redis, object-storage, warehouse, Dagster & Superset volumes)
 
 </details>
@@ -158,7 +158,7 @@ NextRole is a **supervisor agent orchestrating three specialist subagents** on L
 
 ## How It Works
 
-A five-stage pipeline. Stage 4 runs the resume tailor and interview coach **in parallel**; Stage 6 routes follow-up edits to whichever agent owns the target file.
+A five-stage generation pipeline. Stage 4 runs the resume tailor and interview coach **in parallel**; after generation, Stage 6 routes follow-up edits to whichever agent owns the target file.
 
 ![How NextRole works](docs/images/next-role-how-it-works.png)
 
@@ -302,7 +302,7 @@ NextRole runs **zero-login single-user by default** — `docker compose up` and 
 | **Agent I/O** | Tavily (web search) · LlamaParse / LlamaCloud (document parsing) · `rendercv` (resume → PDF) · WeasyPrint (battlecard → PDF) |
 | **Frontend** | Next.js 16 · React 19 · TypeScript · Tailwind · `pnpm` · `@langchain/react` (v2 `useStream`) |
 | **Data** | PostgreSQL 18 + pgvector · Redis 8 · S3-compatible object storage (SeaweedFS locally; S3 / GCS / Azure in the cloud) |
-| **Infra** | Docker Compose (frontend · backend · core-server · postgres · redis · object-store) |
+| **Infra** | Docker Compose (app services · PostgreSQL · Redis · object storage · ClickHouse · Dagster · dbt docs · Cube · Superset) |
 | **Observability** | LangSmith |
 
 </details>
@@ -380,7 +380,7 @@ The same treatment exists for the product's *design history*: every feature ship
 
 ## Contributing
 
-PRs and issues are welcome! Start with **[`CONTRIBUTING.md`](CONTRIBUTING.md)** — it walks through the fork → PR workflow, local setup, the CI quality gate (code quality + backend tests + frontend tests), testing, and conventions. Stack-specific details live in [`backend/CLAUDE.md`](backend/CLAUDE.md) and [`frontend/CLAUDE.md`](frontend/CLAUDE.md); commits follow [Conventional Commits](https://www.conventionalcommits.org/).
+PRs and issues are welcome! Start with **[`CONTRIBUTING.md`](CONTRIBUTING.md)** — it walks through the fork → PR workflow, local setup, the CI quality gate (code quality + backend tests + frontend tests), testing, and conventions. Stack-specific details live in [`backend/CLAUDE.md`](backend/CLAUDE.md), [`frontend/CLAUDE.md`](frontend/CLAUDE.md), and [`analytics/CLAUDE.md`](analytics/CLAUDE.md); commits follow [Conventional Commits](https://www.conventionalcommits.org/).
 
 New here? Issues labelled [`good first issue`](https://github.com/tam159/next-role/labels/good%20first%20issue) are a gentle place to start, and questions are welcome in [Discussions](https://github.com/tam159/next-role/discussions).
 

--- a/analytics/README.md
+++ b/analytics/README.md
@@ -8,11 +8,10 @@
 ![Superset](https://img.shields.io/badge/Superset-BI-20A7C9?logo=apachesuperset&logoColor=white)
 
 The analytics platform behind NextRole: it turns the career agent's operational data (users,
-conversations, agent runs, tool calls, tokens) into governed metrics and dashboards, and lays the
-metadata foundation for an analytics agent that will answer questions about the product in natural
-language. It is Phase 0 of the [analytics platform blueprint](../docs/ideas/analytics-platform-plan.html):
-one open-source stack, the same containers from laptop to production, chosen so nothing has to be
-migrated later.
+conversations, agent runs, tool calls, tokens) into governed metrics and dashboards, and powers an
+analytics agent that answers questions about the product in natural language. It is Phase 0 of the
+[analytics platform blueprint](../docs/ideas/analytics-platform-plan.html): one open-source stack,
+the same containers from laptop to production, chosen so nothing has to be migrated later.
 
 > This page is the overview for people and AI assistants. The working guide — tooling, layout,
 > dev loop, warehouse gotchas — is [`CLAUDE.md`](CLAUDE.md).
@@ -42,7 +41,7 @@ Five principles from the blueprint shape every layer:
    the warehouse, so the app's JSON can evolve without breaking extractors.
 2. **One stack you operate.** ClickHouse, Dagster, dbt, Cube and Superset are the stack from the
    first commit — dev and prod differ by hardware, not dialect.
-3. **The warehouse is the source of truth**; BI and (later) the agent are lenses over the same marts.
+3. **The warehouse is the source of truth**; BI and the agent are lenses over the same marts.
 4. **Governance rides the pipeline.** Descriptions, PII tags, tests and lineage are emitted by dbt
    and Dagster, not documented by hand.
 5. **Structure and metrics, never document bodies.** See [Privacy by construction](#privacy-by-construction).
@@ -71,7 +70,7 @@ LLM can consume directly.
 
 Cube owns the *metrics*: measures, dimensions, joins and curated views over the gold marts, each with
 a description plus `meta` hints (synonyms, units, formulas, example questions, caveats). This is the
-vocabulary the future analytics agent reads through `/cubejs-api/v1/meta`, and the same definitions
+vocabulary the analytics agent reads through `/cubejs-api/v1/meta`, and the same definitions
 serve BI through a Postgres-wire SQL API — so a number means the same thing everywhere.
 
 <img alt="Cube Core data-model view of cubes/runs.yml with descriptions, meta hints, joins and dimensions" src="../docs/images/analytics-cube-core.png" width="100%">
@@ -130,7 +129,7 @@ keeps it fresh from there. Host ports come from `.env`:
 | dbt docs | `http://localhost:<DBT_DOCS_LOCAL_PORT>/` | The data dictionary and column-level lineage |
 | ClickHouse | `http://localhost:<CLICKHOUSE_HTTP_LOCAL_PORT>/play` | Ad-hoc SQL against bronze, staging and marts |
 
-Budget roughly 2–4 GB of RAM for the six long-running containers. Editing the pipeline, refreshing
+Budget roughly 2–4 GB of RAM for the seven long-running containers. Editing the pipeline, refreshing
 docs, and the warehouse's quirks are covered in [`CLAUDE.md`](CLAUDE.md).
 
 ## Metadata for the analytics agent

--- a/backend/README.md
+++ b/backend/README.md
@@ -14,8 +14,11 @@ extra code. See [`ARCHITECTURE.md`](ARCHITECTURE.md) for the full design.
 
 ```
 backend/
-├── agents/                  # First-party agents (full strict lint/type gates)
-│   └── career_agent/        #   the career agent: graph, tools, prompts, skills
+├── agents/                  # First-party agents and their shared HTTP/auth modules
+│   ├── career_agent/        #   career workflow: graph, tools, prompts, skills
+│   ├── analytics_agent/     #   warehouse analysis and persistent charts
+│   ├── auth.py              #   optional multi-user authentication/authorization
+│   └── files_api.py         #   allowlisted /files/* API over object storage
 ├── server/                  # The agent server platform
 │   ├── api/                 #   ASGI app — routes, auth, streaming, graph
 │   │                        #   loading, run workers, gRPC client
@@ -26,10 +29,13 @@ backend/
 │   ├── core_server/         #   gRPC data plane (python -m server.core_server)
 │   ├── openapi.json         #   Served API spec — must sit next to api/
 │   └── logging.json         #   Uvicorn log config
-├── storage/migrations/      # Consolidated SQL schema (000001_init), applied at boot
-├── tests/                   # Unit tests (mirror agents/) + server smoke tests
+├── storage/migrations/      # Consolidated schema (000001_init.up.sql), applied at boot
+├── tests/                   # Agent/auth/files tests plus server integration smoke tests
+├── ARCHITECTURE.md          # Agent-server topology and maintenance guide
+├── init.sql                 # Enables pgvector when Postgres is first initialized
 ├── Dockerfile               # One image for both services (python:3.13-slim + uv)
-└── pyproject.toml           # Single uv project: agent + server dependencies
+├── pyproject.toml           # Single uv project: agent + server dependencies
+└── uv.lock                  # Reproducible Python dependency lock
 ```
 
 Everything under `server/` runs under deliberately relaxed lint/type gates; `agents/` and
@@ -41,7 +47,7 @@ Everything under `server/` runs under deliberately relaxed lint/type gates; `age
 The whole stack runs from the repo root:
 
 ```bash
-docker compose up -d          # frontend · backend · core-server · postgres · redis
+docker compose up -d          # app, data, object-storage, and analytics services
 ```
 
 - API: `http://localhost:${LANGGRAPH_LOCAL_PORT}` — health at `/ok`, docs at `/docs`

--- a/backend/agents/analytics_agent/README.md
+++ b/backend/agents/analytics_agent/README.md
@@ -76,14 +76,17 @@ agents/analytics_agent/
 ├── access.py              the admin allowlist
 ├── middleware.py          the gate that ends a run before the model sees it
 └── skills/analytics-agent/
-    ├── warehouse-analysis/  discovery loop, query safety, dialect + recipes
-    └── charts/              chart selection, dashboards, the Python fallback
+    ├── warehouse-analysis/
+    │   ├── SKILL.md          discovery loop and query safety
+    │   └── references/       ClickHouse dialect and question recipes
+    └── charts/
+        └── SKILL.md          chart selection, dashboards, the Python fallback
 ```
 
 Shared plumbing is imported from `career_agent/` rather than duplicated: the model override and
-UTC-date middleware, the shell backend factory, the execute-approval policy, and the
-object-storage key builders. Only `career_agent/agents.py` builds a graph at import, and nothing
-here imports it.
+UTC-date middleware, shell backend factory, execute-approval policy, object backend, scoping, and
+object-key mapping. Only `career_agent/agents.py` builds a graph at import, and nothing here
+imports it.
 
 ## Tools
 

--- a/backend/agents/career_agent/README.md
+++ b/backend/agents/career_agent/README.md
@@ -8,11 +8,14 @@
 
 ## How It Works
 
-The agent is configured by files:
+The agent is configured and assembled by files:
 
 ```
 career_agent/
-├── CAREER_AGENT.md   # Per-stage procedure (loaded as memory)
+├── agents.py                    # Graph assembly and CompositeBackend routes
+├── CAREER_AGENT.md              # Per-stage procedure (loaded as memory)
+├── prompts.py                   # Main-agent and middleware prompts
+├── middleware.py                # Model override, UTC date, and preference loading
 ├── subagents.yaml               # Subagent definitions (hiring-recon, resume-tailor, interview-coach)
 ├── skills/                      # Per-consumer skill grouping (one source path per agent)
 │   ├── career-agent/            # main agent
@@ -27,7 +30,15 @@ career_agent/
 │   └── interview-coach/         # interview-coach subagent
 │       └── interview-coach/
 │           └── SKILL.md
-├── tools.py                     # Tools for the agents and subagents
+├── tools.py                     # Parsing, extraction, and document rendering tools
+├── object_backend.py            # ObjectStoreBackend for binary artifact routes
+├── object_storage.py            # Virtual-path ↔ object-key mapping and area registry
+├── scope.py                     # Per-user KV namespaces and object scopes
+├── sandbox_backend.py           # Local/E2B backend selection
+├── shell_backend.py             # Host subprocess backend
+├── execute_approval.py          # Human-in-the-loop policy for shell commands
+├── render_scratch.py            # Throwaway host or sandbox render directories
+├── templates/battlecard/        # WeasyPrint HTML, CSS, and fonts
 └── utils.py                     # Utilities
 ```
 
@@ -112,22 +123,26 @@ Both surfaces POST `multipart/form-data` to the backend files API
 (`/files/upload`, served by `backend/agents/files_api.py` via the agent
 server's `LANGGRAPH_HTTP` custom-app hook), which validates the extension,
 size, and path prefix, then stores the bytes in the object store at
-`users/default/career_agent/upload/<filename>`. The agent's
+`users/<scope>/career_agent/upload/<filename>` (`<scope>` is the authenticated user id, or
+`default` in single-user mode). The agent's
 `ObjectStoreBackend` route (`/upload/`) sees the file on its next tool call.
 
-Re-uploading the same filename overwrites. Scoping is global per the layout above
-(no per-thread subdirectories).
+Re-uploading the same filename overwrites within that user's scope. Files are per-user but not
+per-thread.
 
-## File Structure
+## Virtual File Structure
 
 ```
 /upload/                                                      # ObjectStoreBackend
-└── Senior AI Engineer - Tam NGUYEN.pdf                       # Uploaded resume
+├── Senior AI Engineer - Tam NGUYEN.pdf                       # Uploaded resume
 └── AWS AI Solution Engineer.pdf                              # Uploaded JD
 
+/memory/                                                      # StoreBackend
+└── preferences.md                                            # Standing user preferences
+
 /processed/                                                   # StoreBackend
-└── tam-nguyen-senior-ai-engineer-resume.md                   # Processed resume
-└── aws-ai-solution-engineer-jd.md                            # Processed JD
+├── tam-nguyen-senior-ai-engineer-resume.md                   # Processed resume
+├── aws-ai-solution-engineer-jd.md                            # Processed JD
 └── tam-nguyen-senior-ai-engineer-resume-aws-ai-solution-engineer-jd-intake.md  # Intake (per resume×JD pair)
 
 /research/                                                    # StoreBackend
@@ -148,6 +163,10 @@ Re-uploading the same filename overwrites. Scoping is global per the layout abov
 └── tam-nguyen-senior-ai-engineer-resume/
     ├── aws-ai-solution-engineer-jd.json                      # weasyprint source (LLM-written, user-editable)
     └── aws-ai-solution-engineer-jd.pdf                       # weasyprint-rendered day-of cheat sheet
+
+/workspace/                                                   # StoreBackend — ad-hoc working files
+
+/large_tool_results/                                          # StoreBackend — deepagents result offload
 ```
 
-Note: both the tailored resume and the interview battlecard follow the same source-then-render pattern. Tailored resumes use `rendercv` (YAML → `.typ` intermediate → `.pdf`, via the one-shot `render_resume_pdf` tool, which hydrates a scratch copy, renders, and publishes — the throwaway scratch dir lives on the host in `local` sandbox mode and inside the sandbox in `e2b` mode; see `render_scratch.py`). Battlecards use `weasyprint` (JSON → `.pdf`, via `render_battlecard_pdf`). The JSON / YAML side is the user-editable source of truth; the PDF is regenerated on demand. `/upload/`, `/tailored_resume/`, and `/interview_battlecard/` live in S3-compatible object storage (SeaweedFS locally; S3/GCS/Azure in the cloud) under deterministic keys — `users/default/career_agent/<area>/<relpath>` — so binary PDFs live neither on shared disk nor in Postgres.
+Note: both the tailored resume and the interview battlecard follow the same source-then-render pattern. Tailored resumes use `rendercv` (YAML → `.typ` intermediate → `.pdf`, via the one-shot `render_resume_pdf` tool, which hydrates a scratch copy, renders, and publishes — the throwaway scratch dir lives on the host in `local` sandbox mode and inside the sandbox in `e2b` mode; see `render_scratch.py`). Battlecards use `weasyprint` (JSON → `.pdf`, via `render_battlecard_pdf`). The JSON / YAML side is the user-editable source of truth; the PDF is regenerated on demand. `/upload/`, `/tailored_resume/`, and `/interview_battlecard/` live in S3-compatible object storage (SeaweedFS locally; S3/GCS/Azure in the cloud) under deterministic keys — `users/<scope>/career_agent/<area>/<relpath>` — so binary PDFs live neither on shared disk nor in Postgres.

--- a/backend/server/core_server/README.md
+++ b/backend/server/core_server/README.md
@@ -1,67 +1,79 @@
 # core_server — Python reconstruction of `core-api-grpc`
 
-A Python (grpc.aio + psycopg + redis) reimplementation of the Go data-plane
-server, serving the 7 data-plane gRPC services + gRPC health on **:50052**.
+The Python gRPC data plane for NextRole's agent server, built with `grpc.aio`, psycopg, and Redis.
+It owns assistant, thread, run, cron, store, and queue operations and serves seven data-plane
+services plus gRPC health on port `50052`.
 
-The contract comes from the extracted protos / shipped stubs
-(`grpc_common/proto/*_pb2*`). The DB schema is the one the Go server
-created (tables `assistant`, `thread`, `run`, `cron`, `checkpoints`,
-`checkpoint_blobs`, `checkpoint_writes`, `store`, `thread_ttl`).
+The contract comes from the generated stubs in [`server/grpc_common/proto/`](../grpc_common/proto/).
+The implementation is 100% native; the original Go binary is retired. A compatibility forwarding
+hook remains for development, but compose sets `CORE_SERVER_GO_FALLBACK=""`, so every production
+path runs in Python.
 
-## How it runs incrementally
+## Layout
 
-Any RPC **not yet implemented natively** is transparently forwarded to the
-original Go server (`CORE_SERVER_GO_FALLBACK`, default `localhost:50051`), so the
-whole system works end-to-end from day one and each method can be replaced and
-A/B-checked against the Go reference. Set `CORE_SERVER_GO_FALLBACK=""` to run
-fully native (no Go dependency).
+```
+server/core_server/
+├── __main__.py            # gRPC server entrypoint and service registration
+├── settings.py            # Postgres, Redis, bind, pool, and fallback settings
+├── db.py                  # psycopg pool and SQL helpers
+├── redis_db.py            # run queue doorbell and stream pub/sub
+├── _filters.py            # authorization filters translated to parameterized SQL
+├── _convert.py            # protobuf ↔ Python conversion
+├── _forward.py            # optional compatibility forwarding
+└── servicers/
+    ├── assistants.py
+    ├── threads.py
+    ├── runs.py
+    ├── crons.py
+    ├── cache.py
+    ├── admin.py
+    └── checkpointer.py
+```
 
 ## Status
 
-| Service       | Status            |
-|---------------|-------------------|
-| Assistants    | ✅ native (8/8)   |
-| Threads       | ✅ native (11/11) |
-| Crons         | ✅ native (8/8)   |
-| Cache         | ✅ native (2/2, Redis) |
-| Admin         | ✅ native (1/1)   |
-| Checkpointer  | ✅ native (9/9) — mgmt (Delete/Copy/Prune/Caps) via SQL; data methods (Put/GetTuple/List/PutWrites) are MongoDB-only and raise UNIMPLEMENTED. **Postgres persists checkpoints in-process (direct-PG), bypassing this service entirely.** |
-| Runs          | ✅ native (15/15) — CRUD + Create + Next queue (SKIP LOCKED + Redis BLPOP) + Stream/Enter/Publish/MarkDone/Cancel over Redis |
-| Health        | ✅ native         |
+All services are native: Assistants (8/8), Threads (11/11), Crons (8/8), Cache (2/2, Redis),
+Admin (1/1), Checkpointer (9/9), Runs (15/15), and gRPC health. Runs combine SQL queue claiming
+(`SKIP LOCKED`) with Redis doorbells and pub/sub.
 
-**100% native — the Go binary is fully retired.** With `CORE_SERVER_GO_FALLBACK=""` every service reports `forwarded=0`. react_agent runs end-to-end (`/runs/wait` + `/runs/stream`, run `success`, checkpoints persisted) against the Python data plane — verified both as a local process and as the containerized `core-server` compose service, with no Go container running.
+Checkpointer management methods use SQL; MongoDB-only data methods raise `UNIMPLEMENTED`.
+Postgres checkpoint persistence runs in-process and bypasses this service.
 
-## Run (local dev — recommended)
+Both registered graphs (`career_agent` and `analytics_agent`) run through this data plane. Graph
+loading remains in the HTTP backend; core-server receives their ids through `LANGSERVE_GRAPHS` for
+assistant scoping.
 
-Postgres + Redis stay in Docker (`docker compose up -d postgres redis`); the Go
-container stays up only as the fallback while services are being ported.
+## Run
+
+The supported development path is the root compose stack:
 
 ```bash
-# 1) start the data-plane server (reads .env for PG/Redis)
-PYTHONPATH=. python3 -m core_server         # listens on :50052
-
-# 2) start the API against it (config default already points at :50052)
-export LANGSERVE_GRAPHS='{"react_agent": "api/react_agent/graph.py:graph"}'
-export DATABASE_URI="postgresql://langgraph_clone:langgraph_clone@localhost:5406/langgraph_clone?sslmode=disable"
-uvicorn api.server:app --log-config logging.json --host 0.0.0.0 --port 8005 --no-access-log --reload
+docker compose up -d
 ```
 
-Env knobs: `CORE_SERVER_BIND` (default `0.0.0.0:50052`), `CORE_SERVER_GO_FALLBACK`
-(default `localhost:50051`, set `""` for fully native), `CORE_SERVER_POSTGRES_URI`,
-`CORE_SERVER_REDIS_URI`.
-
-## Deploy (containerized — replaces the Go sidecar)
-
-`core_server/Dockerfile` builds the server, and the `core-server` service in
-`docker-compose.yml` runs it on :50052 (Go fallback off), connecting to
-`postgres:5432` / `redis:6379` over the compose network. The original Go
-`core-api-grpc` service is commented out / superseded.
+The `core-server` service uses the same `backend/Dockerfile` image as the HTTP backend, with a
+different command:
 
 ```bash
-docker compose up -d --build core-server   # brings up postgres + redis + core-server
-
-# API stays local, pointed at the container (config default :50052):
-export LANGSERVE_GRAPHS='{"react_agent": "api/react_agent/graph.py:graph"}'
-export DATABASE_URI="postgresql://langgraph_clone:langgraph_clone@localhost:5406/langgraph_clone?sslmode=disable"
-uvicorn api.server:app --log-config logging.json --host 0.0.0.0 --port 8005 --no-access-log --reload
+python -m server.core_server
 ```
+
+It connects to `postgres:5432` and `redis:6379` over the compose network and is internal-only.
+Source changes under `server/core_server/` or `server/grpc_common/` require:
+
+```bash
+docker compose restart core-server
+```
+
+To run it directly, start Postgres and Redis, then invoke the module from `backend/` with
+`CORE_SERVER_POSTGRES_URI` and `CORE_SERVER_REDIS_URI` pointing at their host ports.
+
+## Configuration
+
+- `CORE_SERVER_BIND` — listen address; defaults to `0.0.0.0:50052`.
+- `CORE_SERVER_POSTGRES_URI` — psycopg connection URI.
+- `CORE_SERVER_REDIS_URI` — Redis connection URI.
+- `CORE_SERVER_GO_FALLBACK` — optional compatibility endpoint; set to an empty string for the
+  fully native mode used by compose.
+- `CORE_SERVER_POOL_MIN` / `CORE_SERVER_POOL_MAX` — database pool bounds.
+- `CORE_SERVER_MAX_MSG_BYTES` — maximum gRPC message size.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -6,7 +6,7 @@ The chat + live-workspace UI for NextRole's multi-agent backend: **Next.js 16 (A
 
 ## What it does
 
-- 💬 **Streaming chat** with the career agent — token streaming, tool-call boxes with live arg previews, and nested **subagent activity cards** (`ChatInterface`, `ToolCallBox`, `SubagentCard`).
+- 💬 **Streaming chat** with the career and analytics agents — token streaming, tool-call boxes with live arg previews, and nested **subagent activity cards** (`ChatInterface`, `ToolCallBox`, `SubagentCard`).
 - 🗂️ **Live workspace** beside the chat — the agent's plan (todos), produced artifacts, and research sources update as the run progresses (`Workspace`, `workspace/*`, `TasksFilesSidebar`).
 - ✋ **Human-in-the-loop approvals** — when the agent pauses on a protected tool call, approve / edit / reject inline (`ToolApprovalInterrupt`).
 - 📄 **File preview & editing** — markdown, code, images, and `.docx` (via `mammoth`) in a dialog with edit-and-save, plus a dedicated **print-to-PDF** route (`FileViewDialog`, `/print/file`).
@@ -22,13 +22,18 @@ flowchart LR
     UI["React components"] --> Chat["useChat · ChatProvider"]
     Chat -->|"useStream (@langchain/react)"| LG["LangGraph agent server"]
     Chat -->|"Client: threads / store APIs"| LG
-    UI --> Files["/api/files/* route handlers"]
-    Files -->|"allowlisted fs access"| Disk["repo disk artifacts<br/>(upload · tailored_resume · interview_battlecard)"]
+    UI --> Files["agentFiles · uploadFiles"]
+    Files -->|"authenticated /files/* requests"| LG
+    LG -->|"allowlisted object access"| Obj["S3-compatible object storage<br/>(uploads · rendered files · charts)"]
 ```
 
 - **Streaming**: `useChat` (`src/app/hooks/useChat.ts`) wraps `@langchain/react`'s `useStream` v2 runtime — messages, values, interrupts, and per-subagent channels — and exposes it app-wide through `ChatProvider`.
 - **Data**: the LangGraph SDK `Client` (created once in `ClientProvider`) serves thread history (`useThreads` + SWR) and the Postgres-backed store files; text artifacts live there.
-- **Disk artifacts** (binary uploads, rendered PDFs) are read/written through the app's own `/api/files/{list,read,write,upload,delete}` route handlers, which resolve paths against a strict allowlist (`src/app/api/files/_lib.ts`) — path traversal is rejected server-side.
+- **Artifact files** (uploads, rendered PDFs, and analytics charts) use the backend's
+  `/files/{list,read,write,upload,delete}` API through `src/app/lib/agentFiles.ts` and
+  `uploadFiles.ts`. The server validates virtual paths in
+  [`backend/agents/files_api.py`](../backend/agents/files_api.py) and stores bytes in S3-compatible
+  object storage; file bytes never pass through a Next.js route.
 - Agent-file routing (which store a given virtual path belongs to) is configured in `src/app/config/agentFiles.ts`.
 
 ## Layout
@@ -37,15 +42,19 @@ flowchart LR
 src/
 ├── app/
 │   ├── page.tsx              # Two resizable panels (chat + workspace), threads drawer, config gate
-│   ├── api/files/            # Disk-artifact route handlers + allowlist (_lib.ts)
+│   ├── login/                # Better Auth sign-in page (optional multi-user mode)
+│   ├── api/auth/             # Better Auth handler; disabled in the default single-user mode
 │   ├── print/file/           # Standalone print-to-PDF page (reads a sessionStorage payload)
-│   ├── components/           # Chat, workspace, dialogs (tests colocated as *.test.tsx)
-│   ├── hooks/                # useChat (streaming + file CRUD), useThreads (SWR pagination)
-│   ├── lib/ · utils/         # File categories/sources, upload client, parsers, remark plugin
-│   └── config/               # Agent file-source routing table
+│   ├── components/           # Chat, workspace, auth, charts, dialogs; tests are colocated
+│   ├── hooks/                # Streaming, threads, file uploads, approvals, responsive UI
+│   ├── lib/ · utils/         # File clients/categories, charts, parsers, markdown transforms
+│   └── config/               # Agent registry and per-agent file routing
 ├── providers/                # Client, Chat, FilePreview, Accent, Theme
 ├── components/ui/            # shadcn/Radix primitives
-└── lib/                      # Runtime config (env defaults + localStorage overrides)
+├── lib/
+│   ├── auth/                 # Better Auth client/server config and bearer-token plumbing
+│   └── config.ts             # Runtime config (env defaults + localStorage overrides)
+└── types/                    # Third-party declarations
 ```
 
 ## Development
@@ -77,7 +86,11 @@ Everyday scripts (pnpm only — the version is pinned via `packageManager`):
 
 ## Testing
 
-Vitest 4 + React Testing Library. Tests are **colocated** with their source; the extension picks the environment — `.test.ts` runs in node (pure modules, the `/api/files/*` handlers against a real temp-dir sandbox), `.test.tsx` in jsdom (hooks, providers, components). The suite is a required CI check (`frontend-tests`) and never touches the network.
+Vitest 5 + React Testing Library. Tests are **colocated** with their source; the extension picks
+the environment — `.test.ts` runs in node (pure modules and fetch wrappers), while `.test.tsx`
+runs in jsdom (hooks, providers, components). The suite is a required CI check (`frontend-tests`)
+and never touches the network. Backend validation for `/files/*` is covered in
+[`backend/tests/test_files_api.py`](../backend/tests/test_files_api.py).
 
 Conventions, mocking rules, and gotchas live in [`CLAUDE.md`](CLAUDE.md#testing); the contributor workflow is in the root [`CONTRIBUTING.md`](../CONTRIBUTING.md#testing).
 


### PR DESCRIPTION
## What & why

Refresh seven README files so their folder trees, service topology, storage paths, and development guidance match the current repository. This removes pre-object-storage frontend documentation, retired core-server examples, and pre-analytics-agent wording.

## Type of change

- [ ] 🐛 `fix` — bug fix
- [ ] ✨ `feat` — new feature
- [x] 📝 `docs` — documentation only
- [ ] ♻️ `refactor` — no behavior change
- [ ] 🧹 `chore` / `test` — tooling, deps, tests

## How was it tested?

- `backend/.venv/bin/pre-commit run --all-files`
- Searched all README files for the removed paths and stale terminology

## Checklist

- [x] PR is focused on a single logical change
- [ ] Added/updated tests for changed behavior (not applicable: documentation only)
- [x] Ran the quality gate locally (`pre-commit run --all-files`)
- [x] Updated docs (README / `CLAUDE.md` / `docs/prd/`) if behavior changed
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] No secrets or user uploads (CVs/JDs) committed

Made with [Cursor](https://cursor.com)